### PR TITLE
android: increases max duration of voice messages

### DIFF
--- a/apps/android/app/src/main/java/chat/simplex/app/views/helpers/Util.kt
+++ b/apps/android/app/src/main/java/chat/simplex/app/views/helpers/Util.kt
@@ -228,8 +228,8 @@ const val MAX_IMAGE_SIZE: Long = 236700
 const val MAX_IMAGE_SIZE_AUTO_RCV: Long = MAX_IMAGE_SIZE * 2
 const val MAX_VOICE_SIZE_AUTO_RCV: Long = MAX_IMAGE_SIZE
 
-const val MAX_VOICE_SIZE_FOR_SENDING: Long = 94680 // 6 chunks * 15780 bytes per chunk
-const val MAX_VOICE_MILLIS_FOR_SENDING: Int = 43_000
+const val MAX_VOICE_SIZE_FOR_SENDING: Long = 568080 // 36 chunks * 15780 bytes per chunk
+const val MAX_VOICE_MILLIS_FOR_SENDING: Int = 258_000
 
 const val MAX_FILE_SIZE: Long = 8000000
 


### PR DESCRIPTION
The current maximum duration of 43 seconds is really annoying (#1610 ). Increases from 6 to 36 chunks * 15780 bytes per chunk (43s to 4m18s).