### PR TITLE
android, desktop: protocol servers fix

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
@@ -63,8 +63,6 @@ object ChatModel {
 
   val terminalItems = mutableStateOf<List<TerminalItem>>(listOf())
   val userAddress = mutableStateOf<UserContactLinkRec?>(null)
-  // Allows to temporary save servers that are being edited on multiple screens
-  val userSMPServersUnsaved = mutableStateOf<(List<ServerCfg>)?>(null)
   val chatItemTTL = mutableStateOf<ChatItemTTL>(ChatItemTTL.None)
 
   // set when app opened from external intent

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/NetworkAndServers.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/NetworkAndServers.kt
@@ -47,10 +47,6 @@ fun NetworkAndServersView(
   val onionHosts = remember { mutableStateOf(netCfg.onionHosts) }
   val sessionMode = remember { mutableStateOf(netCfg.sessionMode) }
 
-  LaunchedEffect(Unit) {
-    chatModel.userSMPServersUnsaved.value = null
-  }
-
   val proxyPort = remember { derivedStateOf { chatModel.controller.appPrefs.networkProxyHostPort.state.value?.split(":")?.lastOrNull()?.toIntOrNull() ?: 9050 } }
   NetworkAndServersLayout(
     currentRemoteHost = currentRemoteHost,


### PR DESCRIPTION
- deleting the last server triggered restoration of previously saved servers
- buttons for reset and save were showing wrong enabled/disabled state when disconnects remote on that screen