### PR TITLE
nix: install ghc, cabal, zlib and gmp in dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -339,7 +339,7 @@
           '';
         }; in
 	pkgs.mkShell {
-          buildInputs = [ updateCmd ];
+          buildInputs = [ updateCmd pkgs.haskell.compiler.ghc810 pkgs.cabal-install pkgs.zlib pkgs.gmp ];
           shellHook = ''
             echo "welcome to the shell!"
           '';


### PR DESCRIPTION
I've never used Haskell before, and had some trouble installing it using [the instructions](https://github.com/simplex-chat/simplex-chat/issues/2703). But adding all the Haskell and build dependencies to the shell in `flake.nix` worked for me. I was able to run `nix develop` and `cabal install` and build a usable `simplex-chat` binary.

Perhaps this will be useful to others? 