### PR TITLE
core: clean up incognito profiles

### DIFF
--- a/apps/ios/Shared/Views/ChatList/ChatListNavLink.swift
+++ b/apps/ios/Shared/Views/ChatList/ChatListNavLink.swift
@@ -87,7 +87,7 @@ struct ChatListNavLink: View {
             ChatPreviewView(chat: chat)
                 .frame(height: rowHeights[dynamicTypeSize])
                 .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                    joinGroupButton(groupInfo.hostConnCustomUserProfileId)
+                    joinGroupButton()
                     if groupInfo.canDelete {
                         deleteGroupChatButton(groupInfo)
                     }
@@ -137,7 +137,7 @@ struct ChatListNavLink: View {
         }
     }
 
-    private func joinGroupButton(_ hostConnCustomUserProfileId: Int64?) -> some View {
+    private func joinGroupButton() -> some View {
         Button {
             joinGroup(chat.chatInfo.apiId)
         } label: {

--- a/src/Simplex/Chat.hs
+++ b/src/Simplex/Chat.hs
@@ -493,7 +493,7 @@ processChatCommand = \case
         -- functions below are called in separate transactions to prevent crashes on android
         -- (possibly, race condition on integrity check?)
         withStore' $ \db -> deleteContactConnectionsAndFiles db userId ct
-        withStore' $ \db -> deleteContact db userId ct
+        withStore' $ \db -> deleteContact db user ct
         unsetActive $ ActiveC localDisplayName
         pure $ CRContactDeleted ct
     CTContactConnection -> withChatLock "deleteChat contactConnection" . procCmd $ do

--- a/src/Simplex/Chat/Migrations/M20220101_initial.hs
+++ b/src/Simplex/Chat/Migrations/M20220101_initial.hs
@@ -41,7 +41,7 @@ CREATE TABLE display_names (
 
 CREATE TABLE contacts (
   contact_id INTEGER PRIMARY KEY,
-  contact_profile_id INTEGER REFERENCES contact_profiles ON DELETE SET NULL, -- NULL if it's an incognito profile
+  contact_profile_id INTEGER REFERENCES contact_profiles ON DELETE SET NULL,
   user_id INTEGER NOT NULL REFERENCES users ON DELETE CASCADE,
   local_display_name TEXT NOT NULL,
   is_user INTEGER NOT NULL DEFAULT 0, -- 1 if this contact is a user
@@ -223,7 +223,7 @@ CREATE TABLE contact_requests (
     ON UPDATE CASCADE ON DELETE CASCADE,
   agent_invitation_id  BLOB NOT NULL,
   contact_profile_id INTEGER REFERENCES contact_profiles
-    ON DELETE SET NULL -- NULL if it's an incognito profile
+    ON DELETE SET NULL
     DEFERRABLE INITIALLY DEFERRED,
   local_display_name TEXT NOT NULL,
   created_at TEXT NOT NULL DEFAULT (datetime('now')),

--- a/src/Simplex/Chat/Migrations/chat_schema.sql
+++ b/src/Simplex/Chat/Migrations/chat_schema.sql
@@ -47,10 +47,10 @@ CREATE TABLE display_names(
 ) WITHOUT ROWID;
 CREATE TABLE contacts(
   contact_id INTEGER PRIMARY KEY,
-  contact_profile_id INTEGER REFERENCES contact_profiles ON DELETE SET NULL, -- NULL if it's an incognito profile
-user_id INTEGER NOT NULL REFERENCES users ON DELETE CASCADE,
-local_display_name TEXT NOT NULL,
-is_user INTEGER NOT NULL DEFAULT 0, -- 1 if this contact is a user
+  contact_profile_id INTEGER REFERENCES contact_profiles ON DELETE SET NULL,
+  user_id INTEGER NOT NULL REFERENCES users ON DELETE CASCADE,
+  local_display_name TEXT NOT NULL,
+  is_user INTEGER NOT NULL DEFAULT 0, -- 1 if this contact is a user
   via_group INTEGER REFERENCES groups(group_id) ON DELETE SET NULL,
   created_at TEXT NOT NULL DEFAULT(datetime('now')),
   updated_at TEXT CHECK(updated_at NOT NULL),
@@ -278,18 +278,20 @@ CREATE TABLE contact_requests(
   ON UPDATE CASCADE ON DELETE CASCADE,
   agent_invitation_id BLOB NOT NULL,
   contact_profile_id INTEGER REFERENCES contact_profiles
-  ON DELETE SET NULL -- NULL if it's an incognito profile
-DEFERRABLE INITIALLY DEFERRED,
-local_display_name TEXT NOT NULL,
-created_at TEXT NOT NULL DEFAULT(datetime('now')),
-user_id INTEGER NOT NULL REFERENCES users ON DELETE CASCADE, updated_at TEXT CHECK(updated_at NOT NULL), xcontact_id BLOB,
-FOREIGN KEY(user_id, local_display_name)
-REFERENCES display_names(user_id, local_display_name)
-ON UPDATE CASCADE
-ON DELETE CASCADE
-DEFERRABLE INITIALLY DEFERRED,
-UNIQUE(user_id, local_display_name),
-UNIQUE(user_id, contact_profile_id)
+  ON DELETE SET NULL
+  DEFERRABLE INITIALLY DEFERRED,
+  local_display_name TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT(datetime('now')),
+  user_id INTEGER NOT NULL REFERENCES users ON DELETE CASCADE,
+  updated_at TEXT CHECK(updated_at NOT NULL),
+  xcontact_id BLOB,
+  FOREIGN KEY(user_id, local_display_name)
+  REFERENCES display_names(user_id, local_display_name)
+  ON UPDATE CASCADE
+  ON DELETE CASCADE
+  DEFERRABLE INITIALLY DEFERRED,
+  UNIQUE(user_id, local_display_name),
+  UNIQUE(user_id, contact_profile_id)
 );
 CREATE TABLE messages(
   message_id INTEGER PRIMARY KEY,

--- a/src/Simplex/Chat/Store.hs
+++ b/src/Simplex/Chat/Store.hs
@@ -580,15 +580,15 @@ deleteUnusedIncognitoProfileById_ db User {userId} profile_id =
     db
     [sql|
       DELETE FROM contact_profiles
-      WHERE 1 NOT IN (
+      WHERE user_id = :user_id AND contact_profile_id = :profile_id AND incognito = 1
+        AND 1 NOT IN (
           SELECT 1 FROM connections
           WHERE user_id = :user_id AND custom_user_profile_id = :profile_id LIMIT 1
         )
         AND 1 NOT IN (
-          SELECT group_member_id FROM group_members
+          SELECT 1 FROM group_members
           WHERE user_id = :user_id AND member_profile_id = :profile_id LIMIT 1
         )
-        AND user_id = :user_id AND contact_profile_id = :profile_id AND incognito = 1
     |]
     [":user_id" := userId, ":profile_id" := profile_id]
 

--- a/src/Simplex/Chat/Store.hs
+++ b/src/Simplex/Chat/Store.hs
@@ -581,10 +581,10 @@ checkIncognitoProfileInUse_ db User {userId} profileId = do
   -- this is a bit risky according to schema, but we only set custom_user_profile_id for contact connections (with set contact_id)
   usedByContactId :: (Maybe ContactId) <- maybeFirstRow fromOnly $ DB.query db "SELECT contact_id FROM connections WHERE user_id = ? AND custom_user_profile_id = ? AND contact_id IS NOT NULL LIMIT 1" (userId, profileId)
   case usedByContactId of
+    Just _ -> pure True
     Nothing -> do
       usedByGroupMemberId :: (Maybe GroupMemberId) <- maybeFirstRow fromOnly $ DB.query db "SELECT group_member_id FROM group_members WHERE user_id = ? AND member_profile_id = ? LIMIT 1" (userId, profileId)
       pure $ isJust usedByGroupMemberId
-    Just _ -> pure True
 
 deleteIncognitoProfileById_ :: DB.Connection -> User -> ProfileId -> IO ()
 deleteIncognitoProfileById_ db User {userId} profileId =


### PR DESCRIPTION
for reference:

table | field | used for incognito profiles
---|---|---
contacts | contact_profile_id | -
group_members | contact_profile_id | -
group_members | member_profile_id | +
contact_requests | contact_profile_id | -
groups | host_conn_custom_user_profile_id | - (not used at all)
connections | custom_user_profile_id | +
