### PR TITLE
docs: fix example systemd service unit in xftp-server documentation page

### DIFF
--- a/docs/XFTP-SERVER.md
+++ b/docs/XFTP-SERVER.md
@@ -75,7 +75,7 @@ Manual installation requires some preliminary actions:
    Group=xftp
    Type=simple
    ExecStart=/usr/local/bin/xftp-server start +RTS -N -RTS
-   ExecStopPost=/usr/bin/env sh -c '[ -e "/var/opt/simplex-xftp/file-server-store.log" ] && cp "/var/opt/simplex-xftp/file-server-store.log" "/var/opt/simplex-xftp/file-server-store.log.$(date +'%FT%T')"'
+   ExecStopPost=/usr/bin/env sh -c '[ -e "/var/opt/simplex-xftp/file-server-store.log" ] && cp "/var/opt/simplex-xftp/file-server-store.log" "/var/opt/simplex-xftp/file-server-store.log.$(date +'%%FT%%T')"'
    LimitNOFILE=65535
    KillSignal=SIGINT
    TimeoutStopSec=infinity


### PR DESCRIPTION
Systemd itself uses %<something> tokens so %% needs to be used for specifiers

(https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html)