### PR TITLE
android: catch DecodeException

### DIFF
--- a/apps/android/app/src/main/java/chat/simplex/app/views/chat/ComposeView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/chat/ComposeView.kt
@@ -6,6 +6,7 @@ import android.content.*
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.ImageDecoder
+import android.graphics.ImageDecoder.DecodeException
 import android.graphics.drawable.AnimatedImageDrawable
 import android.net.Uri
 import android.provider.MediaStore
@@ -164,8 +165,17 @@ fun ComposeView(
     val imagesPreview = ArrayList<String>()
     uris.forEach { uri ->
       val source = ImageDecoder.createSource(context.contentResolver, uri)
-      val drawable = ImageDecoder.decodeDrawable(source)
-      var bitmap: Bitmap? = ImageDecoder.decodeBitmap(source)
+      val drawable = try {
+        ImageDecoder.decodeDrawable(source)
+      } catch (e: DecodeException) {
+        AlertManager.shared.showAlertMsg(
+          title = generalGetString(R.string.image_decoding_exception_title),
+          text = generalGetString(R.string.image_decoding_exception_desc)
+        )
+        Log.e(TAG, "Error while decoding drawable: ${e.stackTraceToString()}")
+        null
+      }
+      var bitmap: Bitmap? = if (drawable != null) ImageDecoder.decodeBitmap(source) else null
       if (drawable is AnimatedImageDrawable) {
         // It's a gif or webp
         val fileSize = getFileSize(context, uri)

--- a/apps/android/app/src/main/java/chat/simplex/app/views/chat/ComposeView.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/chat/ComposeView.kt
@@ -10,6 +10,7 @@ import android.graphics.ImageDecoder.DecodeException
 import android.graphics.drawable.AnimatedImageDrawable
 import android.net.Uri
 import android.provider.MediaStore
+import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContract
@@ -66,7 +67,7 @@ data class ComposeState(
   val inProgress: Boolean = false,
   val useLinkPreviews: Boolean
 ) {
-  constructor(editingItem: ChatItem, useLinkPreviews: Boolean): this (
+  constructor(editingItem: ChatItem, useLinkPreviews: Boolean): this(
     editingItem.content.text,
     chatItemPreview(editingItem),
     ComposeContextItem.EditingItem(editingItem),

--- a/apps/android/app/src/main/res/values-de/strings.xml
+++ b/apps/android/app/src/main/res/values-de/strings.xml
@@ -185,6 +185,8 @@
   <string name="icon_descr_cancel_file_preview">Dateivorschau abbrechen</string>
   <string name="images_limit_title">Zu viele Bilder!</string>
   <string name="images_limit_desc">Es können nur 10 Bilder auf einmal gesendet werden</string>
+  <string name="image_decoding_exception_title">***Decoding error</string>
+  <string name="image_decoding_exception_desc">***The image cannot be decoded. Please, try with different image or contact devs</string>
 
   <!-- Images - chat.simplex.app.views.chat.item.CIImageView.kt -->
   <string name="image_descr">Bild</string>

--- a/apps/android/app/src/main/res/values-de/strings.xml
+++ b/apps/android/app/src/main/res/values-de/strings.xml
@@ -186,7 +186,7 @@
   <string name="images_limit_title">Zu viele Bilder!</string>
   <string name="images_limit_desc">Es können nur 10 Bilder auf einmal gesendet werden</string>
   <string name="image_decoding_exception_title">***Decoding error</string>
-  <string name="image_decoding_exception_desc">***The image cannot be decoded. Please, try with different image or contact devs</string>
+  <string name="image_decoding_exception_desc">***The image cannot be decoded. Please, try a different image or contact developers.</string>
 
   <!-- Images - chat.simplex.app.views.chat.item.CIImageView.kt -->
   <string name="image_descr">Bild</string>

--- a/apps/android/app/src/main/res/values-ru/strings.xml
+++ b/apps/android/app/src/main/res/values-ru/strings.xml
@@ -186,7 +186,7 @@
     <string name="images_limit_title">Слишком много изображений!</string>
     <string name="images_limit_desc">Только 10 изображений могут быть отправлены одномоментно</string>
     <string name="image_decoding_exception_title">Ошибка декодирования</string>
-    <string name="image_decoding_exception_desc">Не получается декодировать изображение. Пожалуйста, попробуйте другое или свяжитесь с разработчиками</string>
+    <string name="image_decoding_exception_desc">Не получается декодировать изображение. Пожалуйста, попробуйте другое изображение или свяжитесь с разработчиками.</string>
 
     <!-- Images - chat.simplex.app.views.chat.item.CIImageView.kt -->
     <string name="image_descr">Изображение</string>

--- a/apps/android/app/src/main/res/values-ru/strings.xml
+++ b/apps/android/app/src/main/res/values-ru/strings.xml
@@ -185,6 +185,8 @@
     <string name="icon_descr_cancel_file_preview">Удалить превью файла</string>
     <string name="images_limit_title">Слишком много изображений!</string>
     <string name="images_limit_desc">Только 10 изображений могут быть отправлены одномоментно</string>
+    <string name="image_decoding_exception_title">Ошибка декодирования</string>
+    <string name="image_decoding_exception_desc">Не получается декодировать изображение. Пожалуйста, попробуйте другое или свяжитесь с разработчиками</string>
 
     <!-- Images - chat.simplex.app.views.chat.item.CIImageView.kt -->
     <string name="image_descr">Изображение</string>

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -185,6 +185,8 @@
   <string name="icon_descr_cancel_file_preview">Cancel file preview</string>
   <string name="images_limit_title">Too many images!</string>
   <string name="images_limit_desc">Only 10 images can be sent at the same time</string>
+  <string name="image_decoding_exception_title">Decoding error</string>
+  <string name="image_decoding_exception_desc">The image cannot be decoded. Please, try with different image or contact devs</string>
 
   <!-- Images - chat.simplex.app.views.chat.item.CIImageView.kt -->
   <string name="image_descr">Image</string>

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -186,7 +186,7 @@
   <string name="images_limit_title">Too many images!</string>
   <string name="images_limit_desc">Only 10 images can be sent at the same time</string>
   <string name="image_decoding_exception_title">Decoding error</string>
-  <string name="image_decoding_exception_desc">The image cannot be decoded. Please, try with different image or contact devs</string>
+  <string name="image_decoding_exception_desc">The image cannot be decoded. Please, try a different image or contact developers.</string>
 
   <!-- Images - chat.simplex.app.views.chat.item.CIImageView.kt -->
   <string name="image_descr">Image</string>


### PR DESCRIPTION
Catch drawable's DecodeException that can happen on some devices for unknown reason. Exception has a message "Failed to create image decoder with message 'unimplemented'Input contained an error." so looks like the user use some non-popular image format that is not implemented in Android's ImageDecoder.