### PR TITLE
ios: update image picker

### DIFF
--- a/apps/ios/Shared/Views/Helpers/ImagePicker.swift
+++ b/apps/ios/Shared/Views/Helpers/ImagePicker.swift
@@ -31,12 +31,13 @@ struct FromGalleryImagePicker: UIViewControllerRepresentable {
             guard !results.isEmpty else {
                 return
             }
-            // TODO dont force unwrap
-            let chosenImageProvider = results.first!.itemProvider
-            if chosenImageProvider.canLoadObject(ofClass: UIImage.self) {
-                chosenImageProvider.loadObject(ofClass: UIImage.self)  { [weak self] image, error in
-                    DispatchQueue.main.async {
-                        self?.loadImage(object: image, error: error)
+
+            if let chosenImageProvider = results.first?.itemProvider {
+                if chosenImageProvider.canLoadObject(ofClass: UIImage.self) {
+                    chosenImageProvider.loadObject(ofClass: UIImage.self)  { [weak self] image, error in
+                        DispatchQueue.main.async {
+                            self?.loadImage(object: image, error: error)
+                        }
                     }
                 }
             }

--- a/apps/ios/Shared/Views/Helpers/ImagePicker.swift
+++ b/apps/ios/Shared/Views/Helpers/ImagePicker.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import PhotosUI
 
 enum ImageSelectionMethod {
-    case library
+    case imageLibrary
     case camera
 }
 

--- a/apps/ios/Shared/Views/Helpers/ImagePicker.swift
+++ b/apps/ios/Shared/Views/Helpers/ImagePicker.swift
@@ -7,44 +7,70 @@
 //
 
 import SwiftUI
+import PhotosUI
 
 struct ImagePicker: UIViewControllerRepresentable {
+    typealias UIViewControllerType = PHPickerViewController
     @Environment(\.presentationMode) var presentationMode
     var source: UIImagePickerController.SourceType
     @Binding var image: UIImage?
     @Binding var imageUrl: URL?
-    
-    class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+    var didFinishPicking: (_ didSelectItems: Bool) -> Void
+
+    class Coordinator: PHPickerViewControllerDelegate {
         let parent: ImagePicker
-        
+
         init(_ parent: ImagePicker) {
             self.parent = parent
         }
-        
-        func imagePickerController(_ picker: UIImagePickerController,
-                                   didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
-            if let uiImage = info[.originalImage] as? UIImage {
-                parent.imageUrl = info[.imageURL] as? URL
-                parent.image = uiImage
+
+        func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+            parent.didFinishPicking(!results.isEmpty)
+            guard !results.isEmpty else {
+                return
             }
-            parent.presentationMode.wrappedValue.dismiss()
+            // TODO dont force unwrap
+            let chosenImageProvider = results.first!.itemProvider
+            if chosenImageProvider.canLoadObject(ofClass: UIImage.self) {
+                chosenImageProvider.loadObject(ofClass: UIImage.self)  { [weak self] image, error in
+                    DispatchQueue.main.async {
+                        self?.loadImage(object: image, error: error)
+                    }
+                }
+            }
+        }
+
+        func loadImage(object: Any?, error: Error? = nil) {
+            if let error = error {
+                logger.error("Couldn't load image with error: \(error.localizedDescription)")
+            }
+            parent.image = object as? UIImage
         }
     }
-    
+
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
     }
-    
 
-    func makeUIViewController(context: UIViewControllerRepresentableContext<ImagePicker>) -> UIImagePickerController {
-        let picker = UIImagePickerController()
-        picker.sourceType = source
-        picker.allowsEditing = false
-        picker.delegate = context.coordinator
-        return picker
+
+//    func makeUIViewController(context: UIViewControllerRepresentableContext<ImagePicker>) -> UIImagePickerController {
+//        let picker = UIImagePickerController()
+//        picker.sourceType = source
+//        picker.allowsEditing = false
+//        picker.delegate = context.coordinator
+//        return picker
+//    }
+
+    func makeUIViewController(context: Context) -> PHPickerViewController {
+        var config = PHPickerConfiguration()
+        config.filter = .images
+        config.selectionLimit = 1
+        let controller = PHPickerViewController(configuration: config)
+        controller.delegate = context.coordinator
+        return controller
     }
 
-    func updateUIViewController(_ uiViewController: UIImagePickerController, context: UIViewControllerRepresentableContext<ImagePicker>) {
-   
+    func updateUIViewController(_ uiViewController: PHPickerViewController, context: Context) {
+
     }
 }

--- a/apps/ios/Shared/Views/Helpers/ImagePicker.swift
+++ b/apps/ios/Shared/Views/Helpers/ImagePicker.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 import PhotosUI
 
-enum ImageSelectionMethod {
+enum ImageSource {
     case imageLibrary
     case camera
 }

--- a/apps/ios/Shared/Views/Helpers/ImagePicker.swift
+++ b/apps/ios/Shared/Views/Helpers/ImagePicker.swift
@@ -9,18 +9,20 @@
 import SwiftUI
 import PhotosUI
 
-struct ImagePicker: UIViewControllerRepresentable {
+enum ImageSelectionMethod: Equatable {
+    case gallery
+    case camera
+}
+
+struct FromGalleryImagePicker: UIViewControllerRepresentable {
     typealias UIViewControllerType = PHPickerViewController
-    @Environment(\.presentationMode) var presentationMode
-    var source: UIImagePickerController.SourceType
     @Binding var image: UIImage?
-    @Binding var imageUrl: URL?
     var didFinishPicking: (_ didSelectItems: Bool) -> Void
 
     class Coordinator: PHPickerViewControllerDelegate {
-        let parent: ImagePicker
+        let parent: FromGalleryImagePicker
 
-        init(_ parent: ImagePicker) {
+        init(_ parent: FromGalleryImagePicker) {
             self.parent = parent
         }
 
@@ -52,15 +54,6 @@ struct ImagePicker: UIViewControllerRepresentable {
         Coordinator(self)
     }
 
-
-//    func makeUIViewController(context: UIViewControllerRepresentableContext<ImagePicker>) -> UIImagePickerController {
-//        let picker = UIImagePickerController()
-//        picker.sourceType = source
-//        picker.allowsEditing = false
-//        picker.delegate = context.coordinator
-//        return picker
-//    }
-
     func makeUIViewController(context: Context) -> PHPickerViewController {
         var config = PHPickerConfiguration()
         config.filter = .images
@@ -71,6 +64,44 @@ struct ImagePicker: UIViewControllerRepresentable {
     }
 
     func updateUIViewController(_ uiViewController: PHPickerViewController, context: Context) {
+
+    }
+}
+
+
+struct FromCameraImagePicker: UIViewControllerRepresentable {
+    @Environment(\.presentationMode) var presentationMode
+    @Binding var image: UIImage?
+
+    class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+        let parent: FromCameraImagePicker
+
+        init(_ parent: FromCameraImagePicker) {
+            self.parent = parent
+        }
+
+        func imagePickerController(_ picker: UIImagePickerController,
+                                   didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+            if let uiImage = info[.originalImage] as? UIImage {
+                parent.image = uiImage
+            }
+            parent.presentationMode.wrappedValue.dismiss()
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeUIViewController(context: UIViewControllerRepresentableContext<FromCameraImagePicker>) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.allowsEditing = false
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: UIViewControllerRepresentableContext<FromCameraImagePicker>) {
 
     }
 }

--- a/apps/ios/Shared/Views/Helpers/ImagePicker.swift
+++ b/apps/ios/Shared/Views/Helpers/ImagePicker.swift
@@ -9,20 +9,20 @@
 import SwiftUI
 import PhotosUI
 
-enum ImageSelectionMethod: Equatable {
-    case gallery
+enum ImageSelectionMethod {
+    case library
     case camera
 }
 
-struct FromGalleryImagePicker: UIViewControllerRepresentable {
+struct LibraryImagePicker: UIViewControllerRepresentable {
     typealias UIViewControllerType = PHPickerViewController
     @Binding var image: UIImage?
     var didFinishPicking: (_ didSelectItems: Bool) -> Void
 
     class Coordinator: PHPickerViewControllerDelegate {
-        let parent: FromGalleryImagePicker
+        let parent: LibraryImagePicker
 
-        init(_ parent: FromGalleryImagePicker) {
+        init(_ parent: LibraryImagePicker) {
             self.parent = parent
         }
 
@@ -70,14 +70,14 @@ struct FromGalleryImagePicker: UIViewControllerRepresentable {
 }
 
 
-struct FromCameraImagePicker: UIViewControllerRepresentable {
+struct CameraImagePicker: UIViewControllerRepresentable {
     @Environment(\.presentationMode) var presentationMode
     @Binding var image: UIImage?
 
     class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
-        let parent: FromCameraImagePicker
+        let parent: CameraImagePicker
 
-        init(_ parent: FromCameraImagePicker) {
+        init(_ parent: CameraImagePicker) {
             self.parent = parent
         }
 
@@ -94,7 +94,7 @@ struct FromCameraImagePicker: UIViewControllerRepresentable {
         Coordinator(self)
     }
 
-    func makeUIViewController(context: UIViewControllerRepresentableContext<FromCameraImagePicker>) -> UIImagePickerController {
+    func makeUIViewController(context: UIViewControllerRepresentableContext<CameraImagePicker>) -> UIImagePickerController {
         let picker = UIImagePickerController()
         picker.sourceType = .camera
         picker.allowsEditing = false
@@ -102,7 +102,7 @@ struct FromCameraImagePicker: UIViewControllerRepresentable {
         return picker
     }
 
-    func updateUIViewController(_ uiViewController: UIImagePickerController, context: UIViewControllerRepresentableContext<FromCameraImagePicker>) {
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: UIViewControllerRepresentableContext<CameraImagePicker>) {
 
     }
 }

--- a/apps/ios/Shared/Views/UserSettings/UserProfile.swift
+++ b/apps/ios/Shared/Views/UserSettings/UserProfile.swift
@@ -89,7 +89,9 @@ struct UserProfile: View {
             }
         }
         .sheet(isPresented: $showImagePicker) {
-            ImagePicker(source: imageSource, image: $pickedImage, imageUrl: $tmpImageUrl)
+            ImagePicker(source: imageSource, image: $pickedImage, imageUrl: $tmpImageUrl) {
+                didSelectItem in showImagePicker = false
+            }
         }
         .onChange(of: pickedImage) { image in
             if let image = image,

--- a/apps/ios/Shared/Views/UserSettings/UserProfile.swift
+++ b/apps/ios/Shared/Views/UserSettings/UserProfile.swift
@@ -14,7 +14,7 @@ struct UserProfile: View {
     @State private var editProfile = false
     @State private var showChooseSource = false
     @State private var showImagePicker = false
-    @State private var imageSource: ImageSelectionMethod = .library
+    @State private var imageSource: ImageSelectionMethod = .imageLibrary
     @State private var chosenImage: UIImage? = nil
 
     var body: some View {
@@ -83,13 +83,13 @@ struct UserProfile: View {
                 showImagePicker = true
             }
             Button("Choose from library") {
-                imageSource = .library
+                imageSource = .imageLibrary
                 showImagePicker = true
             }
         }
         .sheet(isPresented: $showImagePicker) {
             switch imageSource {
-            case .library:
+            case .imageLibrary:
                 LibraryImagePicker(image: $chosenImage) {
                     didSelectItem in showImagePicker = false
                 }

--- a/apps/ios/Shared/Views/UserSettings/UserProfile.swift
+++ b/apps/ios/Shared/Views/UserSettings/UserProfile.swift
@@ -14,9 +14,8 @@ struct UserProfile: View {
     @State private var editProfile = false
     @State private var showChooseSource = false
     @State private var showImagePicker = false
-    @State private var imageSource: UIImagePickerController.SourceType = .photoLibrary
-    @State private var pickedImage: UIImage? = nil
-    @State private var tmpImageUrl: URL? = nil
+    @State private var imageSource: ImageSelectionMethod = .gallery
+    @State private var chosenImage: UIImage? = nil
 
     var body: some View {
         let user: User = chatModel.currentUser!
@@ -84,16 +83,20 @@ struct UserProfile: View {
                 showImagePicker = true
             }
             Button("Choose from library") {
-                imageSource = .photoLibrary
+                imageSource = .gallery
                 showImagePicker = true
             }
         }
         .sheet(isPresented: $showImagePicker) {
-            ImagePicker(source: imageSource, image: $pickedImage, imageUrl: $tmpImageUrl) {
-                didSelectItem in showImagePicker = false
+            if imageSource == .gallery {
+                FromGalleryImagePicker(image: $chosenImage) {
+                    didSelectItem in showImagePicker = false
+                }
+            } else {
+                FromCameraImagePicker(image: $chosenImage)
             }
         }
-        .onChange(of: pickedImage) { image in
+        .onChange(of: chosenImage) { image in
             if let image = image,
                let data = resizeToSquare(image, 104).jpegData(compressionQuality: 0.85) {
                 let imageStr = "data:image/jpg;base64,\(data.base64EncodedString())"
@@ -101,13 +104,6 @@ struct UserProfile: View {
                     profile.image = imageStr
                 } else {
                     logger.error("UserProfile: resized image is too big \(imageStr.count)")
-                }
-                if let tmpImageUrl = tmpImageUrl {
-                    do {
-                        try FileManager.default.removeItem(at: tmpImageUrl)
-                    } catch {
-                        logger.error("UserProfile: file deletion error \(error.localizedDescription)")
-                    }
                 }
             } else {
                 profile.image = nil

--- a/apps/ios/Shared/Views/UserSettings/UserProfile.swift
+++ b/apps/ios/Shared/Views/UserSettings/UserProfile.swift
@@ -14,7 +14,7 @@ struct UserProfile: View {
     @State private var editProfile = false
     @State private var showChooseSource = false
     @State private var showImagePicker = false
-    @State private var imageSource: ImageSelectionMethod = .gallery
+    @State private var imageSource: ImageSelectionMethod = .library
     @State private var chosenImage: UIImage? = nil
 
     var body: some View {
@@ -83,17 +83,18 @@ struct UserProfile: View {
                 showImagePicker = true
             }
             Button("Choose from library") {
-                imageSource = .gallery
+                imageSource = .library
                 showImagePicker = true
             }
         }
         .sheet(isPresented: $showImagePicker) {
-            if imageSource == .gallery {
-                FromGalleryImagePicker(image: $chosenImage) {
+            switch imageSource {
+            case .library:
+                LibraryImagePicker(image: $chosenImage) {
                     didSelectItem in showImagePicker = false
                 }
-            } else {
-                FromCameraImagePicker(image: $chosenImage)
+            case .camera:
+                CameraImagePicker(image: $chosenImage)
             }
         }
         .onChange(of: chosenImage) { image in

--- a/apps/ios/Shared/Views/UserSettings/UserProfile.swift
+++ b/apps/ios/Shared/Views/UserSettings/UserProfile.swift
@@ -14,7 +14,7 @@ struct UserProfile: View {
     @State private var editProfile = false
     @State private var showChooseSource = false
     @State private var showImagePicker = false
-    @State private var imageSource: ImageSelectionMethod = .imageLibrary
+    @State private var imageSource: ImageSource = .imageLibrary
     @State private var chosenImage: UIImage? = nil
 
     var body: some View {


### PR DESCRIPTION
Update the image picker to the newer and more private [`PHPicker`](https://developer.apple.com/videos/play/wwdc2020/10652/)

This then separates camera image selection and image selection from gallery.

Note: This also improves privacy as the `PHPicker` runs in a separate process and only shares selected images with the SimpleX app rather than the full library of images.