### PR TITLE
docs/SERVER: use sudo, specify protocol  & add Fedora

### DIFF
--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -49,7 +49,7 @@ Manual installation requires some preliminary actions:
    # For Ubuntu
    sudo ufw allow 5223/tcp
    # For Fedora
-   sudo firewall-cmd --permanent --add-port=5223/tcp
+   sudo firewall-cmd --permanent --add-port=5223/tcp && firewall-cmd --reload
    ```
 
 4. **Optional** — If you're using distribution with `systemd`, create `/etc/systemd/system/smp-server.service` file with the following content:

--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -49,7 +49,8 @@ Manual installation requires some preliminary actions:
    # For Ubuntu
    sudo ufw allow 5223/tcp
    # For Fedora
-   sudo firewall-cmd --permanent --add-port=5223/tcp && firewall-cmd --reload
+   sudo firewall-cmd --permanent --add-port=5223/tcp && \
+   sudo firewall-cmd --reload
    ```
 
 4. **Optional** — If you're using distribution with `systemd`, create `/etc/systemd/system/smp-server.service` file with the following content:

--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -47,7 +47,9 @@ Manual installation requires some preliminary actions:
 
    ```sh
    # For Ubuntu
-   ufw allow 5223
+   sudo ufw allow 5223/tcp
+   # For Fedora
+   sudo firewall-cmd --permanent --add-port=5223/tcp
    ```
 
 4. **Optional** — If you're using distribution with `systemd`, create `/etc/systemd/system/smp-server.service` file with the following content:

--- a/docs/WEBRTC.md
+++ b/docs/WEBRTC.md
@@ -74,27 +74,22 @@ systemctl enable coturn && systemctl start coturn
 - **49152:65535** – port range that Coturn will use by default for TURN relay.
 
 ```sh
+# For Ubuntu
 sudo ufw allow 3478 && \
 sudo ufw allow 443 && \
 sudo ufw allow 5349 && \
 sudo ufw allow 49152:65535/tcp && \
 sudo ufw allow 49152:65535/udp
-```
 
-For firwalld
-
-```sh
+# For Fedora
 sudo firewall-cmd --permanent --add-port=443/tcp && \
 sudo firewall-cmd --permanent --add-port=443/udp && \
 sudo firewall-cmd --permanent --add-port=5349/tcp && \
 sudo firewall-cmd --permanent --add-port=5349/udp && \
 sudo firewall-cmd --permanent --add-port=49152:65535/tcp && \
-sudo firewall-cmd --permanent --add-port=49152:65535/tcp && \
+sudo firewall-cmd --permanent --add-port=49152:65535/udp && \
 sudo firewall-cmd --reload
 ```
-
-   sudo firewall-cmd --permanent --add-port=5223/tcp && firewall-cmd --reload
-
 
 ## Configure mobile apps
 

--- a/docs/WEBRTC.md
+++ b/docs/WEBRTC.md
@@ -74,12 +74,27 @@ systemctl enable coturn && systemctl start coturn
 - **49152:65535** – port range that Coturn will use by default for TURN relay.
 
 ```sh
-ufw allow 3478 && \
-ufw allow 443 && \
-ufw allow 5349 && \
-ufw allow 49152:65535/tcp && \
-ufw allow 49152:65535/udp
+sudo ufw allow 3478 && \
+sudo ufw allow 443 && \
+sudo ufw allow 5349 && \
+sudo ufw allow 49152:65535/tcp && \
+sudo ufw allow 49152:65535/udp
 ```
+
+For firwalld
+
+```sh
+sudo firewall-cmd --permanent --add-port=443/tcp && \
+sudo firewall-cmd --permanent --add-port=443/udp && \
+sudo firewall-cmd --permanent --add-port=5349/tcp && \
+sudo firewall-cmd --permanent --add-port=5349/udp && \
+sudo firewall-cmd --permanent --add-port=49152:65535/tcp && \
+sudo firewall-cmd --permanent --add-port=49152:65535/tcp && \
+sudo firewall-cmd --reload
+```
+
+   sudo firewall-cmd --permanent --add-port=5223/tcp && firewall-cmd --reload
+
 
 ## Configure mobile apps
 

--- a/docs/XFTP-SERVER.md
+++ b/docs/XFTP-SERVER.md
@@ -41,6 +41,10 @@ XFTP is a new file transfer protocol focussed on meta-data protection - it is ba
    ```sh
    # For Ubuntu
    sudo ufw allow 443
+   # For Fedora
+   sudo firewall-cmd --permanent --add-port=443/tcp && \
+   sudo firewall-cmd --permanent --add-port=443/udp && \
+   sudo firewall-cmd --reload
    ```
 
 5. **Optional** — If you're using distribution with `systemd`, create `/etc/systemd/system/xftp-server.service` file with the following content:

--- a/docs/XFTP-SERVER.md
+++ b/docs/XFTP-SERVER.md
@@ -40,10 +40,9 @@ XFTP is a new file transfer protocol focussed on meta-data protection - it is ba
 
    ```sh
    # For Ubuntu
-   sudo ufw allow 443
+   sudo ufw allow 443/tcp
    # For Fedora
    sudo firewall-cmd --permanent --add-port=443/tcp && \
-   sudo firewall-cmd --permanent --add-port=443/udp && \
    sudo firewall-cmd --reload
    ```
 

--- a/docs/lang/cs/SERVER.md
+++ b/docs/lang/cs/SERVER.md
@@ -46,7 +46,9 @@ Ruční instalace vyžaduje několik předběžných úkonů:
 
    ```sh
    # Pro Ubuntu
-   ufw allow 5233
+   sudo ufw allow 5233/tcp
+   # Pro Fedora
+   sudo firewall-cmd --permanent --add-port=5223/tcp
    ```
 
 4. **Volitelné** - Pokud používáte distribuci s `systemd`, vytvořte soubor `/etc/systemd/system/smp-server.service` s následujícím obsahem:

--- a/docs/lang/cs/SERVER.md
+++ b/docs/lang/cs/SERVER.md
@@ -48,7 +48,7 @@ Ruční instalace vyžaduje několik předběžných úkonů:
    # Pro Ubuntu
    sudo ufw allow 5233/tcp
    # Pro Fedora
-   sudo firewall-cmd --permanent --add-port=5223/tcp
+   sudo firewall-cmd --permanent --add-port=5223/tcp && firewall-cmd --reload
    ```
 
 4. **Volitelné** - Pokud používáte distribuci s `systemd`, vytvořte soubor `/etc/systemd/system/smp-server.service` s následujícím obsahem:

--- a/docs/lang/cs/SERVER.md
+++ b/docs/lang/cs/SERVER.md
@@ -48,7 +48,8 @@ Ruční instalace vyžaduje několik předběžných úkonů:
    # Pro Ubuntu
    sudo ufw allow 5233/tcp
    # Pro Fedora
-   sudo firewall-cmd --permanent --add-port=5223/tcp && firewall-cmd --reload
+   sudo firewall-cmd --permanent --add-port=5223/tcp && \
+   sudo firewall-cmd --reload
    ```
 
 4. **Volitelné** - Pokud používáte distribuci s `systemd`, vytvořte soubor `/etc/systemd/system/smp-server.service` s následujícím obsahem:

--- a/docs/lang/cs/WEBRTC.md
+++ b/docs/lang/cs/WEBRTC.md
@@ -73,22 +73,20 @@ systemctl enable coturn && systemctl start coturn
 - **49152:65535** - rozsah portů, který bude společnost Coturn ve výchozím nastavení používat pro přenos TURN.
 
 ```sh
+# Pro Ubuntu
 sudo ufw allow 3478 && \
 sudo ufw allow 443 && \
 sudo ufw allow 5349 && \
 sudo ufw allow 49152:65535/tcp && \
 sudo ufw allow 49152:65535/udp
-```
 
-Pro firewalld:
-
-```sh
+# Pro Fedora
 sudo firewall-cmd --permanent --add-port=443/tcp && \
 sudo firewall-cmd --permanent --add-port=443/udp && \
 sudo firewall-cmd --permanent --add-port=5349/tcp && \
 sudo firewall-cmd --permanent --add-port=5349/udp && \
 sudo firewall-cmd --permanent --add-port=49152:65535/tcp && \
-sudo firewall-cmd --permanent --add-port=49152:65535/tcp && \
+sudo firewall-cmd --permanent --add-port=49152:65535/udp && \
 sudo firewall-cmd --reload
 ```
 

--- a/docs/lang/cs/WEBRTC.md
+++ b/docs/lang/cs/WEBRTC.md
@@ -73,11 +73,23 @@ systemctl enable coturn && systemctl start coturn
 - **49152:65535** - rozsah portů, který bude společnost Coturn ve výchozím nastavení používat pro přenos TURN.
 
 ```sh
-ufw allow 3478 && \
-ufw allow 443 && \
-ufw allow 5349 && \
-ufw allow 49152:65535/tcp && \
-ufw allow 49152:65535/udp
+sudo ufw allow 3478 && \
+sudo ufw allow 443 && \
+sudo ufw allow 5349 && \
+sudo ufw allow 49152:65535/tcp && \
+sudo ufw allow 49152:65535/udp
+```
+
+Pro firewalld:
+
+```sh
+sudo firewall-cmd --permanent --add-port=443/tcp && \
+sudo firewall-cmd --permanent --add-port=443/udp && \
+sudo firewall-cmd --permanent --add-port=5349/tcp && \
+sudo firewall-cmd --permanent --add-port=5349/udp && \
+sudo firewall-cmd --permanent --add-port=49152:65535/tcp && \
+sudo firewall-cmd --permanent --add-port=49152:65535/tcp && \
+sudo firewall-cmd --reload
 ```
 
 ## Konfigurace mobilních aplikací

--- a/docs/lang/fr/SERVER.md
+++ b/docs/lang/fr/SERVER.md
@@ -46,7 +46,9 @@ L'installation manuelle nécessite quelques actions préalables :
 
    ```sh
    # Pour Ubuntu
-   ufw allow 5223
+   sudo ufw allow 5223/tcp
+   # Pour Fedora
+   sudo firewall-cmd --permanent --add-port=5223/tcp
    ```
 
 4. **Optionnel** - Si vous utilisez une distribution avec `systemd`, créez le fichier `/etc/systemd/system/smp-server.service` avec le contenu suivant :

--- a/docs/lang/fr/SERVER.md
+++ b/docs/lang/fr/SERVER.md
@@ -48,7 +48,7 @@ L'installation manuelle nécessite quelques actions préalables :
    # Pour Ubuntu
    sudo ufw allow 5223/tcp
    # Pour Fedora
-   sudo firewall-cmd --permanent --add-port=5223/tcp
+   sudo firewall-cmd --permanent --add-port=5223/tcp && firewall-cmd --reload
    ```
 
 4. **Optionnel** - Si vous utilisez une distribution avec `systemd`, créez le fichier `/etc/systemd/system/smp-server.service` avec le contenu suivant :

--- a/docs/lang/fr/SERVER.md
+++ b/docs/lang/fr/SERVER.md
@@ -48,7 +48,8 @@ L'installation manuelle nécessite quelques actions préalables :
    # Pour Ubuntu
    sudo ufw allow 5223/tcp
    # Pour Fedora
-   sudo firewall-cmd --permanent --add-port=5223/tcp && firewall-cmd --reload
+   sudo firewall-cmd --permanent --add-port=5223/tcp && \
+   sudo firewall-cmd --reload
    ```
 
 4. **Optionnel** - Si vous utilisez une distribution avec `systemd`, créez le fichier `/etc/systemd/system/smp-server.service` avec le contenu suivant :

--- a/docs/lang/fr/WEBRTC.md
+++ b/docs/lang/fr/WEBRTC.md
@@ -73,22 +73,20 @@ systemctl enable coturn && systemctl start coturn
 - **49152:65535** – plage de ports que Coturn utilisera par défaut pour le relais TURN.
 
 ```sh
+# Pour Ubuntu
 sudo ufw allow 3478 && \
 sudo ufw allow 443 && \
 sudo ufw allow 5349 && \
 sudo ufw allow 49152:65535/tcp && \
 sudo ufw allow 49152:65535/udp
-```
 
-Pour firewalld
-
-```sh
+# Pour Fedora
 sudo firewall-cmd --permanent --add-port=443/tcp && \
 sudo firewall-cmd --permanent --add-port=443/udp && \
 sudo firewall-cmd --permanent --add-port=5349/tcp && \
 sudo firewall-cmd --permanent --add-port=5349/udp && \
 sudo firewall-cmd --permanent --add-port=49152:65535/tcp && \
-sudo firewall-cmd --permanent --add-port=49152:65535/tcp && \
+sudo firewall-cmd --permanent --add-port=49152:65535/udp && \
 sudo firewall-cmd --reload
 ```
 

--- a/docs/lang/fr/WEBRTC.md
+++ b/docs/lang/fr/WEBRTC.md
@@ -73,11 +73,23 @@ systemctl enable coturn && systemctl start coturn
 - **49152:65535** – plage de ports que Coturn utilisera par défaut pour le relais TURN.
 
 ```sh
-ufw allow 3478 && \
-ufw allow 443 && \
-ufw allow 5349 && \
-ufw allow 49152:65535/tcp && \
-ufw allow 49152:65535/udp
+sudo ufw allow 3478 && \
+sudo ufw allow 443 && \
+sudo ufw allow 5349 && \
+sudo ufw allow 49152:65535/tcp && \
+sudo ufw allow 49152:65535/udp
+```
+
+Pour firewalld
+
+```sh
+sudo firewall-cmd --permanent --add-port=443/tcp && \
+sudo firewall-cmd --permanent --add-port=443/udp && \
+sudo firewall-cmd --permanent --add-port=5349/tcp && \
+sudo firewall-cmd --permanent --add-port=5349/udp && \
+sudo firewall-cmd --permanent --add-port=49152:65535/tcp && \
+sudo firewall-cmd --permanent --add-port=49152:65535/tcp && \
+sudo firewall-cmd --reload
 ```
 
 ## Configurer l'app mobile


### PR DESCRIPTION
I think the lack of `sudo` was an oversight and I know that not specifying port for `ufw` opens both TCP and UDP, while I was told at SimpleX that the server only uses TCP.