### PR TITLE
desktop: remove slash from update member role alert in group settings

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupMemberInfoView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupMemberInfoView.kt
@@ -492,9 +492,9 @@ private fun updateMemberRoleDialog(
   AlertManager.shared.showAlertDialog(
     title = generalGetString(MR.strings.change_member_role_question),
     text = if (member.memberCurrent)
-      String.format(generalGetString(MR.strings.member_role_will_be_changed_with_notification).replace("\\", ""), newRole.text)
+      String.format(generalGetString(MR.strings.member_role_will_be_changed_with_notification), newRole.text)
     else
-      String.format(generalGetString(MR.strings.member_role_will_be_changed_with_invitation).replace("\\", ""), newRole.text),
+      String.format(generalGetString(MR.strings.member_role_will_be_changed_with_invitation), newRole.text),
     confirmText = generalGetString(MR.strings.change_verb),
     onDismiss = onDismiss,
     onConfirm = onConfirm,

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupMemberInfoView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupMemberInfoView.kt
@@ -492,9 +492,9 @@ private fun updateMemberRoleDialog(
   AlertManager.shared.showAlertDialog(
     title = generalGetString(MR.strings.change_member_role_question),
     text = if (member.memberCurrent)
-      String.format(generalGetString(MR.strings.member_role_will_be_changed_with_notification), newRole.text)
+      String.format(generalGetString(MR.strings.member_role_will_be_changed_with_notification).replace("\\", ""), newRole.text)
     else
-      String.format(generalGetString(MR.strings.member_role_will_be_changed_with_invitation), newRole.text),
+      String.format(generalGetString(MR.strings.member_role_will_be_changed_with_invitation).replace("\\", ""), newRole.text),
     confirmText = generalGetString(MR.strings.change_verb),
     onDismiss = onDismiss,
     onConfirm = onConfirm,

--- a/apps/multiplatform/common/src/commonMain/resources/MR/ar/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/ar/strings.xml
@@ -21,8 +21,8 @@
     <string name="messages_section_description">ينطبق هذا الإعداد على الرسائل الموجودة في ملف تعريف الدردشة الحالي الخاص بك</string>
     <string name="the_messaging_and_app_platform_protecting_your_privacy_and_security">منصة الرسائل والتطبيقات تحمي خصوصيتك وأمنك.</string>
     <string name="profile_is_only_shared_with_your_contacts">يتم مشاركة ملف التعريف مع جهات اتصالك فقط.</string>
-    <string name="member_role_will_be_changed_with_notification">سيتم تغيير الدور إلى \"%s\". سيتم إبلاغ كل فرد في المجموعة.</string>
-    <string name="member_role_will_be_changed_with_invitation">سيتم تغيير الدور إلى \"%s\". سيتلقى العضو دعوة جديدة.</string>
+    <string name="member_role_will_be_changed_with_notification">سيتم تغيير الدور إلى %s. سيتم إبلاغ كل فرد في المجموعة.</string>
+    <string name="member_role_will_be_changed_with_invitation">سيتم تغيير الدور إلى %s. سيتلقى العضو دعوة جديدة.</string>
     <string name="smp_servers_per_user">خوادم الاتصالات الجديدة لملف تعريف الدردشة الحالي الخاص بك</string>
     <string name="switch_receiving_address_desc">سيتم تغيير عنوان الاستلام إلى خادم مختلف. سيتم إكمال تغيير العنوان بعد اتصال المرسل بالإنترنت.</string>
     <string name="this_link_is_not_a_valid_connection_link">هذا الارتباط ليس ارتباط اتصال صالح!</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
@@ -1291,8 +1291,8 @@
   <string name="change_verb">Change</string>
   <string name="switch_verb">Switch</string>
   <string name="change_member_role_question">Change group role?</string>
-  <string name="member_role_will_be_changed_with_notification">The role will be changed to \"%s\". Everyone in the group will be notified.</string>
-  <string name="member_role_will_be_changed_with_invitation">The role will be changed to \"%s\". The member will receive a new invitation.</string>
+  <string name="member_role_will_be_changed_with_notification">The role will be changed to %s. Everyone in the group will be notified.</string>
+  <string name="member_role_will_be_changed_with_invitation">The role will be changed to %s. The member will receive a new invitation.</string>
   <string name="connect_via_member_address_alert_title">Connect directly?</string>
   <string name="connect_via_member_address_alert_desc">Сonnection request will be sent to this group member.</string>
   <string name="error_removing_member">Error removing member</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/bg/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/bg/strings.xml
@@ -521,7 +521,7 @@
     <string name="snd_conn_event_ratchet_sync_agreed">криптирането е съгласувано за %s</string>
     <string name="button_edit_group_profile">Редактирай групов профил</string>
     <string name="share_text_disappears_at">Изчезва в: %s</string>
-    <string name="member_role_will_be_changed_with_invitation">Ролята ще бъде променена на \"%s\". Членът ще получи нова покана.</string>
+    <string name="member_role_will_be_changed_with_invitation">Ролята ще бъде променена на %s. Членът ще получи нова покана.</string>
     <string name="conn_level_desc_direct">директна</string>
     <string name="renegotiate_encryption">Предоговори криптирането</string>
     <string name="group_display_name_field">Групово показвано име:</string>
@@ -925,7 +925,7 @@
     <string name="member_will_be_removed_from_group_cannot_be_undone">Членът ще бъде премахнат от групата - това не може да бъде отменено!</string>
     <string name="item_info_no_text">няма текст</string>
     <string name="button_remove_member">Острани член</string>
-    <string name="member_role_will_be_changed_with_notification">Ролята ще бъде променена на \"%s\". Всички в групата ще бъдат уведомени.</string>
+    <string name="member_role_will_be_changed_with_notification">Ролята ще бъде променена на %s. Всички в групата ще бъдат уведомени.</string>
     <string name="users_delete_data_only">Само данни за локален профил</string>
     <string name="users_delete_with_connections">Профилни и сървърни връзки</string>
     <string name="user_mute">Без звук</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/cs/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/cs/strings.xml
@@ -468,7 +468,7 @@
     <string name="rcv_group_event_member_left">odešel</string>
     <string name="clear_contacts_selection_button">Vyčistit</string>
     <string name="switch_verb">Přepnout</string>
-    <string name="member_role_will_be_changed_with_notification">Role bude změněna na \"%s\". Všichni ve skupině budou informováni.</string>
+    <string name="member_role_will_be_changed_with_notification">Role bude změněna na %s. Všichni ve skupině budou informováni.</string>
     <string name="error_removing_member">Chyba odebírání člena</string>
     <string name="error_saving_group_profile">Chyba ukládání profilu skupiny</string>
     <string name="network_option_seconds_label">vteřiny</string>
@@ -866,7 +866,7 @@
     <string name="role_in_group">Role</string>
     <string name="change_role">Změnit roli</string>
     <string name="change_verb">Změnit</string>
-    <string name="member_role_will_be_changed_with_invitation">Role bude změněna na \"%s\". Člen obdrží novou pozvánku.</string>
+    <string name="member_role_will_be_changed_with_invitation">Role bude změněna na %s. Člen obdrží novou pozvánku.</string>
     <string name="error_changing_role">Chyba změny role</string>
     <string name="conn_level_desc_direct">přímo</string>
     <string name="sending_via">Odesíláno přez</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/de/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/de/strings.xml
@@ -797,8 +797,8 @@
     <string name="change_verb">Ändern</string>
     <string name="switch_verb">Wechseln</string>
     <string name="change_member_role_question">Die Mitgliederrolle ändern?</string>
-    <string name="member_role_will_be_changed_with_notification">Die Mitgliederrolle wird auf \"%s\" geändert. Alle Mitglieder der Gruppe werden benachrichtigt.</string>
-    <string name="member_role_will_be_changed_with_invitation">Die Mitgliederrolle wird auf \"%s\" geändert. Das Mitglied wird eine neue Einladung erhalten.</string>
+    <string name="member_role_will_be_changed_with_notification">Die Mitgliederrolle wird auf %s geändert. Alle Mitglieder der Gruppe werden benachrichtigt.</string>
+    <string name="member_role_will_be_changed_with_invitation">Die Mitgliederrolle wird auf %s geändert. Das Mitglied wird eine neue Einladung erhalten.</string>
     <string name="error_removing_member">Fehler beim Entfernen des Mitglieds</string>
     <string name="error_changing_role">Fehler beim Ändern der Rolle</string>
     <string name="info_row_group">Gruppe</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/es/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/es/strings.xml
@@ -734,7 +734,7 @@
     <string name="icon_descr_sent_msg_status_unauthorized_send">envío no autorizado</string>
     <string name="set_contact_name">Escribe un nombre para el contacto</string>
     <string name="unknown_error">Error desconocido</string>
-    <string name="member_role_will_be_changed_with_notification">El rol cambiará a \"%s\". Se notificará a todos los miembros del grupo.</string>
+    <string name="member_role_will_be_changed_with_notification">El rol cambiará a %s. Se notificará a todos los miembros del grupo.</string>
     <string name="v4_2_security_assessment_desc">La seguridad de SimpleX Chat ha sido auditada por Trail of Bits.</string>
     <string name="v4_4_disappearing_messages_desc">Los mensajes enviados se eliminarán una vez transcurrido el tiempo establecido.</string>
     <string name="ntf_channel_messages">Mensajes de chat SimpleX</string>
@@ -822,7 +822,7 @@
     <string name="update_database_passphrase">Actualizar contraseña base de datos</string>
     <string name="group_invitation_tap_to_join_incognito">Pulsa para unirte en modo incógnito</string>
     <string name="switch_verb">Cambiar</string>
-    <string name="member_role_will_be_changed_with_invitation">El rol cambiará a \"%s\". El miembro recibirá una nueva invitación.</string>
+    <string name="member_role_will_be_changed_with_invitation">El rol cambiará a %s. El miembro recibirá una nueva invitación.</string>
     <string name="update_network_settings_confirmation">Actualizar</string>
     <string name="update_network_settings_question">¿Actualizar la configuración de red\?</string>
     <string name="trying_to_connect_to_server_to_receive_messages">Intentando conectar con el servidor usado para recibir mensajes de este contacto.</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/fi/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/fi/strings.xml
@@ -1118,8 +1118,8 @@
     <string name="the_messaging_and_app_platform_protecting_your_privacy_and_security">Viestintä- ja sovellusalusta, joka suojaa yksityisyyttäsi ja tietoturvaasi.</string>
     <string name="icon_descr_video_call">videopuhelu</string>
     <string name="group_info_section_title_num_members"> %1$s  JÄSENET</string>
-    <string name="member_role_will_be_changed_with_notification">Rooli muuttuu muotoon \"%s\". Kaikille ryhmän jäsenille ilmoitetaan asiasta.</string>
-    <string name="member_role_will_be_changed_with_invitation">Rooli muuttuu muotoon \"%s\". Jäsen saa uuden kutsun.</string>
+    <string name="member_role_will_be_changed_with_notification">Rooli muuttuu muotoon %s. Kaikille ryhmän jäsenille ilmoitetaan asiasta.</string>
+    <string name="member_role_will_be_changed_with_invitation">Rooli muuttuu muotoon %s. Jäsen saa uuden kutsun.</string>
     <string name="voice_prohibited_in_this_chat">Ääniviestit ovat kiellettyjä tässä keskustelussa.</string>
     <string name="v4_3_voice_messages">Ääniviestit</string>
     <string name="trying_to_connect_to_server_to_receive_messages">Yritetään muodostaa yhteys palvelimeen, jota käytetään viestien vastaanottamiseen tältä kontaktilta.</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/fr/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/fr/strings.xml
@@ -717,7 +717,7 @@
     <string name="send_live_message">Envoyer un message dynamique</string>
     <string name="send_live_message_desc">Envoyez un message dynamique - il sera mis à jour pour le⸱s destinataire⸱s au fur et à mesure que vous le tapez</string>
     <string name="send_verb">Envoyer</string>
-    <string name="member_role_will_be_changed_with_invitation">Le rôle sera changé pour «%s». Le membre va recevoir une nouvelle invitation.</string>
+    <string name="member_role_will_be_changed_with_invitation">Le rôle sera changé pour %s. Le membre va recevoir une nouvelle invitation.</string>
     <string name="live">LIVE</string>
     <string name="button_add_members">Inviter des membres</string>
     <string name="you_can_share_group_link_anybody_will_be_able_to_connect">Vous pouvez partager un lien ou un code QR - n\'importe qui pourra rejoindre le groupe. Vous ne perdrez pas les membres du groupe si vous le supprimez par la suite.</string>
@@ -728,7 +728,7 @@
     <string name="only_group_owners_can_change_prefs">Seuls les propriétaires du groupe peuvent modifier les préférences du groupe.</string>
     <string name="section_title_for_console">POUR TERMINAL</string>
     <string name="change_member_role_question">Changer le rôle du groupe \?</string>
-    <string name="member_role_will_be_changed_with_notification">Le rôle sera changé pour «%s». Les membres du groupe seront notifiés.</string>
+    <string name="member_role_will_be_changed_with_notification">Le rôle sera changé pour %s. Les membres du groupe seront notifiés.</string>
     <string name="icon_descr_contact_checked">Contact vérifié⸱e</string>
     <string name="clear_contacts_selection_button">Effacer</string>
     <string name="num_contacts_selected">%d contact·s sélectionné·e·s</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/it/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/it/strings.xml
@@ -829,8 +829,8 @@
     <string name="theme_system">Sistema</string>
     <string name="network_option_tcp_connection_timeout">Scadenza connessione TCP</string>
     <string name="group_is_decentralized">Completamente decentralizzato: visibile solo ai membri.</string>
-    <string name="member_role_will_be_changed_with_notification">Il ruolo verrà cambiato in \"%s\". Tutti i membri del gruppo riceveranno una notifica.</string>
-    <string name="member_role_will_be_changed_with_invitation">Il ruolo verrà cambiato in \"%s\". Il membro riceverà un nuovo invito.</string>
+    <string name="member_role_will_be_changed_with_notification">Il ruolo verrà cambiato in %s. Tutti i membri del gruppo riceveranno una notifica.</string>
+    <string name="member_role_will_be_changed_with_invitation">Il ruolo verrà cambiato in %s. Il membro riceverà un nuovo invito.</string>
     <string name="update_network_settings_confirmation">Aggiorna</string>
     <string name="update_network_settings_question">Aggiornare le impostazioni di rete\?</string>
     <string name="updating_settings_will_reconnect_client_to_all_servers">L\'aggiornamento delle impostazioni riconnetterà il client a tutti i server.</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/iw/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/iw/strings.xml
@@ -1024,7 +1024,7 @@
     <string name="group_invitation_tap_to_join">הקישו כדי להצטרף</string>
     <string name="network_option_tcp_connection_timeout">תום זמן חיבור TCP</string>
     <string name="periodic_notifications_desc">האפליקציה בודקת הודעות חדשות מעת לעת - היא משתמשת בכמה אחוזים מהסוללה ביום. האפליקציה לא משתמשת בהתראות דחיפה - נתונים מהמכשיר שלך לא נשלחים לשרתים.</string>
-    <string name="member_role_will_be_changed_with_notification">התפקיד ישתנה ל־\"%s\". כל חברי הקבוצה יקבלו הודעה על כך.</string>
+    <string name="member_role_will_be_changed_with_notification">התפקיד ישתנה ל־%s. כל חברי הקבוצה יקבלו הודעה על כך.</string>
     <string name="to_connect_via_link_title">כדי להתחבר באמצעות קישור</string>
     <string name="the_messaging_and_app_platform_protecting_your_privacy_and_security">פלטפורמת ההודעות והיישומים המגנה על הפרטיות והאבטחה שלך.</string>
     <string name="alert_text_msg_bad_id">המזהה של ההודעה הבאה שגוי (קטן או שווה להודעה הקודמת).
@@ -1036,7 +1036,7 @@
     <string name="thank_you_for_installing_simplex">תודה שהתקנתם את SimpleX Chat!</string>
     <string name="this_link_is_not_a_valid_connection_link">קישור זה אינו קישור חיבור תקין!</string>
     <string name="theme_colors_section_title">צבעי ערכת נושא</string>
-    <string name="member_role_will_be_changed_with_invitation">התפקיד ישתנה ל־\"%s\". החבר יקבל הזמנה חדשה.</string>
+    <string name="member_role_will_be_changed_with_invitation">התפקיד ישתנה ל־%s. החבר יקבל הזמנה חדשה.</string>
     <string name="smp_servers_per_user">השרתים לחיבורים חדשים של פרופיל הצ׳אט הנוכחי שלך</string>
     <string name="first_platform_without_user_ids">הפלטפורמה הראשונה ללא כל מזהי משתמש - פרטית בעיצובה.</string>
     <string name="next_generation_of_private_messaging">הדור הבא של תקשורת פרטית</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/ja/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/ja/strings.xml
@@ -789,9 +789,9 @@
     <string name="num_contacts_selected">%d 連絡先が選択中</string>
     <string name="snd_group_event_member_deleted">除名しました： %1$s</string>
     <string name="switch_verb">切り替える</string>
-    <string name="member_role_will_be_changed_with_notification">役割が「%s」となります。グループの全員に通知が出ます。</string>
+    <string name="member_role_will_be_changed_with_notification">役割が %s となります。グループの全員に通知が出ます。</string>
     <string name="conn_stats_section_title_servers">サーバ</string>
-    <string name="member_role_will_be_changed_with_invitation">役割が「%s」となります。メンバーに新しい招待が届きます。</string>
+    <string name="member_role_will_be_changed_with_invitation">役割が %s となります。メンバーに新しい招待が届きます。</string>
     <string name="group_is_decentralized">グループは完全分散型で、メンバーしか内容を見れません。</string>
     <string name="network_options_save">保存</string>
     <string name="update_network_settings_question">ネットワーク設定を更新しますか？</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/ko/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/ko/strings.xml
@@ -638,7 +638,7 @@
     <string name="messages_section_title">메시지</string>
     <string name="messages_section_description">이 설정은 현재 내 프로필의 메시지에 적용되어요.</string>
     <string name="member_info_section_title_member">멤버</string>
-    <string name="member_role_will_be_changed_with_invitation">역할이 \"%s\"(으)로 변경되고, 회원은 새로운 초대를 받게 될 거예요.</string>
+    <string name="member_role_will_be_changed_with_invitation">역할이 %s(으)로 변경되고, 회원은 새로운 초대를 받게 될 거예요.</string>
     <string name="network_options_revert">되돌리기</string>
     <string name="message_deletion_prohibited">이 채팅에서는 메시지 영구 삭제가 허용되지 않았어요.</string>
     <string name="leave_group_button">나가기</string>
@@ -683,7 +683,7 @@
     <string name="leave_group_question">그룹에서 나갈까요\?</string>
     <string name="mtr_error_no_down_migration">데이터베이스 버전이 앱보다 최신이지만, 다음에 대한 다운 마이그레이션 없음: %s</string>
     <string name="member_will_be_removed_from_group_cannot_be_undone">멤버가 그룹에서 제거되어요. 이 작업은 되돌릴 수 없어요!</string>
-    <string name="member_role_will_be_changed_with_notification">역할이 \"%s\"(으)로 변경되어요. 그룹의 모든 멤버에게 알림이 전송됩니다.</string>
+    <string name="member_role_will_be_changed_with_notification">역할이 %s(으)로 변경되어요. 그룹의 모든 멤버에게 알림이 전송됩니다.</string>
     <string name="network_options_reset_to_defaults">기본값으로 재설정</string>
     <string name="notification_preview_mode_message">메시지 내용</string>
     <string name="notification_preview_mode_message_desc">대화 상대 이름 및 메시지 표시</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/lt/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/lt/strings.xml
@@ -465,8 +465,8 @@
     <string name="database_restore_error">Duomenų bazės atkūrimo klaida</string>
     <string name="alert_message_no_group">Šios grupės daugiau nebėra.</string>
     <string name="network_option_seconds_label">sek.</string>
-    <string name="member_role_will_be_changed_with_notification">Vaidmuo bus pakeistas į „%s“. Visiems grupėje bus pranešta.</string>
-    <string name="member_role_will_be_changed_with_invitation">Vaidmuo bus pakeistas į „%s“. Narys gaus naują pakvietimą.</string>
+    <string name="member_role_will_be_changed_with_notification">Vaidmuo bus pakeistas į %s. Visiems grupėje bus pranešta.</string>
+    <string name="member_role_will_be_changed_with_invitation">Vaidmuo bus pakeistas į %s. Narys gaus naują pakvietimą.</string>
     <string name="chat_preferences">Pokalbio nuostatos</string>
     <string name="contact_preferences">Adresato nuostatos</string>
     <string name="join_group_button">Prisijungti</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/ml/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/ml/strings.xml
@@ -280,7 +280,7 @@
     <string name="custom_time_unit_weeks">ആഴ്ചകൾ</string>
     <string name="icon_descr_sent_msg_status_unauthorized_send">അനധികൃത അയക്കുക</string>
     <string name="switch_receiving_address_question">സ്വീകരിക്കുന്ന വിലാസം മാറണോ\?</string>
-    <string name="member_role_will_be_changed_with_invitation">കര്‍ത്തവ്യം \"%s\" ആയി മാറ്റും. അംഗത്തിന് പുതിയ ക്ഷണം ലഭിക്കും.</string>
+    <string name="member_role_will_be_changed_with_invitation">കര്‍ത്തവ്യം %s ആയി മാറ്റും. അംഗത്തിന് പുതിയ ക്ഷണം ലഭിക്കും.</string>
     <string name="la_lock_mode_system">സംവിധാനം പ്രാമാണീകരണം</string>
     <string name="skip_inviting_button">അംഗങ്ങളെ ക്ഷണിക്കുന്നത് ഒഴിവാക്കുക</string>
     <string name="save_welcome_message_question">സ്വാഗത സന്ദേശം സംരക്ഷിക്കണോ\?</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/nl/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/nl/strings.xml
@@ -772,7 +772,7 @@
     <string name="group_info_section_title_num_members">%1$s LEDEN</string>
     <string name="you_can_share_group_link_anybody_will_be_able_to_connect">U kunt een link of een QR-code delen. Iedereen kan lid worden van de groep. U verliest geen leden van de groep als u deze later verwijdert.</string>
     <string name="switch_verb">Wijzig</string>
-    <string name="member_role_will_be_changed_with_notification">De rol wordt gewijzigd in \"%s\". Iedereen in de groep wordt op de hoogte gebracht.</string>
+    <string name="member_role_will_be_changed_with_notification">De rol wordt gewijzigd in %s. Iedereen in de groep wordt op de hoogte gebracht.</string>
     <string name="receiving_via">Ontvang via</string>
     <string name="save_group_profile">Groep profiel opslaan</string>
     <string name="group_is_decentralized">Volledig gedecentraliseerd – alleen zichtbaar voor leden.</string>
@@ -805,7 +805,7 @@
     <string name="button_remove_member">Lid verwijderen</string>
     <string name="role_in_group">Rol</string>
     <string name="button_send_direct_message">Direct bericht sturen</string>
-    <string name="member_role_will_be_changed_with_invitation">De rol wordt gewijzigd in \"%s\". De gebruiker ontvangt een nieuwe uitnodiging.</string>
+    <string name="member_role_will_be_changed_with_invitation">De rol wordt gewijzigd in %s. De gebruiker ontvangt een nieuwe uitnodiging.</string>
     <string name="sending_via">Verzenden via</string>
     <string name="conn_stats_section_title_servers">SERVERS</string>
     <string name="network_options_reset_to_defaults">Resetten naar standaardwaarden</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/pl/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/pl/strings.xml
@@ -742,7 +742,7 @@
     <string name="switch_verb">Przełącz</string>
     <string name="switch_receiving_address">Zmień adres odbioru</string>
     <string name="group_is_decentralized">W pełni zdecentralizowana – widoczna tylko dla członków.</string>
-    <string name="member_role_will_be_changed_with_invitation">Rola zostanie zmieniona na \"%s\". Członek otrzyma nowe zaproszenie.</string>
+    <string name="member_role_will_be_changed_with_invitation">Rola zostanie zmieniona na %s. Członek otrzyma nowe zaproszenie.</string>
     <string name="group_welcome_title">Wiadomość powitalna</string>
     <string name="cant_delete_user_profile">Nie można usunąć profilu użytkownika!</string>
     <string name="users_delete_question">Usunąć profil czatu\?</string>
@@ -1004,7 +1004,7 @@
     <string name="thank_you_for_installing_simplex">Dziękujemy za zainstalowanie SimpleX Chat!</string>
     <string name="should_be_at_least_one_visible_profile">Powinien istnieć co najmniej jeden widoczny profil użytkownika.</string>
     <string name="moderate_message_will_be_marked_warning">Wiadomość zostanie oznaczona jako moderowana dla wszystkich członków.</string>
-    <string name="member_role_will_be_changed_with_notification">Rola zostanie zmieniona na \"%s\". Wszyscy w grupie zostaną powiadomieni.</string>
+    <string name="member_role_will_be_changed_with_notification">Rola zostanie zmieniona na %s. Wszyscy w grupie zostaną powiadomieni.</string>
     <string name="delete_files_and_media_desc">Tego działania nie można cofnąć - wszystkie odebrane i wysłane pliki oraz media zostaną usunięte. Obrazy o niskiej rozdzielczości pozostaną.</string>
     <string name="switch_receiving_address_desc">Adres odbiorczy zostanie zmieniony na inny serwer. Zmiana adresu zostanie zakończona gdy nadawca będzie online.</string>
     <string name="this_link_is_not_a_valid_connection_link">Ten link nie jest prawidłowym linkiem połączenia!</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/pt-rBR/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/pt-rBR/strings.xml
@@ -707,7 +707,7 @@
     <string name="mtr_error_different">migração diferente no aplicativo/banco de dados: %s / %s</string>
     <string name="invite_to_group_button">Convidar para o grupo</string>
     <string name="no_contacts_to_add">Sem contatos para adicionar</string>
-    <string name="member_role_will_be_changed_with_notification">A função será alterada para \"%s\". Todos no grupo serão notificados.</string>
+    <string name="member_role_will_be_changed_with_notification">A função será alterada para %s. Todos no grupo serão notificados.</string>
     <string name="user_mute">Mutar</string>
     <string name="should_be_at_least_one_visible_profile">Deve haver pelo menos um perfil de usuário visível.</string>
     <string name="only_you_can_send_voice">Somente você pode enviar mensagens de voz.</string>
@@ -823,7 +823,7 @@
     <string name="settings_section_title_experimenta">EXPERIMENTAL</string>
     <string name="snd_conn_event_switch_queue_phase_completed">você alterou o endereço</string>
     <string name="database_upgrade">Atualização do banco de dados</string>
-    <string name="member_role_will_be_changed_with_invitation">A função será alterada para \"%s\". O membro receberá um novo convite.</string>
+    <string name="member_role_will_be_changed_with_invitation">A função será alterada para %s. O membro receberá um novo convite.</string>
     <string name="only_group_owners_can_change_prefs">Somente os proprietários do grupo podem alterar as preferências do grupo.</string>
     <string name="button_add_welcome_message">Adicionar mensagem de boas-vindas</string>
     <string name="group_welcome_title">Mensagem de boas-vindas</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/ru/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/ru/strings.xml
@@ -802,8 +802,8 @@
     <string name="change_verb">Поменять</string>
     <string name="switch_verb">Переключить</string>
     <string name="change_member_role_question">Поменять роль в группе?</string>
-    <string name="member_role_will_be_changed_with_notification">Роль будет изменена на \"%s\". Все в группе получат сообщение.</string>
-    <string name="member_role_will_be_changed_with_invitation">Роль будет изменена на \"%s\". Будет отправлено новое приглашение.</string>
+    <string name="member_role_will_be_changed_with_notification">Роль будет изменена на %s. Все в группе получат сообщение.</string>
+    <string name="member_role_will_be_changed_with_invitation">Роль будет изменена на %s. Будет отправлено новое приглашение.</string>
     <string name="error_removing_member">Ошибка при удалении члена группы</string>
     <string name="error_changing_role">Ошибка при изменении роли</string>
     <string name="info_row_group">Группа</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/th/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/th/strings.xml
@@ -1029,7 +1029,7 @@
     <string name="v5_0_polish_interface_descr">ขอบคุณผู้ใช้ – มีส่วนร่วมผ่าน Weblate!</string>
     <string name="the_messaging_and_app_platform_protecting_your_privacy_and_security">แพลตฟอร์มการส่งข้อความและแอปพลิเคชันที่ปกป้องความเป็นส่วนตัวและความปลอดภัยของคุณ</string>
     <string name="next_generation_of_private_messaging">การส่งข้อความส่วนตัวรุ่นต่อไป</string>
-    <string name="member_role_will_be_changed_with_notification">บทบาทจะถูกเปลี่ยนเป็น \"%s\" ทุกคนในกลุ่มจะได้รับแจ้ง</string>
+    <string name="member_role_will_be_changed_with_notification">บทบาทจะถูกเปลี่ยนเป็น %s ทุกคนในกลุ่มจะได้รับแจ้ง</string>
     <string name="delete_files_and_media_desc">การดำเนินการนี้ไม่สามารถยกเลิกได้ ไฟล์และสื่อที่ได้รับและส่งทั้งหมดจะถูกลบ รูปภาพความละเอียดต่ำจะยังคงอยู่</string>
     <string name="to_reveal_profile_enter_password">หากต้องการเปิดเผยโปรไฟล์ที่ซ่อนอยู่ของคุณ ให้ป้อนรหัสผ่านแบบเต็มในช่องค้นหาในหน้าโปรไฟล์แชทของคุณ</string>
     <string name="network_session_mode_transport_isolation">การแยกการขนส่ง</string>
@@ -1210,7 +1210,7 @@
     <string name="button_welcome_message">ข้อความต้อนรับ</string>
     <string name="you_can_share_group_link_anybody_will_be_able_to_connect">คุณสามารถแชร์ลิงก์หรือคิวอาร์โค้ดได้ ทุกคนจะสามารถเข้าร่วมกลุ่มได้ คุณจะไม่สูญเสียสมาชิกของกลุ่มหากคุณลบในภายหลัง</string>
     <string name="you_can_share_this_address_with_your_contacts">คุณสามารถแบ่งปันที่อยู่นี้กับผู้ติดต่อของคุณเพื่อให้พวกเขาเชื่อมต่อกับ %s</string>
-    <string name="member_role_will_be_changed_with_invitation">บทบาทจะถูกเปลี่ยนเป็น \"%s\" สมาชิกจะได้รับคำเชิญใหม่</string>
+    <string name="member_role_will_be_changed_with_invitation">บทบาทจะถูกเปลี่ยนเป็น %s สมาชิกจะได้รับคำเชิญใหม่</string>
     <string name="group_welcome_title">ข้อความต้อนรับ</string>
     <string name="group_main_profile_sent">โปรไฟล์การแชทของคุณจะถูกส่งไปยังสมาชิกในกลุ่ม</string>
     <string name="update_network_settings_confirmation">อัปเดต</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/tr/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/tr/strings.xml
@@ -142,14 +142,14 @@
     <string name="save_and_notify_contact">Kaydet ve kişiyi bilgilendir</string>
     <string name="save_passphrase_in_keychain">Parolayı, Keystore\'a kaydet.</string>
     <string name="icon_descr_audio_on">Ses açık</string>
-    <string name="member_role_will_be_changed_with_notification">Yetki, \"%s\" olarak değiştirelecek. Gruptaki herkes bilgilendirilecek.</string>
+    <string name="member_role_will_be_changed_with_notification">Yetki, %s olarak değiştirelecek. Gruptaki herkes bilgilendirilecek.</string>
     <string name="calls_prohibited_with_this_contact">Sesli/görüntülü aramalar yasaktır.</string>
     <string name="la_auth_failed">Kimlik doğrulama başarısız</string>
     <string name="icon_descr_address">SimpleX adresi</string>
     <string name="moderate_message_will_be_deleted_warning">Mesaj, tüm üyeler için silinecek.</string>
     <string name="the_messaging_and_app_platform_protecting_your_privacy_and_security">Gizliliğinizi ve güvenliğinizi koruyan mesajlaşma ve uygulama platformu.</string>
     <string name="settings_section_title_incognito">Gizlilik kipi</string>
-    <string name="member_role_will_be_changed_with_invitation">Yetki, \"%s\" olarak değiştirilecek. Üye, yeni bir davet alacak.</string>
+    <string name="member_role_will_be_changed_with_invitation">Yetki, %s olarak değiştirilecek. Üye, yeni bir davet alacak.</string>
     <string name="role_in_group">Yetki</string>
     <string name="allow_voice_messages_question">Sesli mesajlara izin ver\?</string>
     <string name="users_add">Profil ekle</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/uk/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/uk/strings.xml
@@ -736,8 +736,8 @@
     <string name="share_text_disappears_at">Зникає в: %s</string>
     <string name="item_info_current">(поточний)</string>
     <string name="button_remove_member">Видалити учасника</string>
-    <string name="member_role_will_be_changed_with_notification">Роль буде змінено на \"%s\". Всі учасники групи будуть повідомлені про це.</string>
-    <string name="member_role_will_be_changed_with_invitation">Роль буде змінено на \"%s\". Учасник отримає нове запрошення.</string>
+    <string name="member_role_will_be_changed_with_notification">Роль буде змінено на %s. Всі учасники групи будуть повідомлені про це.</string>
+    <string name="member_role_will_be_changed_with_invitation">Роль буде змінено на %s. Учасник отримає нове запрошення.</string>
     <string name="info_row_group">Група</string>
     <string name="group_welcome_title">Вітальне повідомлення</string>
     <string name="group_profile_is_stored_on_members_devices">Профіль групи зберігається на пристроях учасників, а не на серверах.</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/zh-rCN/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/zh-rCN/strings.xml
@@ -505,7 +505,7 @@
     <string name="show_call_on_lock_screen">显示</string>
     <string name="you_must_use_the_most_recent_version_of_database">您只能在一台设备上使用最新版本的聊天数据库，否则您可能会停止接收来自某些联系人的消息。</string>
     <string name="new_passphrase">新密码……</string>
-    <string name="member_role_will_be_changed_with_notification">该角色将更改为“%s”。群组中每个人都会收到通知。</string>
+    <string name="member_role_will_be_changed_with_notification">该角色将更改为%s。群组中每个人都会收到通知。</string>
     <string name="chat_lock">SimpleX 锁定</string>
     <string name="periodic_notifications">定期通知</string>
     <string name="notifications_mode_periodic">定期启动</string>
@@ -739,7 +739,7 @@
     <string name="image_decoding_exception_desc">图像无法解码。 请尝试不同的图像或联系开发者。</string>
     <string name="theme">主题</string>
     <string name="delete_files_and_media_desc">此操作无法撤消——所有接收和发送的文件和媒体都将被删除。 低分辨率图片将保留。</string>
-    <string name="member_role_will_be_changed_with_invitation">角色将更改为“%s”。 该成员将收到新的邀请。</string>
+    <string name="member_role_will_be_changed_with_invitation">角色将更改为%s。 该成员将收到新的邀请。</string>
     <string name="enable_automatic_deletion_message">此操作无法撤消——早于所选的发送和接收的消息将被删除。 这可能需要几分钟时间。</string>
     <string name="this_QR_code_is_not_a_link">此二维码不是链接！</string>
     <string name="switch_receiving_address_desc">接收地址将变更到不同的服务器。地址更改将在发件人上线后完成。</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/zh-rTW/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/zh-rTW/strings.xml
@@ -605,8 +605,8 @@
     <string name="button_create_group_link">建立連結</string>
     <string name="delete_link_question">刪除連結？</string>
     <string name="button_remove_member">移除成員</string>
-    <string name="member_role_will_be_changed_with_notification">成員的身份會修改為 \"%s\"。所有在群組內的成員都接收到通知。</string>
-    <string name="member_role_will_be_changed_with_invitation">成員的身份會修改為 \"%s\"。該成員將接收到新的邀請。</string>
+    <string name="member_role_will_be_changed_with_notification">成員的身份會修改為 %s。所有在群組內的成員都接收到通知。</string>
+    <string name="member_role_will_be_changed_with_invitation">成員的身份會修改為 %s。該成員將接收到新的邀請。</string>
     <string name="network_status">網路狀態</string>
     <string name="network_options_reset_to_defaults">重置為預設值</string>
     <string name="incognito_info_share">當你與某人分享已啟用匿名聊天模式的個人檔案時，此個人檔案將用於他們邀請你參加的群組。</string>


### PR DESCRIPTION
`The role will be changed to \"%s\".`

becomes

`The role will be changed to %s.`