### PR TITLE
Fix broken RSS feed source URL

### DIFF
--- a/website/src/blogs-atom-feed.njk
+++ b/website/src/blogs-atom-feed.njk
@@ -5,7 +5,7 @@ metadata:
     title: SimpleX Chat Blog
     subtitle: It allows you to stay up to date with the latest Blogs from SimpleX Chat.
     language: en
-    url: https://simplex.chat/,
+    url: https://simplex.chat/
     author:
         name: SimpleX Chat
         email: chat@simplex.chat

--- a/website/src/blogs-rss-feed.njk
+++ b/website/src/blogs-rss-feed.njk
@@ -5,7 +5,7 @@ metadata:
     title: SimpleX Chat Blog
     subtitle: It allows you to stay up to date with the latest Blogs from SimpleX Chat.
     language: en
-    url: https://simplex.chat/,
+    url: https://simplex.chat/
     author:
         name: SimpleX Chat
         email: chat@simplex.chat


### PR DESCRIPTION
Noticed that the blog source URL is incorrectly set and has a comma that breaks the URL.

![image](https://github.com/simplex-chat/simplex-chat/assets/40500387/797fec6a-61b5-49f5-a570-d051bc1b66fe)