### PR TITLE
build: setup dart simple ci using github actions

### DIFF
--- a/.github/workflows/ci_dart.yml
+++ b/.github/workflows/ci_dart.yml
@@ -1,0 +1,32 @@
+name: Run CI
+on:
+  push:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'  # every sunday at midnight
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }} / ${{ matrix.flutter }}
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: packages/repo_support
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        flutter: [stable, beta, dev]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '12.x'
+      - uses: subosito/flutter-action@v1
+        with:
+          channel: ${{ matrix.flutter }}
+      - run: flutter --version
+      - run: flutter upgrade
+      - run: dart --version
+      - run: dart pub get
+      - run: dart run tool/run_ci.dart

--- a/packages/repo_support/.gitignore
+++ b/packages/repo_support/.gitignore
@@ -1,0 +1,23 @@
+# See https://www.dartlang.org/guides/libraries/private-files
+
+# Files and directories created by pub
+.dart_tool/
+.packages
+.pub/
+build/
+# If you're building an application, you may want to check-in your pubspec.lock
+pubspec.lock
+
+# Directory created by dartdoc
+# If you don't generate documentation locally you can remove this line.
+doc/api/
+
+# Intellij
+*.idea/
+*.iml
+
+# VS code
+.vscode
+
+# Local
+.local/

--- a/packages/repo_support/README.md
+++ b/packages/repo_support/README.md
@@ -1,0 +1,8 @@
+# repo_support
+
+App flutter utils repo support
+
+```
+dart run tool/run_ci.dart
+
+```

--- a/packages/repo_support/pubspec.yaml
+++ b/packages/repo_support/pubspec.yaml
@@ -1,0 +1,11 @@
+name: simplex_repo_support
+description: SimpleX build tools
+version: 0.2.0
+publish_to: none
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+
+dev_dependencies:
+  dev_test:
+

--- a/packages/repo_support/tool/run_ci.dart
+++ b/packages/repo_support/tool/run_ci.dart
@@ -1,0 +1,14 @@
+// ignore_for_file: prefer_double_quotes
+
+import 'package:dev_test/package.dart';
+import 'package:path/path.dart';
+
+Future main() async {
+  for (var dir in [
+    'simplex_app',
+    'simplexmq',
+    'repo_support',
+  ]) {
+    await packageRunCi(join('..', dir));
+  }
+}


### PR DESCRIPTION
This is a pull request to get me started. I'm not sure about the convention you use (you seem to create branch from v5 using a path looking like user/feature) so I'm trying to mimic your behavior. Here the CI simply check format, lints and run unit test on all platform (mac, windows, linux) and all flutter version (stable, beta, dev). We might choose to allow failure on dev as sometimes there are changes that could break the linter.

Let me know if I get anything wrong.