### PR TITLE
android, desktop: specifying text color globally

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/ui/theme/Theme.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/ui/theme/Theme.kt
@@ -283,7 +283,21 @@ fun SimpleXTheme(darkTheme: Boolean? = null, content: @Composable () -> Unit) {
   val theme by CurrentColors.collectAsState()
   MaterialTheme(
     colors = theme.colors,
-    typography = Typography,
+    typography = Typography.copy(
+      h1 = Typography.h1.copy(color = theme.colors.onBackground),
+      h2 = Typography.h2.copy(color = theme.colors.onBackground),
+      h3 = Typography.h3.copy(color = theme.colors.onBackground),
+      h4 = Typography.h4.copy(color = theme.colors.onBackground),
+      h5 = Typography.h5.copy(color = theme.colors.onBackground),
+      h6 = Typography.h6.copy(color = theme.colors.onBackground),
+      subtitle1 = Typography.subtitle1.copy(color = theme.colors.onBackground),
+      subtitle2 = Typography.subtitle2.copy(color = theme.colors.onBackground),
+      body1 = Typography.body1.copy(color = theme.colors.onBackground),
+      body2 = Typography.body2.copy(color = theme.colors.onBackground),
+      button = Typography.button.copy(color = theme.colors.onBackground),
+      caption = Typography.caption.copy(color = theme.colors.onBackground),
+      overline = Typography.overline.copy(color = theme.colors.onBackground)
+    ),
     shapes = Shapes,
     content = {
       ProvideTextStyle(

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/ui/theme/Theme.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/ui/theme/Theme.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.*
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import chat.simplex.common.model.ChatController
 import chat.simplex.common.platform.isInNightMode
@@ -284,6 +285,11 @@ fun SimpleXTheme(darkTheme: Boolean? = null, content: @Composable () -> Unit) {
     colors = theme.colors,
     typography = Typography,
     shapes = Shapes,
-    content = content
+    content = {
+      ProvideTextStyle(
+        value = TextStyle(color = theme.colors.onBackground),
+        content = content
+      )
+    }
   )
 }


### PR DESCRIPTION
With such a theme (important color here is a `menus` ) text colors become opposite of what we expect (white on light theme). This PR fixes it by specifying default color that can be overriden in any place of code.

See for more info: https://github.com/simplex-chat/simplex-chat/issues/3363

Closes https://github.com/simplex-chat/simplex-chat/issues/3363
```yaml
base: "LIGHT"
colors:
  accent: "#ff8839ef"           # mauve
  accentVariant:: "#ff4c4f69"   # text
  secondary: "#ff8839ef"        # mauve
  secondaryVariant: "#ff4c4f69" # text
  background: "#ffeff1f5"       # base
  menus: "#ff8839ef"            # mauve
  title: "#ff8839ef"            # mauve
  sentMessage: "#ff4c4f69"      # text
  receivedMessage: "#ff4c4f69"  # text
```