### PR TITLE
Managing battery optimization on Android 12+ via in-app UI

### DIFF
--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
   <application
       android:name="SimplexApp"

--- a/apps/android/app/src/main/java/chat/simplex/app/SimplexApp.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/SimplexApp.kt
@@ -52,7 +52,6 @@ class SimplexApp: Application(), LifecycleEventObserver {
       } else {
         chatController.startChat(user)
         SimplexService.start(applicationContext)
-        chatController.showBackgroundServiceNotice()
       }
     }
   }
@@ -65,6 +64,9 @@ class SimplexApp: Application(), LifecycleEventObserver {
           if (!chatController.getRunServiceInBackground()) SimplexService.stop(applicationContext)
         Lifecycle.Event.ON_START ->
           SimplexService.start(applicationContext)
+        Lifecycle.Event.ON_RESUME ->
+          if (chatModel.onboardingStage.value == OnboardingStage.OnboardingComplete)
+            chatController.showBackgroundServiceNoticeIfNeeded()
       }
     }
   }

--- a/apps/android/app/src/main/java/chat/simplex/app/views/WelcomeView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/WelcomeView.kt
@@ -116,7 +116,7 @@ fun createProfile(chatModel: ChatModel, displayName: String, fullName: String) {
     chatModel.controller.startChat(user)
     SimplexService.start(chatModel.controller.appContext)
     // TODO show it later?
-    chatModel.controller.showBackgroundServiceNotice()
+    chatModel.controller.showBackgroundServiceNoticeIfNeeded()
     chatModel.onboardingStage.value = OnboardingStage.OnboardingComplete
   }
 }

--- a/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/SettingsView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/SettingsView.kt
@@ -37,6 +37,10 @@ fun SettingsView(chatModel: ChatModel) {
       runServiceInBackground = chatModel.runServiceInBackground,
       setRunServiceInBackground = { on ->
         chatModel.controller.setRunServiceInBackground(on)
+        if (on && !chatModel.controller.isIgnoringBatteryOptimizations(chatModel.controller.appContext))
+          chatModel.controller.setBackgroundServiceNoticeShown(false)
+        
+        chatModel.controller.showBackgroundServiceNoticeIfNeeded()
         chatModel.runServiceInBackground.value = on
       },
       showModal = { modalView -> { ModalManager.shared.showModal { modalView(chatModel) } } },

--- a/apps/android/app/src/main/res/values-ru/strings.xml
+++ b/apps/android/app/src/main/res/values-ru/strings.xml
@@ -56,6 +56,8 @@
     <string name="private_instant_notifications">Приватные мгновенные уведомления!</string>
     <string name="to_preserve_privacy_simplex_has_background_service_instead_of_push_notifications_it_uses_a_few_pc_battery">Чтобы защитить ваши личные данные, вместо уведомлений от сервера приложение запускает <b>фоновый сервис <xliff:g id="appName">SimpleX</xliff:g></b>, который потребляет несколько процентов батареи в день.</string>
     <string name="it_can_disabled_via_settings_notifications_still_shown"><b>Он может быть выключен через Настройки</b> – вы продолжите получать уведомления о сообщениях пока приложение запущено.</string>
+    <string name="turn_off_battery_optimization">Для его использования нужно отключить оптимизацию энергопотребления Android. Иначе сервис не заработает.</string>
+    <string name="turning_off_background_service">Оптимизация энергопотребления <b>все еще активна</b>, выключаю сервис. Можете включить его повторно через Настройки.</string>
 
     <!-- SimpleX Chat foreground Service -->
     <string name="simplex_service_notification_title"><xliff:g id="appNameFull">SimpleX Chat</xliff:g> сервис</string>

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -56,6 +56,8 @@
   <string name="private_instant_notifications">Private instant notifications!</string>
   <string name="to_preserve_privacy_simplex_has_background_service_instead_of_push_notifications_it_uses_a_few_pc_battery">To preserve your privacy, instead of push notifications the app has a <b><xliff:g id="appName">SimpleX</xliff:g> background service</b> – it uses a few percent of the battery per day.</string>
   <string name="it_can_disabled_via_settings_notifications_still_shown"><b>It can be disabled via settings</b> – notifications will still be shown while the app is running.</string>
+  <string name="turn_off_battery_optimization">In order to use it you need to disable Android battery optimization on the next screen. Otherwise, the service will be disabled.</string>
+  <string name="turning_off_background_service">Battery optimization <b>is still active</b>, turning off the service. You can re-enable it via settings.</string>
 
   <!-- SimpleX Chat foreground Service -->
   <string name="simplex_service_notification_title"><xliff:g id="appNameFull">SimpleX Chat</xliff:g> service</string>


### PR DESCRIPTION
- in case of battery optimization is enabled a user will be asked to disable it if he wants to have a background service                                                                                
- when the service is enabled but the user don't want to disable the battery optimization, the service will be disabled with an alert for the user.

The behavior is the same as you shown on the mind map in our talk except the left bottom corner of the mind map.