### PR TITLE
cli: remove clashing short option for device-name

### DIFF
--- a/src/Simplex/Chat/Options.hs
+++ b/src/Simplex/Chat/Options.hs
@@ -206,7 +206,6 @@ chatOptsP appDir defaultDbFileName = do
     optional $
       strOption
         ( long "device-name"
-            <> short 'e'
             <> metavar "DEVICE"
             <> help "Device name to use in connections with remote hosts and controller"
         )


### PR DESCRIPTION
`-e` is already used for `--execute`