### PR TITLE
id/get as previews back

### DIFF
--- a/apps/android/app/src/main/java/chat/simplex/app/model/SimpleXAPI.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/model/SimpleXAPI.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Bolt
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import chat.simplex.app.*
@@ -448,9 +449,9 @@ open class ChatController(private val ctrl: ChatCtrl, private val ntfManager: Nt
             Row {
               Icon(
                 Icons.Outlined.Bolt,
-                contentDescription = generalGetString(R.string.icon_descr_instant_notifications),
+                contentDescription = stringResource(R.string.icon_descr_instant_notifications),
               )
-              Text(generalGetString(R.string.private_instant_notifications), fontWeight = FontWeight.Bold)
+              Text(stringResource(R.string.private_instant_notifications), fontWeight = FontWeight.Bold)
             }
           },
           text = {
@@ -463,7 +464,7 @@ open class ChatController(private val ctrl: ChatCtrl, private val ntfManager: Nt
             }
           },
           confirmButton = {
-            Button(onClick = AlertManager.shared::hideAlert) { Text(generalGetString(R.string.ok)) }
+            Button(onClick = AlertManager.shared::hideAlert) { Text(stringResource(R.string.ok)) }
           }
         )
       }

--- a/apps/android/app/src/main/java/chat/simplex/app/views/WelcomeView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/WelcomeView.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -17,7 +18,8 @@ import chat.simplex.app.R
 import chat.simplex.app.SimplexService
 import chat.simplex.app.model.ChatModel
 import chat.simplex.app.model.Profile
-import chat.simplex.app.views.helpers.*
+import chat.simplex.app.views.helpers.getKeyboardState
+import chat.simplex.app.views.helpers.withApi
 import com.google.accompanist.insets.ProvideWindowInsets
 import com.google.accompanist.insets.navigationBarsWithImePadding
 import kotlinx.coroutines.launch
@@ -45,22 +47,22 @@ fun WelcomeView(chatModel: ChatModel) {
       ) {
         Image(
           painter = painterResource(R.drawable.logo),
-          contentDescription = generalGetString(R.string.image_descr_simplex_logo),
+          contentDescription = stringResource(R.string.image_descr_simplex_logo),
           modifier = Modifier.padding(vertical = 15.dp)
         )
         Text(
-          generalGetString(R.string.you_control_your_chat),
+          stringResource(R.string.you_control_your_chat),
           style = MaterialTheme.typography.h4,
           color = MaterialTheme.colors.onBackground
         )
         Text(
-          generalGetString(R.string.the_messaging_and_app_platform_protecting_your_privacy_and_security),
+          stringResource(R.string.the_messaging_and_app_platform_protecting_your_privacy_and_security),
           style = MaterialTheme.typography.body1,
           color = MaterialTheme.colors.onBackground
         )
         Spacer(Modifier.height(8.dp))
         Text(
-          generalGetString(R.string.we_do_not_store_contacts_or_messages_on_servers),
+          stringResource(R.string.we_do_not_store_contacts_or_messages_on_servers),
           style = MaterialTheme.typography.body1,
           color = MaterialTheme.colors.onBackground
         )
@@ -93,19 +95,19 @@ fun CreateProfilePanel(chatModel: ChatModel) {
     modifier=Modifier.fillMaxSize()
   ) {
     Text(
-      generalGetString(R.string.create_profile),
+      stringResource(R.string.create_profile),
       style = MaterialTheme.typography.h4,
       color = MaterialTheme.colors.onBackground,
       modifier = Modifier.padding(vertical = 5.dp)
     )
     Text(
-      generalGetString(R.string.your_profile_is_stored_on_your_decide_and_shared_only_with_your_contacts),
+      stringResource(R.string.your_profile_is_stored_on_your_decide_and_shared_only_with_your_contacts),
       style = MaterialTheme.typography.body1,
       color = MaterialTheme.colors.onBackground
     )
     Spacer(Modifier.height(10.dp))
     Text(
-      generalGetString(R.string.display_name),
+      stringResource(R.string.display_name),
       style = MaterialTheme.typography.h6,
       color = MaterialTheme.colors.onBackground,
       modifier = Modifier.padding(bottom = 3.dp)
@@ -127,7 +129,7 @@ fun CreateProfilePanel(chatModel: ChatModel) {
       ),
       singleLine = true
     )
-    val errorText = if(!isValidDisplayName(displayName)) generalGetString(R.string.display_name_cannot_contain_whitespace) else ""
+    val errorText = if(!isValidDisplayName(displayName)) stringResource(R.string.display_name_cannot_contain_whitespace) else ""
 
     Text(
       errorText,
@@ -137,7 +139,7 @@ fun CreateProfilePanel(chatModel: ChatModel) {
 
     Spacer(Modifier.height(3.dp))
     Text(
-      generalGetString(R.string.full_name_optional__prompt),
+      stringResource(R.string.full_name_optional__prompt),
       style = MaterialTheme.typography.h6,
       color = MaterialTheme.colors.onBackground,
       modifier = Modifier.padding(bottom = 5.dp)
@@ -171,6 +173,6 @@ fun CreateProfilePanel(chatModel: ChatModel) {
       }
     },
     enabled = (displayName.isNotEmpty() && isValidDisplayName(displayName))
-    ) { Text(generalGetString(R.string.create_profile_button)) }
+    ) { Text(stringResource(R.string.create_profile_button)) }
   }
 }

--- a/apps/android/app/src/main/java/chat/simplex/app/views/chat/ChatInfoView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/chat/ChatInfoView.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -97,7 +98,7 @@ fun ChatInfoLayout(chat: Chat, close: () -> Unit, deleteContact: () -> Unit) {
 
       Box(Modifier.padding(48.dp)) {
         SimpleButton(
-          generalGetString(R.string.button_delete_contact),
+          stringResource(R.string.button_delete_contact),
           icon = Icons.Outlined.Delete,
           color = Color.Red,
           click = deleteContact
@@ -112,13 +113,13 @@ fun ServerImage(chat: Chat) {
   val status = chat.serverInfo.networkStatus
   when {
     status is Chat.NetworkStatus.Connected ->
-      Icon(Icons.Filled.Circle, generalGetString(R.string.icon_descr_server_status_connected), tint = MaterialTheme.colors.primaryVariant)
+      Icon(Icons.Filled.Circle, stringResource(R.string.icon_descr_server_status_connected), tint = MaterialTheme.colors.primaryVariant)
     status is Chat.NetworkStatus.Disconnected ->
-      Icon(Icons.Filled.Pending, generalGetString(R.string.icon_descr_server_status_disconnected), tint = HighOrLowlight)
+      Icon(Icons.Filled.Pending, stringResource(R.string.icon_descr_server_status_disconnected), tint = HighOrLowlight)
     status is Chat.NetworkStatus.Error ->
-      Icon(Icons.Filled.Error, generalGetString(R.string.icon_descr_server_status_error), tint = HighOrLowlight)
+      Icon(Icons.Filled.Error, stringResource(R.string.icon_descr_server_status_error), tint = HighOrLowlight)
     else ->
-      Icon(Icons.Outlined.Circle, generalGetString(R.string.icon_descr_server_status_pending), tint = HighOrLowlight)
+      Icon(Icons.Outlined.Circle, stringResource(R.string.icon_descr_server_status_pending), tint = HighOrLowlight)
   }
 }
 

--- a/apps/android/app/src/main/java/chat/simplex/app/views/chat/ChatView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/chat/ChatView.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -246,7 +247,7 @@ fun ChatInfoToolbar(chat: Chat, back: () -> Unit, info: () -> Unit) {
       IconButton(onClick = back) {
         Icon(
           Icons.Outlined.ArrowBackIos,
-          generalGetString(R.string.back),
+          stringResource(R.string.back),
           tint = MaterialTheme.colors.primary,
           modifier = Modifier.padding(10.dp)
         )

--- a/apps/android/app/src/main/java/chat/simplex/app/views/chat/ComposeImageView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/chat/ComposeImageView.kt
@@ -8,12 +8,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import chat.simplex.app.R
 import chat.simplex.app.views.chat.item.SentColorLight
 import chat.simplex.app.views.helpers.base64ToBitmap
-import chat.simplex.app.views.helpers.generalGetString
 
 @Composable
 fun ComposeImageView(image: String, cancelImage: () -> Unit) {
@@ -37,7 +36,7 @@ fun ComposeImageView(image: String, cancelImage: () -> Unit) {
     IconButton(onClick = cancelImage, modifier = Modifier.padding(0.dp)) {
       Icon(
         Icons.Outlined.Close,
-        contentDescription = generalGetString(R.string.icon_descr_cancel_image_preview),
+        contentDescription = stringResource(R.string.icon_descr_cancel_image_preview),
         tint = MaterialTheme.colors.primary,
         modifier = Modifier.padding(10.dp)
       )

--- a/apps/android/app/src/main/java/chat/simplex/app/views/chat/ComposeView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/chat/ComposeView.kt
@@ -8,18 +8,17 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.icons.Icons
-import androidx.compose.foundation.layout.Column
 import androidx.compose.material.icons.filled.AttachFile
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import chat.simplex.app.R
 import chat.simplex.app.model.*
 import chat.simplex.app.views.helpers.ComposeLinkView
-import chat.simplex.app.views.helpers.generalGetString
 
 // TODO ComposeState
 @Composable
@@ -75,7 +74,7 @@ fun ComposeView(
       Box(Modifier.padding(bottom = 12.dp)) {
         Icon(
           Icons.Filled.AttachFile,
-          contentDescription = generalGetString(R.string.attach),
+          contentDescription = stringResource(R.string.attach),
           tint = if (editingItem.value == null) MaterialTheme.colors.primary else Color.Gray,
           modifier = Modifier
             .size(28.dp)

--- a/apps/android/app/src/main/java/chat/simplex/app/views/chat/ContextItemView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/chat/ContextItemView.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.outlined.Close
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
@@ -17,7 +18,6 @@ import chat.simplex.app.model.CIDirection
 import chat.simplex.app.model.ChatItem
 import chat.simplex.app.ui.theme.SimpleXTheme
 import chat.simplex.app.views.chat.item.*
-import chat.simplex.app.views.helpers.generalGetString
 import kotlinx.datetime.Clock
 
 @Composable
@@ -52,7 +52,7 @@ fun ContextItemView(
       }) {
         Icon(
           Icons.Outlined.Close,
-          contentDescription = generalGetString(R.string.cancel_verb),
+          contentDescription = stringResource(R.string.cancel_verb),
           tint = MaterialTheme.colors.primary,
           modifier = Modifier.padding(10.dp)
         )

--- a/apps/android/app/src/main/java/chat/simplex/app/views/chat/SendMsgView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/chat/SendMsgView.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -25,7 +26,8 @@ import chat.simplex.app.model.*
 import chat.simplex.app.ui.theme.HighOrLowlight
 import chat.simplex.app.ui.theme.SimpleXTheme
 import chat.simplex.app.views.chat.item.*
-import chat.simplex.app.views.helpers.*
+import chat.simplex.app.views.helpers.getLinkPreview
+import chat.simplex.app.views.helpers.withApi
 import kotlinx.coroutines.delay
 
 @Composable
@@ -128,7 +130,7 @@ fun SendMsgView(
           val color = if (sendEnabled) MaterialTheme.colors.primary else Color.Gray
           Icon(
             if (editing) Icons.Filled.Check else Icons.Outlined.ArrowUpward,
-            generalGetString(R.string.icon_descr_send_message),
+            stringResource(R.string.icon_descr_send_message),
             tint = Color.White,
             modifier = Modifier
               .size(36.dp)

--- a/apps/android/app/src/main/java/chat/simplex/app/views/chat/item/CIImageView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/chat/item/CIImageView.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import chat.simplex.app.R
 import chat.simplex.app.model.CIFile
@@ -25,7 +26,7 @@ fun CIImageView(
     }
     Image(
       imageBitmap.asImageBitmap(),
-      contentDescription = generalGetString(R.string.image_descr),
+      contentDescription = stringResource(R.string.image_descr),
       // .width(1000.dp) is a hack for image to increase IntrinsicSize of FramedItemView
       // if text is short and take all available width if text is long
       modifier = Modifier

--- a/apps/android/app/src/main/java/chat/simplex/app/views/chat/item/CIMetaView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/chat/item/CIMetaView.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -16,7 +17,6 @@ import chat.simplex.app.R
 import chat.simplex.app.model.*
 import chat.simplex.app.ui.theme.HighOrLowlight
 import chat.simplex.app.ui.theme.SimplexBlue
-import chat.simplex.app.views.helpers.generalGetString
 import kotlinx.datetime.Clock
 
 @Composable
@@ -27,7 +27,7 @@ fun CIMetaView(chatItem: ChatItem, metaColor: Color = HighOrLowlight) {
         Icon(
           Icons.Filled.Edit,
           modifier = Modifier.height(12.dp).padding(end = 1.dp),
-          contentDescription = generalGetString(R.string.icon_descr_edited),
+          contentDescription = stringResource(R.string.icon_descr_edited),
           tint = metaColor,
         )
       }
@@ -47,16 +47,16 @@ fun CIMetaView(chatItem: ChatItem, metaColor: Color = HighOrLowlight) {
 fun CIStatusView(status: CIStatus, metaColor: Color = HighOrLowlight) {
   when (status) {
     is CIStatus.SndSent -> {
-      Icon(Icons.Filled.Check, generalGetString(R.string.icon_descr_sent_msg_status_sent), Modifier.height(12.dp), tint = metaColor)
+      Icon(Icons.Filled.Check, stringResource(R.string.icon_descr_sent_msg_status_sent), Modifier.height(12.dp), tint = metaColor)
     }
     is CIStatus.SndErrorAuth -> {
-      Icon(Icons.Filled.Close,  generalGetString(R.string.icon_descr_sent_msg_status_unauthorized_send), Modifier.height(12.dp), tint = Color.Red)
+      Icon(Icons.Filled.Close,  stringResource(R.string.icon_descr_sent_msg_status_unauthorized_send), Modifier.height(12.dp), tint = Color.Red)
     }
     is CIStatus.SndError -> {
-      Icon(Icons.Filled.WarningAmber, generalGetString(R.string.icon_descr_sent_msg_status_send_failed), Modifier.height(12.dp), tint = Color.Yellow)
+      Icon(Icons.Filled.WarningAmber, stringResource(R.string.icon_descr_sent_msg_status_send_failed), Modifier.height(12.dp), tint = Color.Yellow)
     }
     is CIStatus.RcvNew -> {
-      Icon(Icons.Filled.Circle, generalGetString(R.string.icon_descr_received_msg_status_unread), Modifier.height(12.dp), tint = SimplexBlue)
+      Icon(Icons.Filled.Circle, stringResource(R.string.icon_descr_received_msg_status_unread), Modifier.height(12.dp), tint = SimplexBlue)
     }
     else -> {}
   }

--- a/apps/android/app/src/main/java/chat/simplex/app/views/chat/item/ChatItemView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/chat/item/ChatItemView.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.UriHandler
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import chat.simplex.app.R
@@ -59,21 +60,21 @@ fun ChatItemView(
           onDismissRequest = { showMenu.value = false },
           Modifier.width(220.dp)
         ) {
-          ItemAction(generalGetString(R.string.reply_verb), Icons.Outlined.Reply, onClick = {
+          ItemAction(stringResource(R.string.reply_verb), Icons.Outlined.Reply, onClick = {
             editingItem.value = null
             quotedItem.value = cItem
             showMenu.value = false
           })
-          ItemAction(generalGetString(R.string.share_verb), Icons.Outlined.Share, onClick = {
+          ItemAction(stringResource(R.string.share_verb), Icons.Outlined.Share, onClick = {
             shareText(cxt, cItem.content.text)
             showMenu.value = false
           })
-          ItemAction(generalGetString(R.string.copy_verb), Icons.Outlined.ContentCopy, onClick = {
+          ItemAction(stringResource(R.string.copy_verb), Icons.Outlined.ContentCopy, onClick = {
             copyText(cxt, cItem.content.text)
             showMenu.value = false
           })
           if (cItem.chatDir.sent && cItem.meta.editable) {
-            ItemAction(generalGetString(R.string.edit_verb), Icons.Filled.Edit, onClick = {
+            ItemAction(stringResource(R.string.edit_verb), Icons.Filled.Edit, onClick = {
               quotedItem.value = null
               editingItem.value = cItem
               msg.value = cItem.content.text
@@ -81,7 +82,7 @@ fun ChatItemView(
             })
           }
           ItemAction(
-            generalGetString(R.string.delete_verb),
+            stringResource(R.string.delete_verb),
             Icons.Outlined.Delete,
             onClick = {
               showMenu.value = false
@@ -125,13 +126,13 @@ fun deleteMessageAlertDialog(chatItem: ChatItem, deleteMessage: (Long, CIDeleteM
         Button(onClick = {
           deleteMessage(chatItem.id, CIDeleteMode.cidmInternal)
           AlertManager.shared.hideAlert()
-        }) { Text(generalGetString(R.string.for_me_only)) }
+        }) { Text(stringResource(R.string.for_me_only)) }
         if (chatItem.meta.editable) {
           Spacer(Modifier.padding(horizontal = 4.dp))
           Button(onClick = {
             deleteMessage(chatItem.id, CIDeleteMode.cidmBroadcast)
             AlertManager.shared.hideAlert()
-          }) { Text(generalGetString(R.string.for_everybody)) }
+          }) { Text(stringResource(R.string.for_everybody)) }
         }
       }
     }

--- a/apps/android/app/src/main/java/chat/simplex/app/views/chat/item/FramedItemView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/chat/item/FramedItemView.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.UriHandler
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.*
 import androidx.compose.ui.unit.dp
@@ -22,7 +23,8 @@ import chat.simplex.app.R
 import chat.simplex.app.model.*
 import chat.simplex.app.ui.theme.HighOrLowlight
 import chat.simplex.app.ui.theme.SimpleXTheme
-import chat.simplex.app.views.helpers.*
+import chat.simplex.app.views.helpers.ChatItemLinkView
+import chat.simplex.app.views.helpers.base64ToBitmap
 import kotlinx.datetime.Clock
 
 val SentColorLight = Color(0x1E45B8FF)
@@ -67,7 +69,7 @@ fun FramedItemView(
               val imageBitmap = base64ToBitmap(qi.content.image).asImageBitmap()
               Image(
                 imageBitmap,
-                contentDescription = generalGetString(R.string.image_descr),
+                contentDescription = stringResource(R.string.image_descr),
                 contentScale = ContentScale.Crop,
                 modifier = Modifier
                   .size(60.dp)

--- a/apps/android/app/src/main/java/chat/simplex/app/views/chat/item/ImageFullScreenView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/chat/item/ImageFullScreenView.kt
@@ -7,8 +7,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import chat.simplex.app.R
-import chat.simplex.app.views.helpers.generalGetString
 
 @Composable
 fun ImageFullScreenView(imageBitmap: Bitmap, close: () -> Unit) {
@@ -21,7 +21,7 @@ fun ImageFullScreenView(imageBitmap: Bitmap, close: () -> Unit) {
   ) {
     Image(
       imageBitmap.asImageBitmap(),
-      contentDescription = generalGetString(R.string.image_descr),
+      contentDescription = stringResource(R.string.image_descr),
       modifier = Modifier.fillMaxSize(),
       contentScale = ContentScale.Fit,
     )

--- a/apps/android/app/src/main/java/chat/simplex/app/views/chatlist/ChatHelpView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/chatlist/ChatHelpView.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -18,7 +19,6 @@ import androidx.compose.ui.unit.sp
 import chat.simplex.app.R
 import chat.simplex.app.ui.theme.SimpleXTheme
 import chat.simplex.app.views.helpers.annotatedStringResource
-import chat.simplex.app.views.helpers.generalGetString
 import chat.simplex.app.views.usersettings.simplexTeamUri
 
 val bold = SpanStyle(fontWeight = FontWeight.Bold)
@@ -31,7 +31,7 @@ fun ChatHelpView(addContact: (() -> Unit)? = null) {
   ) {
     val uriHandler = LocalUriHandler.current
 
-    Text(generalGetString(R.string.thank_you_for_installing_simplex), lineHeight = 22.sp)
+    Text(stringResource(R.string.thank_you_for_installing_simplex), lineHeight = 22.sp)
     Text(
       annotatedStringResource(R.string.you_can_connect_to_simplex_chat_founder),
       modifier = Modifier.clickable(onClick = {
@@ -46,7 +46,7 @@ fun ChatHelpView(addContact: (() -> Unit)? = null) {
       verticalArrangement = Arrangement.spacedBy(10.dp)
     ) {
       Text(
-        generalGetString(R.string.to_start_a_new_chat_help_header),
+        stringResource(R.string.to_start_a_new_chat_help_header),
         style = MaterialTheme.typography.h2,
         lineHeight = 22.sp
       )
@@ -54,13 +54,13 @@ fun ChatHelpView(addContact: (() -> Unit)? = null) {
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp)
       ) {
-        Text(generalGetString(R.string.chat_help_tap_button))
+        Text(stringResource(R.string.chat_help_tap_button))
         Icon(
           Icons.Outlined.PersonAdd,
-          generalGetString(R.string.add_contact),
+          stringResource(R.string.add_contact),
           modifier = if (addContact != null) Modifier.clickable(onClick = addContact) else Modifier,
         )
-        Text(generalGetString(R.string.above_then_preposition_continuation))
+        Text(stringResource(R.string.above_then_preposition_continuation))
       }
       Text(annotatedStringResource(R.string.add_new_contact_to_create_one_time_QR_code), lineHeight = 22.sp)
       Text(annotatedStringResource(R.string.scan_QR_code_to_connect_to_contact_who_shows_QR_code), lineHeight = 22.sp)
@@ -71,8 +71,8 @@ fun ChatHelpView(addContact: (() -> Unit)? = null) {
       horizontalAlignment = Alignment.Start,
       verticalArrangement = Arrangement.spacedBy(10.dp)
     ) {
-      Text(generalGetString(R.string.to_connect_via_link_title), style = MaterialTheme.typography.h2)
-      Text(generalGetString(R.string.if_you_received_simplex_invitation_link_you_can_open_in_browser), lineHeight = 22.sp)
+      Text(stringResource(R.string.to_connect_via_link_title), style = MaterialTheme.typography.h2)
+      Text(stringResource(R.string.if_you_received_simplex_invitation_link_you_can_open_in_browser), lineHeight = 22.sp)
       Text(annotatedStringResource(R.string.desktop_scan_QR_code_from_app_via_scan_QR_code), lineHeight = 22.sp)
       Text(annotatedStringResource(R.string.mobile_tap_open_in_mobile_app_then_tap_connect_in_app), lineHeight = 22.sp)
     }

--- a/apps/android/app/src/main/java/chat/simplex/app/views/chatlist/ChatListView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/chatlist/ChatListView.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import chat.simplex.app.R
@@ -19,7 +20,6 @@ import chat.simplex.app.model.ChatModel
 import chat.simplex.app.ui.theme.ToolbarDark
 import chat.simplex.app.ui.theme.ToolbarLight
 import chat.simplex.app.views.helpers.ModalManager
-import chat.simplex.app.views.helpers.generalGetString
 import chat.simplex.app.views.newchat.NewChatSheet
 import chat.simplex.app.views.usersettings.SettingsView
 import kotlinx.coroutines.CoroutineScope
@@ -113,8 +113,8 @@ fun Help(scaffoldCtrl: ScaffoldController, displayName: String?) {
       .padding(16.dp)
   ) {
     val welcomeMsg = if (displayName != null) {
-      String.format(generalGetString(R.string.personal_welcome), displayName)
-    } else generalGetString(R.string.welcome)
+      String.format(stringResource(R.string.personal_welcome), displayName)
+    } else stringResource(R.string.welcome)
     Text(
       text = welcomeMsg,
       Modifier.padding(bottom = 24.dp),
@@ -128,12 +128,12 @@ fun Help(scaffoldCtrl: ScaffoldController, displayName: String?) {
       horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
       Text(
-        generalGetString(R.string.this_text_is_available_in_settings),
+        stringResource(R.string.this_text_is_available_in_settings),
         color = MaterialTheme.colors.onBackground
       )
       Icon(
         Icons.Outlined.Settings,
-        generalGetString(R.string.icon_descr_settings),
+        stringResource(R.string.icon_descr_settings),
         tint = MaterialTheme.colors.onBackground,
         modifier = Modifier.clickable(onClick = { scaffoldCtrl.toggleDrawer() })
       )
@@ -155,13 +155,13 @@ fun ChatListToolbar(scaffoldCtrl: ScaffoldController) {
     IconButton(onClick = { scaffoldCtrl.toggleDrawer() }) {
       Icon(
         Icons.Outlined.Menu,
-        generalGetString(R.string.icon_descr_settings),
+        stringResource(R.string.icon_descr_settings),
         tint = MaterialTheme.colors.primary,
         modifier = Modifier.padding(10.dp)
       )
     }
     Text(
-      generalGetString(R.string.your_chats),
+      stringResource(R.string.your_chats),
       color = MaterialTheme.colors.onBackground,
       fontWeight = FontWeight.SemiBold,
       modifier = Modifier.padding(5.dp)
@@ -169,7 +169,7 @@ fun ChatListToolbar(scaffoldCtrl: ScaffoldController) {
     IconButton(onClick = { scaffoldCtrl.toggleSheet() }) {
       Icon(
         Icons.Outlined.PersonAdd,
-        generalGetString(R.string.add_contact),
+        stringResource(R.string.add_contact),
         tint = MaterialTheme.colors.primary,
         modifier = Modifier.padding(10.dp)
       )

--- a/apps/android/app/src/main/java/chat/simplex/app/views/chatlist/ChatPreviewView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/chatlist/ChatPreviewView.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -18,9 +19,11 @@ import androidx.compose.ui.unit.sp
 import chat.simplex.app.R
 import chat.simplex.app.model.Chat
 import chat.simplex.app.model.getTimestampText
-import chat.simplex.app.ui.theme.*
+import chat.simplex.app.ui.theme.HighOrLowlight
+import chat.simplex.app.ui.theme.SimpleXTheme
 import chat.simplex.app.views.chat.item.MarkdownText
-import chat.simplex.app.views.helpers.*
+import chat.simplex.app.views.helpers.ChatInfoImage
+import chat.simplex.app.views.helpers.badgeLayout
 
 @Composable
 fun ChatPreviewView(chat: Chat) {
@@ -50,7 +53,7 @@ fun ChatPreviewView(chat: Chat) {
           )
         }
       } else {
-        Text(generalGetString(R.string.contact_connection_pending), color = HighOrLowlight)
+        Text(stringResource(R.string.contact_connection_pending), color = HighOrLowlight)
       }
     }
     val ts = chat.chatItems.lastOrNull()?.timestampText ?: getTimestampText(chat.chatInfo.createdAt)
@@ -67,7 +70,7 @@ fun ChatPreviewView(chat: Chat) {
       val n = chat.chatStats.unreadCount
       if (n > 0) {
         Text(
-          if (n < 1000) "$n" else "${n / 1000}" + generalGetString(R.string.thousand_abbreviation),
+          if (n < 1000) "$n" else "${n / 1000}" + stringResource(R.string.thousand_abbreviation),
           color = MaterialTheme.colors.onPrimary,
           fontSize = 14.sp,
           modifier = Modifier

--- a/apps/android/app/src/main/java/chat/simplex/app/views/chatlist/ContactRequestView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/chatlist/ContactRequestView.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -13,7 +14,6 @@ import chat.simplex.app.model.Chat
 import chat.simplex.app.model.getTimestampText
 import chat.simplex.app.ui.theme.HighOrLowlight
 import chat.simplex.app.views.helpers.ChatInfoImage
-import chat.simplex.app.views.helpers.generalGetString
 
 @Composable
 fun ContactRequestView(chat: Chat) {
@@ -33,7 +33,7 @@ fun ContactRequestView(chat: Chat) {
         color = MaterialTheme.colors.primary
       )
       Text(
-        generalGetString(R.string.contact_wants_to_connect_with_you),
+        stringResource(R.string.contact_wants_to_connect_with_you),
         maxLines = 2,
         overflow = TextOverflow.Ellipsis
       )

--- a/apps/android/app/src/main/java/chat/simplex/app/views/helpers/ChatInfoImage.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/helpers/ChatInfoImage.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -40,7 +41,7 @@ fun ProfileImage(
     if (image == null) {
       Icon(
         icon,
-        contentDescription = generalGetString(R.string.icon_descr_profile_image_placeholder),
+        contentDescription = stringResource(R.string.icon_descr_profile_image_placeholder),
         tint = MaterialTheme.colors.secondary,
         modifier = Modifier.fillMaxSize()
       )
@@ -48,7 +49,7 @@ fun ProfileImage(
       val imageBitmap = base64ToBitmap(image).asImageBitmap()
       Image(
         imageBitmap,
-        generalGetString(R.string.image_descr_profile_image),
+        stringResource(R.string.image_descr_profile_image),
         contentScale = ContentScale.Crop,
         modifier = Modifier.size(size).padding(size / 12).clip(CircleShape)
       )

--- a/apps/android/app/src/main/java/chat/simplex/app/views/helpers/CloseSheetBar.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/helpers/CloseSheetBar.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.outlined.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import chat.simplex.app.R
@@ -25,7 +26,7 @@ fun CloseSheetBar(close: () -> Unit) {
     IconButton(onClick = close) {
       Icon(
         Icons.Outlined.Close,
-        generalGetString(R.string.icon_descr_close_button),
+        stringResource(R.string.icon_descr_close_button),
         tint = MaterialTheme.colors.primary,
         modifier = Modifier.padding(10.dp)
       )

--- a/apps/android/app/src/main/java/chat/simplex/app/views/helpers/GetImageView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/helpers/GetImageView.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
@@ -189,7 +190,7 @@ fun GetImageBottomSheet(
         .padding(horizontal = 8.dp, vertical = 30.dp),
       horizontalArrangement = Arrangement.SpaceEvenly
     ) {
-      ActionButton(null, generalGetString(R.string.use_camera_button), icon = Icons.Outlined.PhotoCamera) {
+      ActionButton(null, stringResource(R.string.use_camera_button), icon = Icons.Outlined.PhotoCamera) {
         when (PackageManager.PERMISSION_GRANTED) {
           ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) -> {
             cameraLauncher.launch(null)
@@ -201,7 +202,7 @@ fun GetImageBottomSheet(
           }
         }
       }
-      ActionButton(null, generalGetString(R.string.from_gallery_button), icon = Icons.Outlined.Collections) {
+      ActionButton(null, stringResource(R.string.from_gallery_button), icon = Icons.Outlined.Collections) {
         when (PackageManager.PERMISSION_GRANTED) {
           ContextCompat.checkSelfPermission(context, Manifest.permission.READ_EXTERNAL_STORAGE) -> {
             galleryLauncher.launch("image/*")

--- a/apps/android/app/src/main/java/chat/simplex/app/views/helpers/LinkPreviews.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/helpers/LinkPreviews.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -73,7 +74,7 @@ fun ComposeLinkView(linkPreview: LinkPreview, cancelPreview: () -> Unit) {
     val imageBitmap = base64ToBitmap(linkPreview.image).asImageBitmap()
     Image(
       imageBitmap,
-      generalGetString(R.string.image_descr_link_preview),
+      stringResource(R.string.image_descr_link_preview),
       modifier = Modifier.width(80.dp).height(60.dp).padding(end = 8.dp)
     )
     Column(Modifier.fillMaxWidth().weight(1F)) {
@@ -86,7 +87,7 @@ fun ComposeLinkView(linkPreview: LinkPreview, cancelPreview: () -> Unit) {
     IconButton(onClick = cancelPreview, modifier = Modifier.padding(0.dp)) {
       Icon(
         Icons.Outlined.Close,
-        contentDescription = generalGetString(R.string.icon_descr_cancel_link_preview),
+        contentDescription = stringResource(R.string.icon_descr_cancel_link_preview),
         tint = MaterialTheme.colors.primary,
         modifier = Modifier.padding(10.dp)
       )
@@ -99,7 +100,7 @@ fun ChatItemLinkView(linkPreview: LinkPreview) {
   Column {
     Image(
       base64ToBitmap(linkPreview.image).asImageBitmap(),
-      generalGetString(R.string.image_descr_link_preview),
+      stringResource(R.string.image_descr_link_preview),
       modifier = Modifier.fillMaxWidth(),
       contentScale = ContentScale.FillWidth,
     )

--- a/apps/android/app/src/main/java/chat/simplex/app/views/helpers/Util.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/helpers/Util.kt
@@ -57,9 +57,11 @@ fun getKeyboardState(): State<KeyboardState> {
 
   return keyboardState
 }
+
 // Resource to annotated string from
 // https://stackoverflow.com/questions/68549248/android-jetpack-compose-how-to-show-styled-text-from-string-resources
 fun generalGetString(id: Int): String {
+  // prefer stringResource in Composable items to retain preview abilities
   return SimplexApp.context.getString(id)
 }
 

--- a/apps/android/app/src/main/java/chat/simplex/app/views/newchat/AddContactView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/newchat/AddContactView.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -19,7 +20,6 @@ import chat.simplex.app.R
 import chat.simplex.app.model.ChatModel
 import chat.simplex.app.ui.theme.SimpleButton
 import chat.simplex.app.ui.theme.SimpleXTheme
-import chat.simplex.app.views.helpers.generalGetString
 import chat.simplex.app.views.helpers.shareText
 
 @Composable
@@ -43,11 +43,11 @@ fun AddContactLayout(connReq: String, share: () -> Unit) {
       verticalArrangement = Arrangement.SpaceBetween,
     ) {
       Text(
-        generalGetString(R.string.add_contact),
+        stringResource(R.string.add_contact),
         style = MaterialTheme.typography.h1.copy(fontWeight = FontWeight.Normal),
       )
       Text(
-        generalGetString(R.string.show_QR_code_for_your_contact_to_scan_from_the_app__multiline),
+        stringResource(R.string.show_QR_code_for_your_contact_to_scan_from_the_app__multiline),
         style = MaterialTheme.typography.h3,
         textAlign = TextAlign.Center,
       )
@@ -58,14 +58,14 @@ fun AddContactLayout(connReq: String, share: () -> Unit) {
           .padding(vertical = 3.dp)
       )
       Text(
-        generalGetString(R.string.if_you_cannot_meet_in_person_show_QR_in_video_call_or_via_another_channel),
+        stringResource(R.string.if_you_cannot_meet_in_person_show_QR_in_video_call_or_via_another_channel),
         textAlign = TextAlign.Center,
         lineHeight = 22.sp,
         modifier = Modifier
           .padding(horizontal = 16.dp)
           .padding(bottom = if (screenHeight > 600.dp) 16.dp else 8.dp)
       )
-      SimpleButton(generalGetString(R.string.share_invitation_link), icon = Icons.Outlined.Share, click = share)
+      SimpleButton(stringResource(R.string.share_invitation_link), icon = Icons.Outlined.Share, click = share)
       Spacer(Modifier.height(10.dp))
     }
   }

--- a/apps/android/app/src/main/java/chat/simplex/app/views/newchat/NewChatSheet.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/newchat/NewChatSheet.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -20,7 +21,8 @@ import chat.simplex.app.model.ChatModel
 import chat.simplex.app.ui.theme.HighOrLowlight
 import chat.simplex.app.ui.theme.SimpleXTheme
 import chat.simplex.app.views.chatlist.ScaffoldController
-import chat.simplex.app.views.helpers.*
+import chat.simplex.app.views.helpers.ModalManager
+import chat.simplex.app.views.helpers.withApi
 import com.google.accompanist.permissions.rememberPermissionState
 
 @Composable
@@ -56,7 +58,7 @@ fun NewChatSheetLayout(addContact: () -> Unit, scanCode: () -> Unit, pasteLink: 
     horizontalAlignment = Alignment.CenterHorizontally
   ) {
     Text(
-      generalGetString(R.string.add_contact_to_start_new_chat),
+      stringResource(R.string.add_contact_to_start_new_chat),
       modifier = Modifier.padding(horizontal = 8.dp).padding(top = 32.dp)
     )
     Row(
@@ -71,8 +73,8 @@ fun NewChatSheetLayout(addContact: () -> Unit, scanCode: () -> Unit, pasteLink: 
           .weight(1F)
           .fillMaxWidth()) {
         ActionButton(
-          generalGetString(R.string.create_one_time_link),
-          generalGetString(R.string.to_share_with_your_contact),
+          stringResource(R.string.create_one_time_link),
+          stringResource(R.string.to_share_with_your_contact),
           Icons.Outlined.PersonAdd,
           click = addContact
         )
@@ -82,8 +84,8 @@ fun NewChatSheetLayout(addContact: () -> Unit, scanCode: () -> Unit, pasteLink: 
           .weight(1F)
           .fillMaxWidth()) {
         ActionButton(
-          generalGetString(R.string.paste_received_link),
-          generalGetString(R.string.paste_received_link_from_clipboard),
+          stringResource(R.string.paste_received_link),
+          stringResource(R.string.paste_received_link_from_clipboard),
           Icons.Outlined.Link,
           click = pasteLink
         )
@@ -93,8 +95,8 @@ fun NewChatSheetLayout(addContact: () -> Unit, scanCode: () -> Unit, pasteLink: 
           .weight(1F)
           .fillMaxWidth()) {
         ActionButton(
-          generalGetString(R.string.scan_QR_code),
-          generalGetString(R.string.in_person_or_in_video_call__bracketed),
+          stringResource(R.string.scan_QR_code),
+          stringResource(R.string.in_person_or_in_video_call__bracketed),
           Icons.Outlined.QrCode,
           click = scanCode
         )

--- a/apps/android/app/src/main/java/chat/simplex/app/views/newchat/PasteToConnect.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/newchat/PasteToConnect.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -65,12 +66,12 @@ fun PasteToConnectLayout(
       verticalArrangement = Arrangement.SpaceBetween,
     ) {
       Text(
-        generalGetString(R.string.connect_via_link),
+        stringResource(R.string.connect_via_link),
         style = MaterialTheme.typography.h1.copy(fontWeight = FontWeight.Normal),
         modifier = Modifier.padding(bottom = 16.dp)
       )
-      Text(generalGetString(R.string.paste_connection_link_below_to_connect))
-      Text(generalGetString(R.string.profile_will_be_sent_to_contact_sending_link))
+      Text(stringResource(R.string.paste_connection_link_below_to_connect))
+      Text(stringResource(R.string.profile_will_be_sent_to_contact_sending_link))
 
       Box(Modifier.padding(top = 16.dp, bottom = 6.dp)) {
         TextEditor(Modifier.height(180.dp), text = connectionLink)

--- a/apps/android/app/src/main/java/chat/simplex/app/views/newchat/QRCode.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/newchat/QRCode.kt
@@ -6,10 +6,10 @@ import androidx.compose.foundation.Image
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import chat.simplex.app.R
 import chat.simplex.app.ui.theme.SimpleXTheme
-import chat.simplex.app.views.helpers.generalGetString
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.EncodeHintType
 import com.google.zxing.qrcode.QRCodeWriter
@@ -18,7 +18,7 @@ import com.google.zxing.qrcode.QRCodeWriter
 fun QRCode(connReq: String, modifier: Modifier = Modifier) {
   Image(
     bitmap = qrCodeBitmap(connReq, 1024).asImageBitmap(),
-    contentDescription = generalGetString(R.string.image_descr_qr_code),
+    contentDescription = stringResource(R.string.image_descr_qr_code),
     modifier = modifier
   )
 }

--- a/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/HelpView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/HelpView.kt
@@ -10,13 +10,13 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import chat.simplex.app.R
 import chat.simplex.app.model.ChatModel
 import chat.simplex.app.ui.theme.SimpleXTheme
 import chat.simplex.app.views.chatlist.ChatHelpView
-import chat.simplex.app.views.helpers.generalGetString
 
 @Composable
 fun HelpView(chatModel: ChatModel) {
@@ -35,7 +35,7 @@ fun HelpLayout(displayName: String) {
     horizontalAlignment = Alignment.Start
   ){
     Text(
-      String.format(generalGetString(R.string.personal_welcome), displayName),
+      String.format(stringResource(R.string.personal_welcome), displayName),
       Modifier.padding(bottom = 24.dp),
       style = MaterialTheme.typography.h1,
     )

--- a/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/MarkdownHelpView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/MarkdownHelpView.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.*
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -14,25 +15,24 @@ import chat.simplex.app.R
 import chat.simplex.app.model.Format
 import chat.simplex.app.model.FormatColor
 import chat.simplex.app.ui.theme.SimpleXTheme
-import chat.simplex.app.views.helpers.generalGetString
 
 @Composable
 fun MarkdownHelpView() {
   Column {
     Text(
-      generalGetString(R.string.how_to_use_markdown),
+      stringResource(R.string.how_to_use_markdown),
       style = MaterialTheme.typography.h1,
     )
     Text(
-      generalGetString(R.string.you_can_use_markdown_to_format_messages__prompt),
+      stringResource(R.string.you_can_use_markdown_to_format_messages__prompt),
       Modifier.padding(vertical = 16.dp)
     )
-    val bold = generalGetString(R.string.bold)
-    val italic = generalGetString(R.string.italic)
-    val strikethrough = generalGetString(R.string.strikethrough)
-    val equation = generalGetString(R.string.a_plus_b)
-    val colored = generalGetString(R.string.colored)
-    val secret = generalGetString(R.string.secret)
+    val bold = stringResource(R.string.bold)
+    val italic = stringResource(R.string.italic)
+    val strikethrough = stringResource(R.string.strikethrough)
+    val equation = stringResource(R.string.a_plus_b)
+    val colored = stringResource(R.string.colored)
+    val secret = stringResource(R.string.secret)
 
     MdFormat("*$bold*", bold, Format.Bold())
     MdFormat("_${italic}_", italic, Format.Italic())

--- a/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/SMPServers.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/SMPServers.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.tooling.preview.Preview
@@ -102,14 +103,14 @@ fun SMPServersLayout(
     verticalArrangement = Arrangement.spacedBy(8.dp)
   ) {
     Text(
-      generalGetString(R.string.your_SMP_servers),
+      stringResource(R.string.your_SMP_servers),
       Modifier.padding(bottom = 24.dp),
       style = MaterialTheme.typography.h1
     )
     Row(
       verticalAlignment = Alignment.CenterVertically
     ) {
-      Text(generalGetString(R.string.configure_SMP_servers), Modifier.padding(end = 24.dp))
+      Text(stringResource(R.string.configure_SMP_servers), Modifier.padding(end = 24.dp))
       Switch(
         checked = isUserSMPServers,
         onCheckedChange = isUserSMPServersOnOff,
@@ -121,9 +122,9 @@ fun SMPServersLayout(
     }
 
     if (!isUserSMPServers) {
-      Text(generalGetString(R.string.using_simplex_chat_servers), lineHeight = 22.sp)
+      Text(stringResource(R.string.using_simplex_chat_servers), lineHeight = 22.sp)
     } else {
-      Text(generalGetString(R.string.enter_one_SMP_server_per_line))
+      Text(stringResource(R.string.enter_one_SMP_server_per_line))
       if (editSMPServers) {
         TextEditor(Modifier.height(160.dp), text = userSMPServersStr)
 
@@ -135,14 +136,14 @@ fun SMPServersLayout(
           Column(horizontalAlignment = Alignment.Start) {
             Row {
               Text(
-                generalGetString(R.string.cancel_verb),
+                stringResource(R.string.cancel_verb),
                 color = MaterialTheme.colors.primary,
                 modifier = Modifier
                   .clickable(onClick = cancelEdit)
               )
               Spacer(Modifier.padding(horizontal = 8.dp))
               Text(
-                generalGetString(R.string.save_servers_button),
+                stringResource(R.string.save_servers_button),
                 color = MaterialTheme.colors.primary,
                 modifier = Modifier.clickable(onClick = {
                   val servers = userSMPServersStr.value.split("\n")
@@ -181,7 +182,7 @@ fun SMPServersLayout(
         ) {
           Column(horizontalAlignment = Alignment.Start) {
             Text(
-              generalGetString(R.string.edit_verb),
+              stringResource(R.string.edit_verb),
               color = MaterialTheme.colors.primary,
               modifier = Modifier
                 .clickable(onClick = editOn)
@@ -203,9 +204,9 @@ fun howToButton() {
     verticalAlignment = Alignment.CenterVertically,
     modifier = Modifier.clickable { uriHandler.openUri("https://github.com/simplex-chat/simplexmq#using-smp-server-and-smp-agent") }
   ) {
-    Text(generalGetString(R.string.how_to), color = MaterialTheme.colors.primary)
+    Text(stringResource(R.string.how_to), color = MaterialTheme.colors.primary)
     Icon(
-      Icons.Outlined.OpenInNew, generalGetString(R.string.how_to), tint = MaterialTheme.colors.primary,
+      Icons.Outlined.OpenInNew, stringResource(R.string.how_to), tint = MaterialTheme.colors.primary,
       modifier = Modifier.padding(horizontal = 5.dp)
     )
   }

--- a/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/SettingsView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/SettingsView.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -69,7 +70,7 @@ fun SettingsLayout(
         .padding(top = 16.dp)
     ) {
       Text(
-        generalGetString(R.string.your_settings),
+        stringResource(R.string.your_settings),
         style = MaterialTheme.typography.h1,
         modifier = Modifier.padding(start = 8.dp)
       )
@@ -91,39 +92,39 @@ fun SettingsLayout(
       SettingsSectionView(showModal { UserAddressView(it) }) {
         Icon(
           Icons.Outlined.QrCode,
-          contentDescription = generalGetString(R.string.icon_descr_address),
+          contentDescription = stringResource(R.string.icon_descr_address),
         )
         Spacer(Modifier.padding(horizontal = 4.dp))
-        Text(generalGetString(R.string.your_simplex_contact_address))
+        Text(stringResource(R.string.your_simplex_contact_address))
       }
       Spacer(Modifier.height(24.dp))
 
       SettingsSectionView(showModal { HelpView(it) }) {
         Icon(
           Icons.Outlined.HelpOutline,
-          contentDescription = generalGetString(R.string.icon_descr_help),
+          contentDescription = stringResource(R.string.icon_descr_help),
         )
         Spacer(Modifier.padding(horizontal = 4.dp))
-        Text(generalGetString(R.string.how_to_use_simplex_chat))
+        Text(stringResource(R.string.how_to_use_simplex_chat))
       }
       Divider(Modifier.padding(horizontal = 8.dp))
       SettingsSectionView(showModal { MarkdownHelpView() }) {
         Icon(
           Icons.Outlined.TextFormat,
-          contentDescription = generalGetString(R.string.markdown_help),
+          contentDescription = stringResource(R.string.markdown_help),
         )
         Spacer(Modifier.padding(horizontal = 4.dp))
-        Text(generalGetString(R.string.markdown_in_messages))
+        Text(stringResource(R.string.markdown_in_messages))
       }
       Divider(Modifier.padding(horizontal = 8.dp))
       SettingsSectionView({ uriHandler.openUri(simplexTeamUri) }) {
         Icon(
           Icons.Outlined.Tag,
-          contentDescription = generalGetString(R.string.icon_descr_simplex_team),
+          contentDescription = stringResource(R.string.icon_descr_simplex_team),
         )
         Spacer(Modifier.padding(horizontal = 4.dp))
         Text(
-          generalGetString(R.string.chat_with_the_founder),
+          stringResource(R.string.chat_with_the_founder),
           color = MaterialTheme.colors.primary
         )
       }
@@ -131,11 +132,11 @@ fun SettingsLayout(
       SettingsSectionView({ uriHandler.openUri("mailto:chat@simplex.chat") }) {
         Icon(
           Icons.Outlined.Email,
-          contentDescription = generalGetString(R.string.icon_descr_email),
+          contentDescription = stringResource(R.string.icon_descr_email),
         )
         Spacer(Modifier.padding(horizontal = 4.dp))
         Text(
-          generalGetString(R.string.send_us_an_email),
+          stringResource(R.string.send_us_an_email),
           color = MaterialTheme.colors.primary
         )
       }
@@ -144,20 +145,20 @@ fun SettingsLayout(
       SettingsSectionView(showModal { SMPServersView(it) }) {
         Icon(
           Icons.Outlined.Dns,
-          contentDescription = generalGetString(R.string.smp_servers),
+          contentDescription = stringResource(R.string.smp_servers),
         )
         Spacer(Modifier.padding(horizontal = 4.dp))
-        Text(generalGetString(R.string.smp_servers))
+        Text(stringResource(R.string.smp_servers))
       }
       Divider(Modifier.padding(horizontal = 8.dp))
       SettingsSectionView() {
         Icon(
           Icons.Outlined.Bolt,
-          contentDescription = generalGetString(R.string.private_notifications),
+          contentDescription = stringResource(R.string.private_notifications),
         )
         Spacer(Modifier.padding(horizontal = 4.dp))
         Text(
-          generalGetString(R.string.private_notifications), Modifier
+          stringResource(R.string.private_notifications), Modifier
           .padding(end = 24.dp)
           .fillMaxWidth()
           .weight(1F))
@@ -175,10 +176,10 @@ fun SettingsLayout(
       SettingsSectionView(showTerminal) {
         Icon(
           painter = painterResource(id = R.drawable.ic_outline_terminal),
-          contentDescription = generalGetString(R.string.chat_console),
+          contentDescription = stringResource(R.string.chat_console),
         )
         Spacer(Modifier.padding(horizontal = 4.dp))
-        Text(generalGetString(R.string.chat_console))
+        Text(stringResource(R.string.chat_console))
       }
       Divider(Modifier.padding(horizontal = 8.dp))
       SettingsSectionView({ uriHandler.openUri("https://github.com/simplex-chat/simplex-chat") }) {

--- a/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/UserAddressView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/UserAddressView.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -60,12 +61,12 @@ fun UserAddressLayout(
     verticalArrangement = Arrangement.Top
   ) {
     Text(
-      generalGetString(R.string.your_chat_address),
+      stringResource(R.string.your_chat_address),
       Modifier.padding(bottom = 16.dp),
       style = MaterialTheme.typography.h1,
     )
     Text(
-      generalGetString(R.string.you_can_share_your_address_anybody_will_be_able_to_connect),
+      stringResource(R.string.you_can_share_your_address_anybody_will_be_able_to_connect),
       Modifier.padding(bottom = 12.dp),
       lineHeight = 22.sp
     )
@@ -76,11 +77,11 @@ fun UserAddressLayout(
     ) {
       if (userAddress == null) {
         Text(
-          generalGetString(R.string.if_you_delete_address_you_wont_lose_contacts),
+          stringResource(R.string.if_you_delete_address_you_wont_lose_contacts),
           Modifier.padding(bottom = 12.dp),
           lineHeight = 22.sp
         )
-        SimpleButton(generalGetString(R.string.create_address), icon = Icons.Outlined.QrCode, click = createAddress)
+        SimpleButton(stringResource(R.string.create_address), icon = Icons.Outlined.QrCode, click = createAddress)
       } else {
         QRCode(userAddress, Modifier.weight(1f, fill = false).aspectRatio(1f))
         Row(
@@ -89,11 +90,11 @@ fun UserAddressLayout(
           modifier = Modifier.padding(vertical = 10.dp)
         ) {
           SimpleButton(
-            generalGetString(R.string.share_link),
+            stringResource(R.string.share_link),
             icon = Icons.Outlined.Share,
             click = { share(userAddress) })
           SimpleButton(
-            generalGetString(R.string.delete_address),
+            stringResource(R.string.delete_address),
             icon = Icons.Outlined.Delete,
             color = Color.Red,
             click = deleteAddress

--- a/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/UserProfileView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/UserProfileView.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.tooling.preview.Preview
@@ -95,13 +96,13 @@ fun UserProfileLayout(
           horizontalAlignment = Alignment.Start
         ) {
           Text(
-            generalGetString(R.string.your_chat_profile),
+            stringResource(R.string.your_chat_profile),
             Modifier.padding(bottom = 24.dp),
             style = MaterialTheme.typography.h1,
             color = MaterialTheme.colors.onBackground
           )
           Text(
-            generalGetString(R.string.your_profile_is_stored_on_device_and_shared_only_with_contacts_simplex_cannot_see_it),
+            stringResource(R.string.your_profile_is_stored_on_device_and_shared_only_with_contacts_simplex_cannot_see_it),
             Modifier.padding(bottom = 24.dp),
             color = MaterialTheme.colors.onBackground,
             lineHeight = 22.sp
@@ -130,14 +131,14 @@ fun UserProfileLayout(
               ProfileNameTextField(displayName)
               ProfileNameTextField(fullName)
               Row {
-                TextButton(generalGetString(R.string.cancel_verb)) {
+                TextButton(stringResource(R.string.cancel_verb)) {
                   displayName.value = profile.displayName
                   fullName.value = profile.fullName
                   profileImage.value = profile.image
                   editProfile.value = false
                 }
                 Spacer(Modifier.padding(horizontal = 8.dp))
-                TextButton(generalGetString(R.string.save_and_notify_contacts)) {
+                TextButton(stringResource(R.string.save_and_notify_contacts)) {
                   saveProfile(displayName.value, fullName.value, profileImage.value)
                 }
               }
@@ -160,9 +161,9 @@ fun UserProfileLayout(
                   }
                 }
               }
-              ProfileNameRow(generalGetString(R.string.display_name__field), profile.displayName)
-              ProfileNameRow(generalGetString(R.string.full_name__field), profile.fullName)
-              TextButton(generalGetString(R.string.edit_verb)) { editProfile.value = true }
+              ProfileNameRow(stringResource(R.string.display_name__field), profile.displayName)
+              ProfileNameRow(stringResource(R.string.full_name__field), profile.fullName)
+              TextButton(stringResource(R.string.edit_verb)) { editProfile.value = true }
             }
           }
           if (savedKeyboardState != keyboardState) {
@@ -229,7 +230,7 @@ fun EditImageButton(click: () -> Unit) {
   ) {
     Icon(
       Icons.Outlined.PhotoCamera,
-      contentDescription = generalGetString(R.string.edit_image),
+      contentDescription = stringResource(R.string.edit_image),
       tint = MaterialTheme.colors.primary,
       modifier = Modifier.size(36.dp)
     )
@@ -241,7 +242,7 @@ fun DeleteImageButton(click: () -> Unit) {
   IconButton(onClick = click) {
     Icon(
       Icons.Outlined.Close,
-      contentDescription = generalGetString(R.string.delete_image),
+      contentDescription = stringResource(R.string.delete_image),
       tint = MaterialTheme.colors.primary,
     )
   }


### PR DESCRIPTION
In order to retain the ability to have Previews in android studio we need to use `stringResource` over `generalGetString` in composable items. This PR refactors to achieve this.

Note that `generalGetString` is still used outside of composables.