### PR TITLE
core: update deleteGroupMember logic and its usages (no items & expiration)

### DIFF
--- a/src/Simplex/Chat.hs
+++ b/src/Simplex/Chat.hs
@@ -537,6 +537,8 @@ processChatCommand = \case
       maxItemTs_ <- withStore' $ \db -> getGroupMaxItemTs db user gInfo
       forM_ filesInfo $ \fileInfo -> deleteFile user fileInfo
       withStore' $ \db -> deleteGroupCIs db user gInfo
+      membersToDelete <- withStore' $ \db -> getGroupMembersForExpiration db user gInfo
+      forM_ membersToDelete $ \m -> withStore' $ \db -> deleteGroupMember db user m
       gInfo' <- case maxItemTs_ of
         Just ts -> do
           withStore' $ \db -> updateGroupTs db user gInfo ts

--- a/src/Simplex/Chat/Store.hs
+++ b/src/Simplex/Chat/Store.hs
@@ -98,6 +98,7 @@ module Simplex.Chat.Store
     updateGroupMemberStatus,
     updateGroupMemberStatusById,
     createNewGroupMember,
+    checkGroupMemberHasItems,
     deleteGroupMember,
     deleteGroupMemberConnection,
     updateGroupMemberRole,
@@ -1985,6 +1986,10 @@ createNewMember_
       (groupId, memberId, memberRole, memberCategory, memberStatus, invitedById, userId, localDisplayName, memberContactId, memberContactProfileId, createdAt, createdAt)
     groupMemberId <- insertedRowId db
     pure GroupMember {groupMemberId, groupId, memberId, memberRole, memberCategory, memberStatus, invitedBy, localDisplayName, memberProfile = toLocalProfile memberContactProfileId memberProfile "", memberContactId, memberContactProfileId, activeConn}
+
+checkGroupMemberHasItems :: DB.Connection -> User -> GroupMember -> IO (Maybe ChatItemId)
+checkGroupMemberHasItems db User {userId} GroupMember {groupMemberId, groupId} =
+  maybeFirstRow fromOnly $ DB.query db "SELECT chat_item_id FROM chat_items WHERE user_id = ? AND group_id = ? AND group_member_id = ? LIMIT 1" (userId, groupId, groupMemberId)
 
 deleteGroupMember :: DB.Connection -> User -> GroupMember -> IO ()
 deleteGroupMember db user@User {userId} m@GroupMember {groupMemberId, groupId, memberContactId, memberContactProfileId} = do

--- a/tests/ChatTests.hs
+++ b/tests/ChatTests.hs
@@ -768,7 +768,13 @@ testGroupDelete =
       cath <## "#team: you deleted the group"
       alice <##> bob
       alice <##> cath
-      bob <##> cath
+      -- unused group contacts are deleted
+      bob ##> "@cath hi"
+      bob <## "no contact cath"
+      (cath </)
+      cath ##> "@bob hi"
+      cath <## "no contact bob"
+      (bob </)
 
 testGroupSameName :: IO ()
 testGroupSameName =
@@ -3557,8 +3563,10 @@ testGroupLinkDeleteInvitedMemberNoBrokenItem =
       alice <## "#team: you removed bob from the group"
       alice #$> ("/_get chat #1 count=100", chat, [])
       alice @@@ [("#team", "")]
-      alice <##> bob
-      alice @@@ [("@bob", "hey"), ("#team", "")]
+      -- removing member deletes unused group contact
+      alice ##> "@bob hi"
+      alice <## "no contact bob"
+      (bob </)
       bob ##> "/j team"
       bob <## "error: connection authorization failed - this could happen if connection was deleted, secured with different credentials, or due to a bug - please re-create the connection"
       -- repeat request is prohibited because of the re-used XContactId, until contact is deleted
@@ -3568,11 +3576,11 @@ testGroupLinkDeleteInvitedMemberNoBrokenItem =
       bob <## "alice: contact is deleted"
       bob ##> ("/c " <> gLink)
       bob <## "connection request sent!"
-      alice <## "bob_1 (Bob): accepting request to join group #team..."
+      alice <## "bob (Bob): accepting request to join group #team..."
       concurrentlyN_
         [ do
-            alice <## "bob_1 (Bob): contact is connected"
-            alice <## "bob_1 invited to group #team via your group link",
+            alice <## "bob (Bob): contact is connected"
+            alice <## "bob invited to group #team via your group link",
           do
             bob <## "alice_1 (Alice): contact is connected"
             bob <## "#team_1 (team): alice_1 invites you to join the group as member"
@@ -3580,12 +3588,12 @@ testGroupLinkDeleteInvitedMemberNoBrokenItem =
         ]
       bob ##> "/j team_1"
       concurrently_
-        (alice <## "#team: bob_1 joined the group")
+        (alice <## "#team: bob joined the group")
         (bob <## "#team_1: you joined the group")
       alice #> "#team hello"
       bob <# "#team_1 alice_1> hello"
       bob #> "#team_1 hi there"
-      alice <# "#team bob_1> hi there"
+      alice <# "#team bob> hi there"
 
 withTestChatContactConnected :: String -> (TestCC -> IO a) -> IO a
 withTestChatContactConnected dbPrefix action =


### PR DESCRIPTION
- Fully delete member record without items when removing member
- Fully delete removed/left/"group deleted" member records without items when expiring messages
- Delete “unused” group contact when deleting member