### PR TITLE
fix incorrect comment syntax in cabal.project.mac

### DIFF
--- a/scripts/cabal.project.local.mac
+++ b/scripts/cabal.project.local.mac
@@ -1,6 +1,6 @@
 ignore-project: False
 
-# amend to point to the actual openssl location
+-- amend to point to the actual openssl location
 package direct-sqlcipher
     extra-include-dirs: /opt/homebrew/opt/openssl@1.1/include
     extra-lib-dirs: /opt/homebrew/opt/openssl@1.1/lib


### PR DESCRIPTION
`cabal update` would fail complaining about an unrecognized `#` character