### PR TITLE
Button in notification that routes to settings for notification channel

### DIFF
--- a/apps/android/app/src/main/java/chat/simplex/app/SimplexService.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/SimplexService.kt
@@ -3,6 +3,7 @@ package chat.simplex.app
 import android.app.*
 import android.content.*
 import android.os.*
+import android.provider.Settings
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
@@ -117,7 +118,8 @@ class SimplexService: Service() {
     val pendingIntent: PendingIntent = Intent(this, MainActivity::class.java).let { notificationIntent ->
       PendingIntent.getActivity(this, 0, notificationIntent, PendingIntent.FLAG_IMMUTABLE)
     }
-    return NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
+
+    val builder =  NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
       .setSmallIcon(R.drawable.ntf_service_icon)
       .setColor(0x88FFFF)
       .setContentTitle(title)
@@ -125,7 +127,18 @@ class SimplexService: Service() {
       .setContentIntent(pendingIntent)
       .setSilent(true)
       .setShowWhen(false) // no date/time
-      .build()
+
+    // Shows a button which opens notification channel settings
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      val flags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+      val setupIntent = Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS)
+      setupIntent.putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
+      setupIntent.putExtra(Settings.EXTRA_CHANNEL_ID, NOTIFICATION_CHANNEL_ID)
+      val setup = PendingIntent.getActivity(this, 0, setupIntent, flags)
+      builder.addAction(0, getString(R.string.hide_notification), setup)
+    }
+
+    return builder.build()
   }
 
   override fun onBind(intent: Intent): IBinder? {

--- a/apps/android/app/src/main/res/values-ru/strings.xml
+++ b/apps/android/app/src/main/res/values-ru/strings.xml
@@ -65,6 +65,7 @@
     <!-- SimpleX Chat foreground Service -->
     <string name="simplex_service_notification_title"><xliff:g id="appNameFull">SimpleX Chat</xliff:g> сервис</string>
     <string name="simplex_service_notification_text">Приём сообщений…</string>
+    <string name="hide_notification">Скрыть</string>
 
     <!-- local authentication notice - SimpleXAPI.kt -->
     <string name="la_notice_title_simplex_lock">Блокировка SimpleX</string>

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -65,6 +65,7 @@
   <!-- SimpleX Chat foreground Service -->
   <string name="simplex_service_notification_title"><xliff:g id="appNameFull">SimpleX Chat</xliff:g> service</string>
   <string name="simplex_service_notification_text">Receiving messages…</string>
+  <string name="hide_notification">Hide</string>
 
   <!-- local authentication notice - SimpleXAPI.kt -->
   <string name="la_notice_title_simplex_lock">SimpleX Lock</string>


### PR DESCRIPTION
Now users are able to hide a notification without finding the app in the settings. At least now they will be aware of such possibility. I could write `setup` instead of `hide` (which is closer to actual situation) but in this case users could misunderstand of what they will be trying to setup.