### PR TITLE
desktop: add image pasting from clipboard

### DIFF
--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/PlatformTextField.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/PlatformTextField.desktop.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import chat.simplex.common.model.ChatModel
 import chat.simplex.common.views.chat.*
 import chat.simplex.common.views.helpers.*
 import chat.simplex.res.MR
@@ -33,7 +34,9 @@ import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.net.URI
+import java.util.*
 import javax.imageio.ImageIO
+import kotlin.collections.ArrayList
 import kotlin.io.path.*
 import kotlin.math.min
 import kotlin.text.substring
@@ -145,12 +148,17 @@ actual fun PlatformTextField(
 
                 if (bitmap != null) {
                   val imagePreview = resizeImageToStrSize(bitmap, maxDataSize = 14000)
-
-                  val tempFile = createTempFile("paste.png")
+                  val fileName = UUID.randomUUID().toString()
+                  val tempFile = File(tmpDir, "$fileName.png")
                   tempFile.writeBytes(bytes)
-                  val uri = tempFile.toUri()
-                  composeState.value = composeState.value.copy(preview = ComposePreview.MediaPreview(listOf(imagePreview),
-                    listOf(UploadContent.SimpleImage(uri))))
+
+                  // handle deleting the temp file when program exits
+                  val content = ArrayList<UploadContent>()
+                  content.add(UploadContent.SimpleImage(tempFile.toURI()))
+                  ChatModel.filesToDelete.add(tempFile)
+
+                  val uri = tempFile.toURI()
+                  composeState.value = composeState.value.copy(preview = ComposePreview.MediaPreview(listOf(imagePreview), content))
                 }
 
               }

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/PlatformTextField.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/PlatformTextField.desktop.kt
@@ -150,8 +150,6 @@ actual fun PlatformTextField(
                   listOf(UploadContent.SimpleImage(uri))))
               }
 
-            } else {
-              println("Flavor is NOT supported")
             }
 
             true

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/PlatformTextField.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/PlatformTextField.desktop.kt
@@ -120,39 +120,43 @@ actual fun PlatformTextField(
         } else if (it.key == Key.V &&
             it.type == KeyEventType.KeyDown &&
             ((it.isCtrlPressed && !desktopPlatform.isMac()) || (it.isMetaPressed && desktopPlatform.isMac()))) {
-            // check if clipboard contains image
-            var transferable = Toolkit.getDefaultToolkit().systemClipboard.getContents(null)
-            var isFlavorSupported = transferable.isDataFlavorSupported(DataFlavor.imageFlavor)
+            if (parseToFiles(clipboard.getText()).isNotEmpty()) {
+              onFilesPasted(parseToFiles(clipboard.getText()))
+            } else {
+              // check if clipboard contains image
+              var transferable = Toolkit.getDefaultToolkit().systemClipboard.getContents(null)
+              var isFlavorSupported = transferable.isDataFlavorSupported(DataFlavor.imageFlavor)
 
-            if (transferable != null && isFlavorSupported) {
-              var data = transferable.getTransferData(DataFlavor.imageFlavor) as Image
+              if (transferable != null && isFlavorSupported) {
+                var data = transferable.getTransferData(DataFlavor.imageFlavor) as Image
 
-              // create BufferedImage from Image
-              var bi = BufferedImage(data.getWidth(null), data.getHeight(null), BufferedImage.TYPE_INT_ARGB)
-              var bgr = bi.createGraphics()
-              bgr.drawImage(data, 0, 0, null)
-              bgr.dispose()
+                // create BufferedImage from Image
+                var bi = BufferedImage(data.getWidth(null), data.getHeight(null), BufferedImage.TYPE_INT_ARGB)
+                var bgr = bi.createGraphics()
+                bgr.drawImage(data, 0, 0, null)
+                bgr.dispose()
 
-              // create byte array from BufferedImage
-              val baos = ByteArrayOutputStream()
-              ImageIO.write(bi, "png", baos)
-              val bytes = baos.toByteArray()
+                // create byte array from BufferedImage
+                val baos = ByteArrayOutputStream()
+                ImageIO.write(bi, "png", baos)
+                val bytes = baos.toByteArray()
 
-              val bitmap = getBitmapFromByteArray(bytes, false)
+                val bitmap = getBitmapFromByteArray(bytes, false)
 
-              if (bitmap != null) {
-                val imagePreview = resizeImageToStrSize(bitmap, maxDataSize = 14000)
+                if (bitmap != null) {
+                  val imagePreview = resizeImageToStrSize(bitmap, maxDataSize = 14000)
 
-                val tempFile = createTempFile("paste.png")
-                tempFile.writeBytes(bytes)
-                val uri = tempFile.toUri()
-                composeState.value = composeState.value.copy(preview = ComposePreview.MediaPreview(listOf(imagePreview),
-                  listOf(UploadContent.SimpleImage(uri))))
+                  val tempFile = createTempFile("paste.png")
+                  tempFile.writeBytes(bytes)
+                  val uri = tempFile.toUri()
+                  composeState.value = composeState.value.copy(preview = ComposePreview.MediaPreview(listOf(imagePreview),
+                    listOf(UploadContent.SimpleImage(uri))))
+                }
+
               }
-
             }
 
-            true
+            false
           }
         else false
       },


### PR DESCRIPTION
The following PR adds the ability, on Desktop, to paste images from the clipboard into the send message input box.

Tested On:
1. Ubuntu

Supported image formats (all I've tested so far):
1. png
2. jpg
3. webp
4. bmp

Unsupported image formats:
1. svg
2. gif (It displays but does not transition between frames)
