### PR TITLE
Debug package suffix and ability to override Gradle variables

### DIFF
--- a/apps/android/.gitignore
+++ b/apps/android/.gitignore
@@ -9,6 +9,7 @@
 /.idea/assetWizardSettings.xml
 /.idea/deploymentTargetDropDown.xml
 /.idea/misc.xml
+/.idea/uiDesigner.xml
 .DS_Store
 /build
 /captures

--- a/apps/android/app/build.gradle
+++ b/apps/android/app/build.gradle
@@ -29,9 +29,16 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix "$application_id_suffix"
+            debuggable new Boolean("$enable_debuggable")
+            // Provider can't be the same for different apps on the same device
+            manifestPlaceholders = [provider_authorities: "chat.simplex.app${application_id_suffix}.provider"]
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            manifestPlaceholders = [provider_authorities: "chat.simplex.app.provider"]
         }
     }
     compileOptions {

--- a/apps/android/app/build.gradle
+++ b/apps/android/app/build.gradle
@@ -26,19 +26,21 @@ android {
                 cppFlags ''
             }
         }
+        manifestPlaceholders.app_name = "@string/app_name"
+        manifestPlaceholders.provider_authorities = "chat.simplex.app.provider"
     }
 
     buildTypes {
         debug {
             applicationIdSuffix "$application_id_suffix"
             debuggable new Boolean("$enable_debuggable")
+            manifestPlaceholders.app_name = "$app_name"
             // Provider can't be the same for different apps on the same device
-            manifestPlaceholders = [provider_authorities: "chat.simplex.app${application_id_suffix}.provider"]
+            manifestPlaceholders.provider_authorities = "chat.simplex.app${application_id_suffix}.provider"
         }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            manifestPlaceholders = [provider_authorities: "chat.simplex.app.provider"]
         }
     }
     compileOptions {

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -98,7 +98,7 @@
 
     <provider
         android:name="androidx.core.content.FileProvider"
-        android:authorities="chat.simplex.app.provider"
+        android:authorities="${provider_authorities}"
         android:exported="false"
         android:grantUriPermissions="true">
       <meta-data

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
       android:name="SimplexApp"
       android:allowBackup="true"
       android:icon="@mipmap/icon"
-      android:label="@string/app_name"
+      android:label="${app_name}"
       android:supportsRtl="true"
       android:theme="@style/Theme.SimpleX">
 
@@ -34,7 +34,7 @@
         android:name=".MainActivity"
         android:launchMode="singleTask"
         android:exported="true"
-        android:label="@string/app_name"
+        android:label="${app_name}"
         android:windowSoftInputMode="adjustResize"
         android:theme="@style/Theme.SimpleX">
       <intent-filter>
@@ -66,9 +66,7 @@
 
     <activity-alias
         android:name=".MainActivity_default"
-        android:launchMode="singleTask"
         android:exported="true"
-        android:label="@string/app_name"
         android:icon="@mipmap/icon"
         android:enabled="true"
         android:targetActivity=".MainActivity">
@@ -80,9 +78,7 @@
 
     <activity-alias
         android:name=".MainActivity_dark_blue"
-        android:launchMode="singleTask"
         android:exported="true"
-        android:label="@string/app_name"
         android:icon="@mipmap/icon_dark_blue"
         android:enabled="false"
         android:targetActivity=".MainActivity">

--- a/apps/android/app/src/main/java/chat/simplex/app/SimplexApp.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/SimplexApp.kt
@@ -84,7 +84,7 @@ class SimplexApp: Application(), LifecycleEventObserver {
     lateinit var context: SimplexApp private set
 
     init {
-      val socketName = "local.socket.address.listen.native.cmd2"
+      val socketName = BuildConfig.APPLICATION_ID + ".local.socket.address.listen.native.cmd2"
       val s = Semaphore(0)
       thread(name="stdout/stderr pipe") {
         Log.d(TAG, "starting server")

--- a/apps/android/build.gradle
+++ b/apps/android/build.gradle
@@ -1,14 +1,34 @@
 buildscript {
+    Properties localProperties = new Properties()
+    if (rootProject.file('local.properties').canRead()) {
+        localProperties.load(rootProject.file("local.properties").newDataInputStream())
+    }
+
     ext {
-        compose_version = '1.2.0-beta02'
+        compose_version = localProperties['compose_version'] ?: '1.2.0-beta02'
+        kotlin_version = localProperties['kotlin_version'] ?: '1.6.21'
+        gradle_plugin_version = localProperties['gradle_plugin_version'] ?: '7.2.0'
+
+        // Whether the app is debuggable or not. Specify `false` if you want good performance in debug builds
+        enable_debuggable = localProperties['debuggable'] ?: true
+        // Ending part of package name. Allows debug & release versions to coexist
+        application_id_suffix = localProperties['application_id_suffix'] ?: '.debug'
+        // Provide `application_id_suffix=` in local.properties file if you have old installation
+        // and want to preserve your data
+        if (localProperties.getProperty('application_id_suffix') == '') {
+            application_id_suffix = ''
+        }
+
+        // NOTE: If you need a different version of something, provide it in `local.properties`
+        // like so: compose_version=123, or gradle_plugin_version=1.2.3, etc
     }
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21"
+        classpath "com.android.tools.build:gradle:$gradle_plugin_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:1.3.2"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -16,10 +36,10 @@ buildscript {
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.2.0' apply false
-    id 'com.android.library' version '7.2.0' apply false
-    id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
-    id 'org.jetbrains.kotlin.plugin.serialization' version '1.6.21'
+    id 'com.android.application' version "$gradle_plugin_version" apply false
+    id 'com.android.library' version "$gradle_plugin_version" apply false
+    id 'org.jetbrains.kotlin.android' version "$kotlin_version" apply false
+    id 'org.jetbrains.kotlin.plugin.serialization' version "$kotlin_version"
 }
 
 task clean(type: Delete) {

--- a/apps/android/build.gradle
+++ b/apps/android/build.gradle
@@ -9,6 +9,8 @@ buildscript {
         kotlin_version = localProperties['kotlin_version'] ?: '1.6.21'
         gradle_plugin_version = localProperties['gradle_plugin_version'] ?: '7.2.0'
 
+        // Name that will be shown for debug build
+        app_name = localProperties['app_name'] ?: "SimpleX Debug"
         // Whether the app is debuggable or not. Specify `false` if you want good performance in debug builds
         enable_debuggable = localProperties['debuggable'] ?: true
         // Ending part of package name. Allows debug & release versions to coexist

--- a/apps/android/build.gradle
+++ b/apps/android/build.gradle
@@ -9,17 +9,14 @@ buildscript {
         kotlin_version = localProperties['kotlin_version'] ?: '1.6.21'
         gradle_plugin_version = localProperties['gradle_plugin_version'] ?: '7.2.0'
 
-        // Name that will be shown for debug build
-        app_name = localProperties['app_name'] ?: "SimpleX Debug"
+        // Name that will be shown for debug build. By default it is from strings
+        app_name = localProperties['app_name'] ?: "@string/app_name"
         // Whether the app is debuggable or not. Specify `false` if you want good performance in debug builds
         enable_debuggable = localProperties['debuggable'] ?: true
-        // Ending part of package name. Allows debug & release versions to coexist
-        application_id_suffix = localProperties['application_id_suffix'] ?: '.debug'
-        // Provide `application_id_suffix=` in local.properties file if you have old installation
-        // and want to preserve your data
-        if (localProperties.getProperty('application_id_suffix') == '') {
-            application_id_suffix = ''
-        }
+        // Ending part of package name.
+        // Provide, for example, `application_id_suffix=.debug` in local.properties
+        // to allow debug & release versions to coexist
+        application_id_suffix = localProperties['application_id_suffix'] ?: ''
 
         // NOTE: If you need a different version of something, provide it in `local.properties`
         // like so: compose_version=123, or gradle_plugin_version=1.2.3, etc


### PR DESCRIPTION
- now debug builds will have `.debug` suffix by default. It allows to have multiple app builds (debug and release) on the same device. If you don't need this, create a file local.properties and add `application_id_suffix=` into it
- now everyone can override some variables from top-level build.gradle file. For example, gradle_plugin_version, debuggable manifest attribute, and so on. Overriding Gradle plugin version is useful for those who uses Intellij IDEA with older Gradle plugin than in Android Studio.

There is no behaviour changes for release build and no changes in versions of plugins/libs. 
There is a change for debug build which can be easily returned to previous behavior by adding `application_id_suffix=` into local.properties file.
