### PR TITLE
Support Markdown Composition 

### DIFF
--- a/src/Simplex/Chat/Styled.hs
+++ b/src/Simplex/Chat/Styled.hs
@@ -40,14 +40,14 @@ styleMarkdown = \case
         merge :: StyledString -> StyledString 
         merge = \case 
             (Styled f1 s :<>: Styled f2 _) -> Styled (f1 ++ f2) s 
-            (Styled f s :<>: a) -> (<> Styled f s) . merge $ a 
+            (Styled f s :<>: a) -> merge . (<>) (Styled f s) . merge $ a 
             sing -> sing
 
 styleMarkdownList :: MarkdownList -> StyledString
 styleMarkdownList = \case 
     [] -> plain ""
     [FormattedText f s] -> styleMarkdown (Markdown f s)
-    (FormattedText f s : ts) -> (<> styleMarkdown (Markdown f s)) . styleMarkdownList $ ts
+    (FormattedText f s : ts) -> (<>) (styleMarkdown (Markdown f s)) . styleMarkdownList $ ts
 
 styleFormat :: Maybe Format -> Text -> StyledString
 styleFormat (Just Snippet) s = '`' `wrap` styled Snippet s

--- a/src/Simplex/Chat/Styled.hs
+++ b/src/Simplex/Chat/Styled.hs
@@ -30,48 +30,47 @@ instance Monoid StyledString where mempty = plain ""
 instance IsString StyledString where fromString = plain
 
 data SingleStyled = SStyled [SGR] String
+
 type MaybeSnippet = Either StyledString SingleStyled
 
 styleMarkdown :: Markdown -> StyledString
-styleMarkdown = \case 
-    (a :|: b) -> styleMarkdown a <> styleMarkdown b 
-    Markdown f t -> inlineSnippets . styleSMarkdown $ FormattedText f t 
-    
-    where
+styleMarkdown = \case
+  (a :|: b) -> styleMarkdown a <> styleMarkdown b
+  Markdown f t -> inlineSnippets . styleSMarkdown $ FormattedText f t
+  where
+    breakApart :: Markdown -> [FormattedText]
+    breakApart = \case
+      Markdown f s -> [FormattedText f s]
+      a :|: b -> breakApart a ++ breakApart b
 
-        breakApart :: Markdown -> [FormattedText]
-        breakApart = \case 
-            Markdown f s -> [FormattedText f s]
-            a :|: b -> breakApart a ++ breakApart b
+    unify :: MaybeSnippet -> StyledString
+    unify = \case
+      Left a -> a
+      Right (SStyled a b) -> Styled a b
 
-        unify :: MaybeSnippet -> StyledString 
-        unify = \case 
-            Left a -> a
-            Right (SStyled a b) -> Styled a b
+    inlineSnippets :: [MaybeSnippet] -> StyledString
+    inlineSnippets = foldr (\nxt acc -> (<> acc) . unify $ nxt) (plain "")
 
-        inlineSnippets :: [MaybeSnippet] -> StyledString 
-        inlineSnippets = foldr (\nxt acc -> (<> acc) . unify $ nxt) (plain "")
+    inherit :: [SGR] -> MaybeSnippet -> MaybeSnippet
+    inherit f1 = \case
+      Left snippet -> Left snippet
+      Right (SStyled f2 s) -> Right $ SStyled (f1 ++ f2) s
 
-        inherit :: [SGR] -> MaybeSnippet -> MaybeSnippet
-        inherit f1 = \case
-            Left snippet        -> Left snippet 
-            Right (SStyled f2 s) -> Right $ SStyled (f1 ++ f2) s 
-        
-        inheritAll :: [SGR] -> Markdown -> [MaybeSnippet]
-        inheritAll f = concatMap (map (inherit f) . styleSMarkdown) . breakApart 
+    inheritAll :: [SGR] -> Markdown -> [MaybeSnippet]
+    inheritAll f = concatMap (map (inherit f) . styleSMarkdown) . breakApart
 
-        styleSMarkdown :: FormattedText -> [MaybeSnippet]
-        styleSMarkdown = \case 
-            FormattedText (Just Snippet) s -> (: []) . Left $ '`' `wrap` styled Snippet s
-            FormattedText (Just Secret) s ->  (:) (Right $ SStyled [] "#") . (++ [Right $ SStyled [] "#"]) . inheritAll (sgr Secret) . parseMarkdown $ s   
-            FormattedText (Just f) s -> inheritAll (sgr f) . parseMarkdown $ s
-            FormattedText Nothing s -> (: []) . Right . SStyled [] . T.unpack $ s 
+    styleSMarkdown :: FormattedText -> [MaybeSnippet]
+    styleSMarkdown = \case
+      FormattedText (Just Snippet) s -> (: []) . Left $ '`' `wrap` styled Snippet s
+      FormattedText (Just Secret) s -> (:) (Right $ SStyled [] "#") . (++ [Right $ SStyled [] "#"]) . inheritAll (sgr Secret) . parseMarkdown $ s
+      FormattedText (Just f) s -> inheritAll (sgr f) . parseMarkdown $ s
+      FormattedText Nothing s -> (: []) . Right . SStyled [] . T.unpack $ s
 
 styleMarkdownList :: MarkdownList -> StyledString
-styleMarkdownList = \case 
-    [] -> plain ""
-    [FormattedText f s] -> styleMarkdown (Markdown f s)
-    (FormattedText f s : ts) -> (<>) (styleMarkdown (Markdown f s)) . styleMarkdownList $ ts
+styleMarkdownList = \case
+  [] -> plain ""
+  [FormattedText f s] -> styleMarkdown (Markdown f s)
+  (FormattedText f s : ts) -> (<>) (styleMarkdown (Markdown f s)) . styleMarkdownList $ ts
 
 wrap :: Char -> StyledString -> StyledString
 wrap c s = plain [c] <> s <> plain [c]

--- a/src/Simplex/Chat/Styled.hs
+++ b/src/Simplex/Chat/Styled.hs
@@ -29,31 +29,49 @@ instance Monoid StyledString where mempty = plain ""
 
 instance IsString StyledString where fromString = plain
 
+data SingleStyled = SStyled [SGR] String
+type MaybeSnippet = Either StyledString SingleStyled
+
 styleMarkdown :: Markdown -> StyledString
 styleMarkdown = \case 
-    Markdown Nothing s -> plain s 
-    Markdown (Just Snippet) s -> '`' `wrap` styled Snippet s -- TODO: This can't "undo" outer layers, meaning formatting still gets gorked if this is on the inside 
-    Markdown f s -> merge . (<> styleFormat f s) . styleMarkdown . parseMarkdown $ s 
-    (s1 :|: s2) -> styleMarkdown s1 <> styleMarkdown s2 
+    (a :|: b) -> styleMarkdown a <> styleMarkdown b 
+    Markdown f t -> inlineSnippets . styleSMarkdown $ FormattedText f t 
+    
+    where
 
-    where 
-        merge :: StyledString -> StyledString 
-        merge = \case 
-            (Styled f1 s :<>: Styled f2 _) -> Styled (f1 ++ f2) s 
-            (Styled f s :<>: a) -> merge . (<>) (Styled f s) . merge $ a 
-            sing -> sing
+        breakApart :: Markdown -> [FormattedText]
+        breakApart = \case 
+            Markdown f s -> [FormattedText f s]
+            a :|: b -> breakApart a ++ breakApart b
+
+        unify :: MaybeSnippet -> StyledString 
+        unify = \case 
+            Left a -> a
+            Right (SStyled a b) -> Styled a b
+
+        inlineSnippets :: [MaybeSnippet] -> StyledString 
+        inlineSnippets = foldr (\nxt acc -> (<> acc) . unify $ nxt) (plain "")
+
+        inherit :: [SGR] -> MaybeSnippet -> MaybeSnippet
+        inherit f1 = \case
+            Left snippet        -> Left snippet 
+            Right (SStyled f2 s) -> Right $ SStyled (f1 ++ f2) s 
+        
+        inheritAll :: [SGR] -> Markdown -> [MaybeSnippet]
+        inheritAll f = concatMap (map (inherit f) . styleSMarkdown) . breakApart 
+
+        styleSMarkdown :: FormattedText -> [MaybeSnippet]
+        styleSMarkdown = \case 
+            FormattedText (Just Snippet) s -> (: []) . Left $ '`' `wrap` styled Snippet s
+            FormattedText (Just Secret) s ->  (:) (Right $ SStyled [] "#") . (++ [Right $ SStyled [] "#"]) . inheritAll (sgr Secret) . parseMarkdown $ s   
+            FormattedText (Just f) s -> inheritAll (sgr f) . parseMarkdown $ s
+            FormattedText Nothing s -> (: []) . Right . SStyled [] . T.unpack $ s 
 
 styleMarkdownList :: MarkdownList -> StyledString
 styleMarkdownList = \case 
     [] -> plain ""
     [FormattedText f s] -> styleMarkdown (Markdown f s)
     (FormattedText f s : ts) -> (<>) (styleMarkdown (Markdown f s)) . styleMarkdownList $ ts
-
-styleFormat :: Maybe Format -> Text -> StyledString
-styleFormat (Just Snippet) s = '`' `wrap` styled Snippet s
-styleFormat (Just Secret) s = '#' `wrap` styled Secret s
-styleFormat (Just f) s = styled f s
-styleFormat Nothing s = plain s
 
 wrap :: Char -> StyledString -> StyledString
 wrap c s = plain [c] <> s <> plain [c]


### PR DESCRIPTION
Important notes to start:

1. This has only been tested for the terminal. I don't see any reason at the style-level for this to behave strangely on other devices, but it's worth an overview from someone more familiar with the project as of now. 

2. This may have an inconsistent style with the rest of the project. Right off the bat, the explicit exports mean it could be desirable to drop the `where` clause if it is deemed unnecessary. Personally, I just find that some of the function names lose meaning outside of the context. Additionally, the use of lambda cases can be interchanged with equations if desired. 

3. It's very evident that this is a tacked-on solution. It compensates greatly for the existing structure, and while this is great for compatibility and minimizing conflicts, it leaves the code feeling out-of-place. While I wouldn't consider it unintuitive in its present form, it appears to fight rather than leverage the rest of the system in place. 

With that out of the way, it seems to work quite well at the moment. All of the elements laid out in `/markdown` seem to work as described and meet basic sanity checks. With cases like secret + color, it may be worth clarifying exactly how that should be have. Currently both operate about as the code would have you expect, black highlight and colored text (allowing it to be seen). 