### PR TITLE
android: fix ForegroundServiceDidNotStartInTimeException

### DIFF
--- a/apps/android/app/src/main/java/chat/simplex/app/model/SimpleXAPI.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/model/SimpleXAPI.kt
@@ -1220,7 +1220,7 @@ open class ChatController(var ctrl: ChatCtrl?, val ntfManager: NtfManager, val a
         chatModel.notificationsMode.value = NotificationsMode.OFF
         SimplexService.StartReceiver.toggleReceiver(false)
         MessagesFetcherWorker.cancelAll()
-        SimplexService.stop(SimplexApp.context)
+        SimplexService.safeStopService(SimplexApp.context)
       } else {
         // show battery optimization notice
         showBGServiceNoticeIgnoreOptimization(mode)

--- a/apps/android/app/src/main/java/chat/simplex/app/views/call/CallView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/call/CallView.kt
@@ -63,7 +63,7 @@ fun ActiveCallView(chatModel: ChatModel) {
   DisposableEffect(Unit) {
     onDispose {
       // Stop it when call ended
-      if (!ntfModeService) SimplexService.stop(SimplexApp.context)
+      if (!ntfModeService) SimplexService.safeStopService(SimplexApp.context)
       // Clear selected communication device to default value after we changed it in call
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
         val am = SimplexApp.context.getSystemService(Context.AUDIO_SERVICE) as AudioManager

--- a/apps/android/app/src/main/java/chat/simplex/app/views/database/DatabaseView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/database/DatabaseView.kt
@@ -409,7 +409,7 @@ private fun stopChat(m: ChatModel, runChat: MutableState<Boolean>, context: Cont
       m.controller.apiStopChat()
       runChat.value = false
       m.chatRunning.value = false
-      SimplexService.stop(context)
+      SimplexService.safeStopService(context)
       MessagesFetcherWorker.cancelAll()
     } catch (e: Error) {
       runChat.value = true

--- a/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/NotificationsSettingsView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/NotificationsSettingsView.kt
@@ -57,7 +57,7 @@ fun NotificationsSettingsView(
       if (mode == NotificationsMode.SERVICE)
         SimplexService.start(SimplexApp.context)
       else
-        SimplexService.stop(SimplexApp.context)
+        SimplexService.safeStopService(SimplexApp.context)
     }
 
     if (mode != NotificationsMode.PERIODIC) {


### PR DESCRIPTION
Fixes ForegroundServiceDidNotStartInTimeException that could happen when a code starting a service and then quickly stops it until it has created. This situation was stopping the service from running startForeground function, which is required by Android.

(cherry picked from commit a5d235e559edec51204c1551d20ee4aaddb8588f)