### PR TITLE
cli: update docker image to use ghc 9.6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,12 @@ RUN a=$(arch); curl https://downloads.haskell.org/~ghcup/$a-linux-ghcup -o /usr/
     chmod +x /usr/bin/ghcup
 
 # Install ghc
-RUN ghcup install ghc 8.10.7
+RUN ghcup install ghc 9.6.2
 # Install cabal
-RUN ghcup install cabal
+RUN ghcup install cabal 3.10.1.0
 # Set both as default
-RUN ghcup set ghc 8.10.7 && \
-    ghcup set cabal
+RUN ghcup set ghc 9.6.2 && \
+    ghcup set cabal 3.10.1.0
 
 COPY . /project
 WORKDIR /project


### PR DESCRIPTION
The docker image was not updated to use ghc 9.6, this PR updates it using the versions from the github workflows.