### PR TITLE
Endless scrolling in a chat view

### DIFF
--- a/apps/android/app/src/main/java/chat/simplex/app/MainActivity.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/MainActivity.kt
@@ -31,7 +31,7 @@ import chat.simplex.app.views.call.ActiveCallView
 import chat.simplex.app.views.call.IncomingCallAlertView
 import chat.simplex.app.views.chat.ChatView
 import chat.simplex.app.views.chatlist.ChatListView
-import chat.simplex.app.views.chatlist.showChat
+import chat.simplex.app.views.chatlist.openChat
 import chat.simplex.app.views.helpers.*
 import chat.simplex.app.views.newchat.connectViaUri
 import chat.simplex.app.views.newchat.withUriAction
@@ -333,7 +333,7 @@ fun processNotificationIntent(intent: Intent?, chatModel: ChatModel) {
       if (chatId != null) {
         val cInfo = chatModel.getChat(chatId)?.chatInfo
         chatModel.clearOverlays.value = true
-        if (cInfo != null) withApi { showChat(cInfo, chatModel) }
+        if (cInfo != null) withApi { openChat(cInfo, chatModel) }
       }
     }
     NtfManager.ShowChatsAction -> {

--- a/apps/android/app/src/main/java/chat/simplex/app/MainActivity.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/MainActivity.kt
@@ -31,7 +31,7 @@ import chat.simplex.app.views.call.ActiveCallView
 import chat.simplex.app.views.call.IncomingCallAlertView
 import chat.simplex.app.views.chat.ChatView
 import chat.simplex.app.views.chatlist.ChatListView
-import chat.simplex.app.views.chatlist.openChat
+import chat.simplex.app.views.chatlist.showChat
 import chat.simplex.app.views.helpers.*
 import chat.simplex.app.views.newchat.connectViaUri
 import chat.simplex.app.views.newchat.withUriAction
@@ -333,7 +333,7 @@ fun processNotificationIntent(intent: Intent?, chatModel: ChatModel) {
       if (chatId != null) {
         val cInfo = chatModel.getChat(chatId)?.chatInfo
         chatModel.clearOverlays.value = true
-        if (cInfo != null) withApi { openChat(cInfo, chatModel) }
+        if (cInfo != null) withApi { showChat(cInfo, chatModel) }
       }
     }
     NtfManager.ShowChatsAction -> {

--- a/apps/android/app/src/main/java/chat/simplex/app/model/ChatModel.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/model/ChatModel.kt
@@ -212,7 +212,7 @@ class ChatModel(val controller: ChatController) {
   }
 
   fun markChatItemsRead(cInfo: ChatInfo, range: CC.ItemRange? = null) {
-    val markedRead = markItemsReadInCurrentChat(cInfo.id, range)
+    val markedRead = markItemsReadInCurrentChat(cInfo, range)
     // update preview
     val chatIdx = getChatIndex(cInfo.id)
     if (chatIdx >= 0) {
@@ -230,9 +230,9 @@ class ChatModel(val controller: ChatController) {
     }
   }
 
-  private fun markItemsReadInCurrentChat(infoChatId: ChatId, range: CC.ItemRange? = null): Int {
+  private fun markItemsReadInCurrentChat(cInfo: ChatInfo, range: CC.ItemRange? = null): Int {
     var markedRead = 0
-    if (chatId.value == infoChatId) {
+    if (chatId.value == cInfo.id) {
       var i = 0
       while (i < chatItems.count()) {
         val item = chatItems[i]

--- a/apps/android/app/src/main/java/chat/simplex/app/model/SimpleXAPI.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/model/SimpleXAPI.kt
@@ -1265,6 +1265,12 @@ sealed class ChatPagination {
     is After -> "after=${this.chatItemId} count=${this.count}"
     is Before -> "before=${this.chatItemId} count=${this.count}"
   }
+
+  companion object {
+    const val INITIAL_COUNT = 50
+    const val PRELOAD_COUNT = 20
+    const val UNTIL_PRELOAD_COUNT = 10
+  }
 }
 
 @Serializable

--- a/apps/android/app/src/main/java/chat/simplex/app/model/SimpleXAPI.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/model/SimpleXAPI.kt
@@ -314,7 +314,7 @@ open class ChatController(private val ctrl: ChatCtrl, val ntfManager: NtfManager
     throw Error("failed getting the list of chats: ${r.responseType} ${r.details}")
   }
 
-  suspend fun apiGetChat(type: ChatType, id: Long, pagination: ChatPagination = ChatPagination.Last(100)): Chat? {
+  suspend fun apiGetChat(type: ChatType, id: Long, pagination: ChatPagination = ChatPagination.Last(ChatPagination.INITIAL_COUNT)): Chat? {
     val r = sendCmd(CC.ApiGetChat(type, id, pagination))
     if (r is CR.ApiChat ) return r.chat
     Log.e(TAG, "apiGetChat bad response: ${r.responseType} ${r.details}")
@@ -1278,7 +1278,7 @@ sealed class ChatPagination {
   }
 
   companion object {
-    const val INITIAL_COUNT = 50
+    const val INITIAL_COUNT = 100
     const val PRELOAD_COUNT = 20
     const val UNTIL_PRELOAD_COUNT = 10
   }

--- a/apps/android/app/src/main/java/chat/simplex/app/views/chat/ChatView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/chat/ChatView.kt
@@ -113,13 +113,11 @@ fun ChatView(chatModel: ChatModel) {
           }
         }
       },
-      loadPrevMessages = { apiId, chatType ->
-        val c = chatModel.chats.firstOrNull {
-          it.chatInfo.chatType == chatType && it.chatInfo.apiId == apiId
-        }
+      loadPrevMessages = { cInfo ->
+        val c = chatModel.getChat(cInfo.id)
         val firstId = chatModel.chatItems.firstOrNull()?.id
         if (c != null && firstId != null) {
-          withApi { loadPrevMessages(firstId, c.chatInfo, chatModel) }
+          withApi { apiLoadPrevMessages(firstId, c.chatInfo, chatModel) }
         }
       },
       deleteMessage = { itemId, mode ->
@@ -198,7 +196,7 @@ fun ChatLayout(
   back: () -> Unit,
   info: () -> Unit,
   openDirectChat: (Long) -> Unit,
-  loadPrevMessages: (Long, ChatType) -> Unit,
+  loadPrevMessages: (ChatInfo) -> Unit,
   deleteMessage: (Long, CIDeleteMode) -> Unit,
   receiveFile: (Long) -> Unit,
   joinGroup: (Long) -> Unit,
@@ -343,7 +341,7 @@ fun BoxWithConstraintsScope.ChatItemsList(
   chatItems: List<ChatItem>,
   useLinkPreviews: Boolean,
   openDirectChat: (Long) -> Unit,
-  loadPrevMessages: (Long, ChatType) -> Unit,
+  loadPrevMessages: (ChatInfo) -> Unit,
   deleteMessage: (Long, CIDeleteMode) -> Unit,
   receiveFile: (Long) -> Unit,
   joinGroup: (Long) -> Unit,
@@ -376,7 +374,7 @@ fun BoxWithConstraintsScope.ChatItemsList(
   }
 
   PreloadItems(listState, ChatPagination.UNTIL_PRELOAD_COUNT, chat, chatItems) { c ->
-    loadPrevMessages(c.chatInfo.apiId, c.chatInfo.chatType)
+    loadPrevMessages(c.chatInfo)
   }
 
   Spacer(Modifier.size(8.dp))
@@ -526,7 +524,7 @@ fun PreviewChatLayout() {
       back = {},
       info = {},
       openDirectChat = {},
-      loadPrevMessages = { _, _ -> },
+      loadPrevMessages = { _ -> },
       deleteMessage = { _, _ -> },
       receiveFile = {},
       joinGroup = {},
@@ -577,7 +575,7 @@ fun PreviewGroupChatLayout() {
       back = {},
       info = {},
       openDirectChat = {},
-      loadPrevMessages = { _, _ -> },
+      loadPrevMessages = { _ -> },
       deleteMessage = { _, _ -> },
       receiveFile = {},
       joinGroup = {},

--- a/apps/android/app/src/main/java/chat/simplex/app/views/chatlist/ChatListNavLinkView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/chatlist/ChatListNavLinkView.kt
@@ -96,7 +96,7 @@ suspend fun openChat(chatInfo: ChatInfo, chatModel: ChatModel) {
   }
 }
 
-suspend fun loadPrevMessages(beforeChatItemId: Long, chatInfo: ChatInfo, chatModel: ChatModel) {
+suspend fun apiLoadPrevMessages(beforeChatItemId: Long, chatInfo: ChatInfo, chatModel: ChatModel) {
   val pagination = ChatPagination.Before(beforeChatItemId, ChatPagination.PRELOAD_COUNT)
   val chat = chatModel.controller.apiGetChat(chatInfo.chatType, chatInfo.apiId, pagination) ?: return
   chatModel.chatItems.addAll(0, chat.chatItems)

--- a/apps/android/app/src/main/java/chat/simplex/app/views/chatlist/ChatListNavLinkView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/chatlist/ChatListNavLinkView.kt
@@ -259,12 +259,16 @@ fun ContactConnectionMenuItems(chatInfo: ChatInfo.ContactConnection, chatModel: 
 }
 
 fun markChatRead(chat: Chat, chatModel: ChatModel) {
+  // Just to be sure
+  if (chat.chatStats.unreadCount == 0) return
+
+  val minUnreadItemId = chat.chatStats.minUnreadItemId
   chatModel.markChatItemsRead(chat.chatInfo)
   withApi {
     chatModel.controller.apiChatRead(
       chat.chatInfo.chatType,
       chat.chatInfo.apiId,
-      CC.ItemRange(chat.chatStats.minUnreadItemId, chat.chatItems.last().id)
+      CC.ItemRange(minUnreadItemId, chat.chatItems.last().id)
     )
   }
 }

--- a/apps/android/app/src/main/java/chat/simplex/app/views/chatlist/ChatListNavLinkView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/chatlist/ChatListNavLinkView.kt
@@ -73,7 +73,7 @@ fun ChatListNavLinkView(chat: Chat, chatModel: ChatModel) {
 
 fun directChatAction(chatInfo: ChatInfo, chatModel: ChatModel) {
   if (chatInfo.ready) {
-    withApi { openChat(chatInfo, chatModel) }
+    withApi { showChat(chatInfo, chatModel) }
   } else {
     pendingContactAlertDialog(chatInfo, chatModel)
   }
@@ -83,17 +83,29 @@ fun groupChatAction(groupInfo: GroupInfo, chatModel: ChatModel) {
   when (groupInfo.membership.memberStatus) {
     GroupMemberStatus.MemInvited -> acceptGroupInvitationAlertDialog(groupInfo, chatModel)
     GroupMemberStatus.MemAccepted -> groupInvitationAcceptedAlert()
-    else -> withApi { openChat(ChatInfo.Group(groupInfo), chatModel) }
+    else -> withApi { showChat(ChatInfo.Group(groupInfo), chatModel) }
   }
 }
 
-suspend fun openChat(chatInfo: ChatInfo, chatModel: ChatModel) {
-  val chat = chatModel.controller.apiGetChat(chatInfo.chatType, chatInfo.apiId)
-  if (chat != null) {
-    chatModel.chatItems.clear()
-    chatModel.chatItems.addAll(chat.chatItems)
-    chatModel.chatId.value = chatInfo.id
+suspend fun showChat(
+  chatInfo: ChatInfo,
+  chatModel: ChatModel,
+  pagination: ChatPagination = ChatPagination.Last(ChatPagination.INITIAL_COUNT)
+) {
+  val chat = chatModel.controller.apiGetChat(chatInfo.chatType, chatInfo.apiId, pagination) ?: return
+  when (pagination) {
+    is ChatPagination.Last -> {
+      chatModel.chatItems.clear()
+      chatModel.chatItems.addAll(chat.chatItems)
+    }
+    is ChatPagination.Before -> {
+      chatModel.chatItems.addAll(0, chat.chatItems)
+    }
+    is ChatPagination.After -> {
+      chatModel.chatItems.addAll(chat.chatItems)
+    }
   }
+  chatModel.chatId.value = chatInfo.id
 }
 
 suspend fun setGroupMembers(groupInfo: GroupInfo, chatModel: ChatModel) {


### PR DESCRIPTION
- scroll position when you open keyboard/change screen orientation will remain the same
- scrolling to top will show messages from history
- unread messages will be positioned at the top of the screen