### PR TITLE
android: fix crash on restoring from backup

### DIFF
--- a/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/Cryptor.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/Cryptor.kt
@@ -13,17 +13,17 @@ import javax.crypto.spec.GCMParameterSpec
 @SuppressLint("ObsoleteSdkInt")
 internal class Cryptor {
   private var keyStore: KeyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
-  private var warningIsShown = false
+  private var warningShown = false
 
   fun decryptData(data: ByteArray, iv: ByteArray, alias: String): String? {
     val secretKey = getSecretKey(alias)
     if (secretKey == null) {
-      if (!warningIsShown) {
+      if (!warningShown) {
         // Repeated calls will not show the alert again
-        warningIsShown = true
+        warningShown = true
         AlertManager.shared.showAlertMsg(
           title = generalGetString(R.string.wrong_passphrase),
-          text = generalGetString(R.string.restored_from_backup_broken_text)
+          text = generalGetString(R.string.restore_passphrase_not_found_desc)
         )
       }
       return null

--- a/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/Cryptor.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/usersettings/Cryptor.kt
@@ -3,6 +3,9 @@ package chat.simplex.app.views.usersettings
 import android.annotation.SuppressLint
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
+import chat.simplex.app.R
+import chat.simplex.app.views.helpers.AlertManager
+import chat.simplex.app.views.helpers.generalGetString
 import java.security.KeyStore
 import javax.crypto.*
 import javax.crypto.spec.GCMParameterSpec
@@ -10,11 +13,24 @@ import javax.crypto.spec.GCMParameterSpec
 @SuppressLint("ObsoleteSdkInt")
 internal class Cryptor {
   private var keyStore: KeyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+  private var warningIsShown = false
 
-  fun decryptData(data: ByteArray, iv: ByteArray, alias: String): String {
+  fun decryptData(data: ByteArray, iv: ByteArray, alias: String): String? {
+    val secretKey = getSecretKey(alias)
+    if (secretKey == null) {
+      if (!warningIsShown) {
+        // Repeated calls will not show the alert again
+        warningIsShown = true
+        AlertManager.shared.showAlertMsg(
+          title = generalGetString(R.string.wrong_passphrase),
+          text = generalGetString(R.string.restored_from_backup_broken_text)
+        )
+      }
+      return null
+    }
     val cipher: Cipher = Cipher.getInstance(TRANSFORMATION)
     val spec = GCMParameterSpec(128, iv)
-    cipher.init(Cipher.DECRYPT_MODE, getSecretKey(alias), spec)
+    cipher.init(Cipher.DECRYPT_MODE, secretKey, spec)
     return String(cipher.doFinal(data))
   }
 
@@ -29,7 +45,7 @@ internal class Cryptor {
     keyStore.deleteEntry(alias)
   }
 
-  private fun createSecretKey(alias: String): SecretKey {
+  private fun createSecretKey(alias: String): SecretKey? {
     if (keyStore.containsAlias(alias)) return getSecretKey(alias)
     val keyGenerator: KeyGenerator = KeyGenerator.getInstance(KEY_ALGORITHM, "AndroidKeyStore")
     keyGenerator.init(
@@ -41,8 +57,8 @@ internal class Cryptor {
     return keyGenerator.generateKey()
   }
 
-  private fun getSecretKey(alias: String): SecretKey {
-    return (keyStore.getEntry(alias, null) as KeyStore.SecretKeyEntry).secretKey
+  private fun getSecretKey(alias: String): SecretKey? {
+    return (keyStore.getEntry(alias, null) as? KeyStore.SecretKeyEntry)?.secretKey
   }
 
   companion object {

--- a/apps/android/app/src/main/res/values-de/strings.xml
+++ b/apps/android/app/src/main/res/values-de/strings.xml
@@ -682,7 +682,7 @@
   <string name="restore_database_alert_desc">Bitte geben Sie das vorherige Passwort ein, nachdem Sie die Datenbanksicherung wiederhergestellt haben. Diese Aktion kann nicht rückgängig gemacht werden.</string>
   <string name="restore_database_alert_confirm">Wiederherstellen</string>
   <string name="database_restore_error">Fehler bei der Wiederherstellung der Datenbank</string>
-  <string name="restored_from_backup_broken_text">***Looks like you restored the app\'s data from a backup (using TitaniumBackup or similar tool). Encryption passphrase should be entered manually. \n\nIf it\'s not the case, please, contact devs</string>
+  <string name="restore_passphrase_not_found_desc">***Passphrase not found in Keystore, please enter it manually. This may have happened if you restored the app\'s data using a backup tool. If it\'s not the case, please, contact developers.</string>
 
   <!-- ChatModel.chatRunning interactions -->
   <string name="chat_is_stopped_indication">Chat wurde beendet</string>

--- a/apps/android/app/src/main/res/values-de/strings.xml
+++ b/apps/android/app/src/main/res/values-de/strings.xml
@@ -680,6 +680,7 @@
   <string name="restore_database_alert_desc">Bitte geben Sie das vorherige Passwort ein, nachdem Sie die Datenbanksicherung wiederhergestellt haben. Diese Aktion kann nicht rückgängig gemacht werden.</string>
   <string name="restore_database_alert_confirm">Wiederherstellen</string>
   <string name="database_restore_error">Fehler bei der Wiederherstellung der Datenbank</string>
+  <string name="restored_from_backup_broken_text">***Looks like you restored the app\'s data from a backup (using TitaniumBackup or similar tool). Encryption passphrase should be entered manually. \n\nIf it\'s not the case, please, contact devs</string>
 
   <!-- ChatModel.chatRunning interactions -->
   <string name="chat_is_stopped_indication">Chat wurde beendet</string>

--- a/apps/android/app/src/main/res/values-ru/strings.xml
+++ b/apps/android/app/src/main/res/values-ru/strings.xml
@@ -680,6 +680,7 @@
     <string name="restore_database_alert_desc">Введите предыдущий пароль после восстановления резервной копии. Это действие нельзя отменить.</string>
     <string name="restore_database_alert_confirm">Восстановить</string>
     <string name="database_restore_error">Ошибка при восстановлении базы данных</string>
+    <string name="restored_from_backup_broken_text">Похоже, вы восстановили данные программы из бэкапа (используя TitaniumBackup или похожий инструмент). Нужно ввести пароль от базы данных вручную. \n\nЕсли причина не в этом, пожалуйста, свяжитесь с разработчиками</string>
 
     <!-- ChatModel.chatRunning interactions -->
     <string name="chat_is_stopped_indication">Чат остановлен</string>

--- a/apps/android/app/src/main/res/values-ru/strings.xml
+++ b/apps/android/app/src/main/res/values-ru/strings.xml
@@ -682,7 +682,7 @@
     <string name="restore_database_alert_desc">Введите предыдущий пароль после восстановления резервной копии. Это действие нельзя отменить.</string>
     <string name="restore_database_alert_confirm">Восстановить</string>
     <string name="database_restore_error">Ошибка при восстановлении базы данных</string>
-    <string name="restored_from_backup_broken_text">Похоже, вы восстановили данные программы из бэкапа (используя TitaniumBackup или похожий инструмент). Нужно ввести пароль от базы данных вручную. \n\nЕсли причина не в этом, пожалуйста, свяжитесь с разработчиками</string>
+    <string name="restore_passphrase_not_found_desc">Пароль не найден в Keystore, пожалуйста, введите его вручную. Это могло произойти, если вы восстановили данные приложения с помощью инструмента резервного копирования. Если это не так, пожалуйста, свяжитесь с разработчиками.</string>
 
     <!-- ChatModel.chatRunning interactions -->
     <string name="chat_is_stopped_indication">Чат остановлен</string>

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -680,6 +680,7 @@
   <string name="restore_database_alert_desc">Please enter the previous password after restoring database backup. This action can not be undone.</string>
   <string name="restore_database_alert_confirm">Restore</string>
   <string name="database_restore_error">Restore database error</string>
+  <string name="restored_from_backup_broken_text">Looks like you restored the app\'s data from a backup (using TitaniumBackup or similar tool). Encryption passphrase should be entered manually. \n\nIf it\'s not the case, please, contact devs</string>
 
   <!-- ChatModel.chatRunning interactions -->
   <string name="chat_is_stopped_indication">Chat is stopped</string>

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -682,7 +682,7 @@
   <string name="restore_database_alert_desc">Please enter the previous password after restoring database backup. This action can not be undone.</string>
   <string name="restore_database_alert_confirm">Restore</string>
   <string name="database_restore_error">Restore database error</string>
-  <string name="restored_from_backup_broken_text">Looks like you restored the app\'s data from a backup (using TitaniumBackup or similar tool). Encryption passphrase should be entered manually. \n\nIf it\'s not the case, please, contact devs</string>
+  <string name="restore_passphrase_not_found_desc">Passphrase not found in Keystore, please enter it manually. This may have happened if you restored the app\'s data using a backup tool. If it\'s not the case, please, contact developers.</string>
 
   <!-- ChatModel.chatRunning interactions -->
   <string name="chat_is_stopped_indication">Chat is stopped</string>


### PR DESCRIPTION
Restoring app's data from backup tools will still allow to enter passphrase instead of just crashing like it was before. When restoring happens, keys from keystore gets deleted and the app wasn't ready for this situation

(cherry picked from commit 256243dc8c8e0b8547d794624c1d0f256f1ac5f2)