### PR TITLE
android: Random crashes fix

### DIFF
--- a/apps/android/app/src/main/java/chat/simplex/app/model/SimpleXAPI.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/model/SimpleXAPI.kt
@@ -1216,7 +1216,7 @@ open class ChatController(var ctrl: ChatCtrl?, val ntfManager: NtfManager, val a
         chatModel.notificationsMode.value = NotificationsMode.OFF
         SimplexService.StartReceiver.toggleReceiver(false)
         MessagesFetcherWorker.cancelAll()
-        SimplexService.stop(SimplexApp.context)
+        SimplexService.safeStopService(SimplexApp.context)
       } else {
         // show battery optimization notice
         showBGServiceNoticeIgnoreOptimization(mode)

--- a/apps/android/app/src/main/java/chat/simplex/app/views/call/CallView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/call/CallView.kt
@@ -63,7 +63,7 @@ fun ActiveCallView(chatModel: ChatModel) {
   DisposableEffect(Unit) {
     onDispose {
       // Stop it when call ended
-      if (!ntfModeService) SimplexService.stop(SimplexApp.context)
+      if (!ntfModeService) SimplexService.safeStopService(SimplexApp.context)
       // Clear selected communication device to default value after we changed it in call
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
         val am = SimplexApp.context.getSystemService(Context.AUDIO_SERVICE) as AudioManager

--- a/apps/android/app/src/main/java/chat/simplex/app/views/chat/ComposeView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/chat/ComposeView.kt
@@ -7,6 +7,7 @@ import android.content.*
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.ImageDecoder
+import android.graphics.ImageDecoder.DecodeException
 import android.graphics.drawable.AnimatedImageDrawable
 import android.net.Uri
 import android.provider.MediaStore
@@ -199,8 +200,17 @@ fun ComposeView(
     val imagesPreview = ArrayList<String>()
     uris.forEach { uri ->
       val source = ImageDecoder.createSource(context.contentResolver, uri)
-      val drawable = ImageDecoder.decodeDrawable(source)
-      var bitmap: Bitmap? = ImageDecoder.decodeBitmap(source)
+      val drawable = try {
+        ImageDecoder.decodeDrawable(source)
+      } catch (e: DecodeException) {
+        AlertManager.shared.showAlertMsg(
+          title = generalGetString(R.string.image_decoding_exception_title),
+          text = generalGetString(R.string.image_decoding_exception_desc)
+        )
+        Log.e(TAG, "Error while decoding drawable: ${e.stackTraceToString()}")
+        null
+      }
+      var bitmap: Bitmap? = if (drawable != null) ImageDecoder.decodeBitmap(source) else null
       if (drawable is AnimatedImageDrawable) {
         // It's a gif or webp
         val fileSize = getFileSize(context, uri)

--- a/apps/android/app/src/main/java/chat/simplex/app/views/chat/group/AddGroupMembersView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/chat/group/AddGroupMembersView.kt
@@ -43,8 +43,10 @@ fun AddGroupMembersView(groupInfo: GroupInfo, chatModel: ChatModel, close: () ->
     selectedContacts = selectedContacts,
     selectedRole = selectedRole,
     inviteMembers = {
+      // A copy of the list to prevent ConcurrentModification exception
+      val contacts = selectedContacts.toList()
       withApi {
-        for (contactId in selectedContacts) {
+        for (contactId in contacts) {
           val member = chatModel.controller.apiAddMember(groupInfo.groupId, contactId, selectedRole.value)
           if (member != null) {
             chatModel.upsertGroupMember(groupInfo, member)

--- a/apps/android/app/src/main/java/chat/simplex/app/views/chat/group/AddGroupMembersView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/chat/group/AddGroupMembersView.kt
@@ -14,7 +14,6 @@ import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.TheaterComedy
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.runtime.*
-import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -35,18 +34,18 @@ import chat.simplex.app.views.usersettings.SettingsActionItem
 fun AddGroupMembersView(groupInfo: GroupInfo, chatModel: ChatModel, close: () -> Unit) {
   val selectedContacts = remember { mutableStateListOf<Long>() }
   val selectedRole = remember { mutableStateOf(GroupMemberRole.Member) }
-
+  var allowModifyMembers by remember { mutableStateOf(true) }
   BackHandler(onBack = close)
   AddGroupMembersLayout(
     groupInfo = groupInfo,
     contactsToAdd = getContactsToAdd(chatModel),
     selectedContacts = selectedContacts,
     selectedRole = selectedRole,
+    allowModifyMembers = allowModifyMembers,
     inviteMembers = {
-      // A copy of the list to prevent ConcurrentModification exception
-      val contacts = selectedContacts.toList()
+      allowModifyMembers = false
       withApi {
-        for (contactId in contacts) {
+        for (contactId in selectedContacts) {
           val member = chatModel.controller.apiAddMember(groupInfo.groupId, contactId, selectedRole.value)
           if (member != null) {
             chatModel.upsertGroupMember(groupInfo, member)
@@ -81,8 +80,9 @@ fun getContactsToAdd(chatModel: ChatModel): List<Contact> {
 fun AddGroupMembersLayout(
   groupInfo: GroupInfo,
   contactsToAdd: List<Contact>,
-  selectedContacts: SnapshotStateList<Long>,
+  selectedContacts: List<Long>,
   selectedRole: MutableState<GroupMemberRole>,
+  allowModifyMembers: Boolean,
   inviteMembers: () -> Unit,
   clearSelection: () -> Unit,
   addContact: (Long) -> Unit,
@@ -121,18 +121,18 @@ fun AddGroupMembersLayout(
     } else {
       SectionView {
         SectionItemView {
-          RoleSelectionRow(groupInfo, selectedRole)
+          RoleSelectionRow(groupInfo, selectedRole, allowModifyMembers)
         }
         SectionDivider()
-        InviteMembersButton(inviteMembers, disabled = selectedContacts.isEmpty())
+        InviteMembersButton(inviteMembers, disabled = selectedContacts.isEmpty() || !allowModifyMembers)
       }
       SectionCustomFooter {
-        InviteSectionFooter(selectedContactsCount = selectedContacts.count(), clearSelection)
+        InviteSectionFooter(selectedContactsCount = selectedContacts.size, allowModifyMembers, clearSelection)
       }
       SectionSpacer()
 
       SectionView {
-        ContactList(contacts = contactsToAdd, selectedContacts, groupInfo, addContact, removeContact)
+        ContactList(contacts = contactsToAdd, selectedContacts, groupInfo, allowModifyMembers, addContact, removeContact)
       }
       SectionSpacer()
     }
@@ -140,7 +140,7 @@ fun AddGroupMembersLayout(
 }
 
 @Composable
-private fun RoleSelectionRow(groupInfo: GroupInfo, selectedRole: MutableState<GroupMemberRole>) {
+private fun RoleSelectionRow(groupInfo: GroupInfo, selectedRole: MutableState<GroupMemberRole>, enabled: Boolean) {
   Row(
     Modifier.fillMaxWidth(),
     verticalAlignment = Alignment.CenterVertically,
@@ -152,7 +152,7 @@ private fun RoleSelectionRow(groupInfo: GroupInfo, selectedRole: MutableState<Gr
       values,
       selectedRole,
       icon = null,
-      enabled = remember { mutableStateOf(true) },
+      enabled = rememberUpdatedState(enabled),
       onSelected = { selectedRole.value = it }
     )
   }
@@ -171,7 +171,7 @@ fun InviteMembersButton(onClick: () -> Unit, disabled: Boolean) {
 }
 
 @Composable
-fun InviteSectionFooter(selectedContactsCount: Int, clearSelection: () -> Unit) {
+fun InviteSectionFooter(selectedContactsCount: Int, enabled: Boolean, clearSelection: () -> Unit) {
   Row(
     Modifier.fillMaxWidth(),
     horizontalArrangement = Arrangement.SpaceBetween,
@@ -184,11 +184,11 @@ fun InviteSectionFooter(selectedContactsCount: Int, clearSelection: () -> Unit) 
         fontSize = 12.sp
       )
       Box(
-        Modifier.clickable { clearSelection() }
+        Modifier.clickable { if (enabled) clearSelection() }
       ) {
         Text(
           stringResource(R.string.clear_contacts_selection_button),
-          color = MaterialTheme.colors.primary,
+          color = if (enabled) MaterialTheme.colors.primary else HighOrLowlight,
           fontSize = 12.sp
         )
       }
@@ -205,8 +205,9 @@ fun InviteSectionFooter(selectedContactsCount: Int, clearSelection: () -> Unit) 
 @Composable
 fun ContactList(
   contacts: List<Contact>,
-  selectedContacts: SnapshotStateList<Long>,
+  selectedContacts: List<Long>,
   groupInfo: GroupInfo,
+  enabled: Boolean,
   addContact: (Long) -> Unit,
   removeContact: (Long) -> Unit
 ) {
@@ -214,7 +215,8 @@ fun ContactList(
     contacts.forEachIndexed { index, contact ->
       ContactCheckRow(
         contact, groupInfo, addContact, removeContact,
-        checked = selectedContacts.contains(contact.apiId)
+        checked = selectedContacts.contains(contact.apiId),
+        enabled = enabled,
       )
       if (index < contacts.lastIndex) {
         SectionDivider()
@@ -229,7 +231,8 @@ fun ContactCheckRow(
   groupInfo: GroupInfo,
   addContact: (Long) -> Unit,
   removeContact: (Long) -> Unit,
-  checked: Boolean
+  checked: Boolean,
+  enabled: Boolean,
 ) {
   val prohibitedToInviteIncognito = !groupInfo.membership.memberIncognito && contact.contactConnIncognito
   val icon: ImageVector
@@ -239,12 +242,14 @@ fun ContactCheckRow(
     iconColor = HighOrLowlight
   } else if (checked) {
     icon = Icons.Filled.CheckCircle
-    iconColor = MaterialTheme.colors.primary
+    iconColor = if (enabled) MaterialTheme.colors.primary else HighOrLowlight
   } else {
     icon = Icons.Outlined.Circle
     iconColor = HighOrLowlight
   }
   SectionItemView(click = {
+    if (!enabled) return@SectionItemView
+
     if (prohibitedToInviteIncognito) {
       showProhibitedToInviteIncognitoAlertDialog()
     } else if (!checked)
@@ -284,6 +289,7 @@ fun PreviewAddGroupMembersLayout() {
       contactsToAdd = listOf(Contact.sampleData, Contact.sampleData, Contact.sampleData),
       selectedContacts = remember { mutableStateListOf() },
       selectedRole = remember { mutableStateOf(GroupMemberRole.Admin) },
+      allowModifyMembers = true,
       inviteMembers = {},
       clearSelection = {},
       addContact = {},

--- a/apps/android/app/src/main/java/chat/simplex/app/views/database/DatabaseView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/database/DatabaseView.kt
@@ -409,7 +409,7 @@ private fun stopChat(m: ChatModel, runChat: MutableState<Boolean>, context: Cont
       m.controller.apiStopChat()
       runChat.value = false
       m.chatRunning.value = false
-      SimplexService.stop(context)
+      SimplexService.safeStopService(context)
       MessagesFetcherWorker.cancelAll()
     } catch (e: Error) {
       runChat.value = true

--- a/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/Cryptor.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/Cryptor.kt
@@ -23,7 +23,7 @@ internal class Cryptor {
         warningIsShown = true
         AlertManager.shared.showAlertMsg(
           title = generalGetString(R.string.wrong_passphrase),
-          text = generalGetString(R.string.restored_from_backup_broken_text)
+          text = generalGetString(R.string.restored_from_backup_broken_desc)
         )
       }
       return null

--- a/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/Cryptor.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/Cryptor.kt
@@ -3,6 +3,9 @@ package chat.simplex.app.views.usersettings
 import android.annotation.SuppressLint
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
+import chat.simplex.app.R
+import chat.simplex.app.views.helpers.AlertManager
+import chat.simplex.app.views.helpers.generalGetString
 import java.security.KeyStore
 import javax.crypto.*
 import javax.crypto.spec.GCMParameterSpec
@@ -10,11 +13,24 @@ import javax.crypto.spec.GCMParameterSpec
 @SuppressLint("ObsoleteSdkInt")
 internal class Cryptor {
   private var keyStore: KeyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+  private var warningIsShown = false
 
-  fun decryptData(data: ByteArray, iv: ByteArray, alias: String): String {
+  fun decryptData(data: ByteArray, iv: ByteArray, alias: String): String? {
+    val secretKey = getSecretKey(alias)
+    if (secretKey == null) {
+      if (!warningIsShown) {
+        // Repeated calls will not show the alert again
+        warningIsShown = true
+        AlertManager.shared.showAlertMsg(
+          title = generalGetString(R.string.wrong_passphrase),
+          text = generalGetString(R.string.restored_from_backup_broken_text)
+        )
+      }
+      return null
+    }
     val cipher: Cipher = Cipher.getInstance(TRANSFORMATION)
     val spec = GCMParameterSpec(128, iv)
-    cipher.init(Cipher.DECRYPT_MODE, getSecretKey(alias), spec)
+    cipher.init(Cipher.DECRYPT_MODE, secretKey, spec)
     return String(cipher.doFinal(data))
   }
 
@@ -29,7 +45,7 @@ internal class Cryptor {
     keyStore.deleteEntry(alias)
   }
 
-  private fun createSecretKey(alias: String): SecretKey {
+  private fun createSecretKey(alias: String): SecretKey? {
     if (keyStore.containsAlias(alias)) return getSecretKey(alias)
     val keyGenerator: KeyGenerator = KeyGenerator.getInstance(KEY_ALGORITHM, "AndroidKeyStore")
     keyGenerator.init(
@@ -41,8 +57,8 @@ internal class Cryptor {
     return keyGenerator.generateKey()
   }
 
-  private fun getSecretKey(alias: String): SecretKey {
-    return (keyStore.getEntry(alias, null) as KeyStore.SecretKeyEntry).secretKey
+  private fun getSecretKey(alias: String): SecretKey? {
+    return (keyStore.getEntry(alias, null) as? KeyStore.SecretKeyEntry)?.secretKey
   }
 
   companion object {

--- a/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/NotificationsSettingsView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/NotificationsSettingsView.kt
@@ -57,7 +57,7 @@ fun NotificationsSettingsView(
       if (mode == NotificationsMode.SERVICE)
         SimplexService.start(SimplexApp.context)
       else
-        SimplexService.stop(SimplexApp.context)
+        SimplexService.safeStopService(SimplexApp.context)
     }
 
     if (mode != NotificationsMode.PERIODIC) {

--- a/apps/android/app/src/main/res/values-de/strings.xml
+++ b/apps/android/app/src/main/res/values-de/strings.xml
@@ -183,6 +183,8 @@
   <string name="icon_descr_cancel_file_preview">Dateivorschau abbrechen</string>
   <string name="images_limit_title">Zu viele Bilder!</string>
   <string name="images_limit_desc">Es können nur 10 Bilder auf einmal gesendet werden</string>
+  <string name="image_decoding_exception_title">***Decoding error</string>
+  <string name="image_decoding_exception_desc">***The image cannot be decoded. Please, try with different image or contact devs</string>
 
   <!-- Images - chat.simplex.app.views.chat.item.CIImageView.kt -->
   <string name="image_descr">Bild</string>
@@ -674,7 +676,7 @@
   <string name="restore_database_alert_desc">Bitte geben Sie das vorherige Passwort ein, nachdem Sie die Datenbanksicherung wiederhergestellt haben. Diese Aktion kann nicht rückgängig gemacht werden.</string>
   <string name="restore_database_alert_confirm">Wiederherstellen</string>
   <string name="database_restore_error">Fehler bei der Wiederherstellung der Datenbank</string>
-  <string name="restored_from_backup_broken_text">***Looks like you restored the app\'s data from a backup (using TitaniumBackup or similar tool). Encryption passphrase should be entered manually. \n\nIf it\'s not the case, please, contact devs</string>
+  <string name="restored_from_backup_broken_desc">***Looks like you restored the app\'s data from a backup (using TitaniumBackup or similar tool). Encryption passphrase should be entered manually. \n\nIf it\'s not the case, please, contact devs</string>
 
   <!-- ChatModel.chatRunning interactions -->
   <string name="chat_is_stopped_indication">Chat wurde beendet</string>

--- a/apps/android/app/src/main/res/values-de/strings.xml
+++ b/apps/android/app/src/main/res/values-de/strings.xml
@@ -674,6 +674,7 @@
   <string name="restore_database_alert_desc">Bitte geben Sie das vorherige Passwort ein, nachdem Sie die Datenbanksicherung wiederhergestellt haben. Diese Aktion kann nicht rückgängig gemacht werden.</string>
   <string name="restore_database_alert_confirm">Wiederherstellen</string>
   <string name="database_restore_error">Fehler bei der Wiederherstellung der Datenbank</string>
+  <string name="restored_from_backup_broken_text">***Looks like you restored the app\'s data from a backup (using TitaniumBackup or similar tool). Encryption passphrase should be entered manually. \n\nIf it\'s not the case, please, contact devs</string>
 
   <!-- ChatModel.chatRunning interactions -->
   <string name="chat_is_stopped_indication">Chat wurde beendet</string>

--- a/apps/android/app/src/main/res/values-ru/strings.xml
+++ b/apps/android/app/src/main/res/values-ru/strings.xml
@@ -183,6 +183,8 @@
     <string name="icon_descr_cancel_file_preview">Удалить превью файла</string>
     <string name="images_limit_title">Слишком много изображений!</string>
     <string name="images_limit_desc">Только 10 изображений могут быть отправлены одномоментно</string>
+    <string name="image_decoding_exception_title">Ошибка декодирования</string>
+    <string name="image_decoding_exception_desc">Не получается декодировать изображение. Пожалуйста, попробуйте другое или свяжитесь с разработчиками</string>
 
     <!-- Images - chat.simplex.app.views.chat.item.CIImageView.kt -->
     <string name="image_descr">Изображение</string>
@@ -674,7 +676,7 @@
     <string name="restore_database_alert_desc">Введите предыдущий пароль после восстановления резервной копии. Это действие нельзя отменить.</string>
     <string name="restore_database_alert_confirm">Восстановить</string>
     <string name="database_restore_error">Ошибка при восстановлении базы данных</string>
-    <string name="restored_from_backup_broken_text">Похоже, вы восстановили данные программы из бэкапа (используя TitaniumBackup или похожий инструмент). Нужно ввести пароль от базы данных вручную. \n\nЕсли причина не в этом, пожалуйста, свяжитесь с разработчиками</string>
+    <string name="restored_from_backup_broken_desc">Похоже, вы восстановили данные программы из бэкапа (используя TitaniumBackup или похожий инструмент). Нужно ввести пароль от базы данных вручную. \n\nЕсли причина не в этом, пожалуйста, свяжитесь с разработчиками</string>
 
     <!-- ChatModel.chatRunning interactions -->
     <string name="chat_is_stopped_indication">Чат остановлен</string>

--- a/apps/android/app/src/main/res/values-ru/strings.xml
+++ b/apps/android/app/src/main/res/values-ru/strings.xml
@@ -674,6 +674,7 @@
     <string name="restore_database_alert_desc">Введите предыдущий пароль после восстановления резервной копии. Это действие нельзя отменить.</string>
     <string name="restore_database_alert_confirm">Восстановить</string>
     <string name="database_restore_error">Ошибка при восстановлении базы данных</string>
+    <string name="restored_from_backup_broken_text">Похоже, вы восстановили данные программы из бэкапа (используя TitaniumBackup или похожий инструмент). Нужно ввести пароль от базы данных вручную. \n\nЕсли причина не в этом, пожалуйста, свяжитесь с разработчиками</string>
 
     <!-- ChatModel.chatRunning interactions -->
     <string name="chat_is_stopped_indication">Чат остановлен</string>

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -674,6 +674,7 @@
   <string name="restore_database_alert_desc">Please enter the previous password after restoring database backup. This action can not be undone.</string>
   <string name="restore_database_alert_confirm">Restore</string>
   <string name="database_restore_error">Restore database error</string>
+  <string name="restored_from_backup_broken_text">Looks like you restored the app\'s data from a backup (using TitaniumBackup or similar tool). Encryption passphrase should be entered manually. \n\nIf it\'s not the case, please, contact devs</string>
 
   <!-- ChatModel.chatRunning interactions -->
   <string name="chat_is_stopped_indication">Chat is stopped</string>

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -183,6 +183,8 @@
   <string name="icon_descr_cancel_file_preview">Cancel file preview</string>
   <string name="images_limit_title">Too many images!</string>
   <string name="images_limit_desc">Only 10 images can be sent at the same time</string>
+  <string name="image_decoding_exception_title">Decoding error</string>
+  <string name="image_decoding_exception_desc">The image cannot be decoded. Please, try with different image or contact devs</string>
 
   <!-- Images - chat.simplex.app.views.chat.item.CIImageView.kt -->
   <string name="image_descr">Image</string>
@@ -674,7 +676,7 @@
   <string name="restore_database_alert_desc">Please enter the previous password after restoring database backup. This action can not be undone.</string>
   <string name="restore_database_alert_confirm">Restore</string>
   <string name="database_restore_error">Restore database error</string>
-  <string name="restored_from_backup_broken_text">Looks like you restored the app\'s data from a backup (using TitaniumBackup or similar tool). Encryption passphrase should be entered manually. \n\nIf it\'s not the case, please, contact devs</string>
+  <string name="restored_from_backup_broken_desc">Looks like you restored the app\'s data from a backup (using TitaniumBackup or similar tool). Encryption passphrase should be entered manually. \n\nIf it\'s not the case, please, contact devs</string>
 
   <!-- ChatModel.chatRunning interactions -->
   <string name="chat_is_stopped_indication">Chat is stopped</string>


### PR DESCRIPTION
Commits in order:
1,5. Prevents `ConcurrentModificationException` that could happen if a user repeatedly tried to add members to a group while previous attempt is in progress and working with a backend
2. Fixing `ForegroundServiceDidNotStartInTimeException` that could happen when a code starting a service and then quickly stops it until it has created. This situation was stopping the service from running `startForeground` function, which is required by Android
3. Restoring app's data from backup tools will still allow to enter passphrase instead of just crashing like it was before. When restoring happens, keys from keystore gets deleted and the app wasn't ready for this situation
4. Catched drawable's `DecodeException` that can happen on some devices for unknown reason. Exception has a message "Failed to create image decoder with message 'unimplemented'Input contained an error." so looks like the user use some non-popular image format that is not implemented in Android's ImageDecoder. 