### PR TITLE
iOS Timeline: 2. Views

### DIFF
--- a/apps/ios/Shared/Model/ChatModel.swift
+++ b/apps/ios/Shared/Model/ChatModel.swift
@@ -728,6 +728,15 @@ final class ChatModel: ObservableObject {
             logger.error("apiChatItemReaction error: \(responseError(error))")
         }
     }
+
+    func loadGroupMembers(groupInfo: GroupInfo) async {
+        let groupMembers = await apiListMembers(groupInfo.groupId)
+        await MainActor.run {
+            if chatId == groupInfo.id {
+                self.groupMembers = groupMembers.map { GMember.init($0) }
+            }
+        }
+    }
 }
 
 struct ShowingInvitation {

--- a/apps/ios/Shared/Model/ChatModel.swift
+++ b/apps/ios/Shared/Model/ChatModel.swift
@@ -711,6 +711,23 @@ final class ChatModel: ObservableObject {
             .unknown
         }
     }
+
+    func set(reaction: MsgReaction, for chatItem: ChatItem, chatInfo: ChatInfo, add: Bool) async {
+        do {
+            let chatItem = try await apiChatItemReaction(
+                type: chatInfo.chatType,
+                id: chatInfo.apiId,
+                itemId: chatItem.id,
+                add: add,
+                reaction: reaction
+            )
+            await MainActor.run {
+                updateChatItem(chatInfo, chatItem)
+            }
+        } catch let error {
+            logger.error("apiChatItemReaction error: \(responseError(error))")
+        }
+    }
 }
 
 struct ShowingInvitation {

--- a/apps/ios/Shared/Views/Chat/ChatItemMenu/ChatItemMenu.Allowed.swift
+++ b/apps/ios/Shared/Views/Chat/ChatItemMenu/ChatItemMenu.Allowed.swift
@@ -1,0 +1,91 @@
+//
+//  ChatItemMenu.Computed.swift
+//  SimpleX (iOS)
+//
+//  Created by Levitating Pineapple on 17/06/2024.
+//  Copyright © 2024 SimpleX Chat. All rights reserved.
+//
+
+import Foundation
+import SimpleXChat
+
+extension ChatItemMenu {
+    var reactionsAllowed: Bool {
+        chat.chatInfo.featureEnabled(.reactions) &&
+        chatItem.allowAddReaction
+    }
+
+    var replyAllowed: Bool {
+        chatItem.meta.itemDeleted == nil &&
+        !chatItem.isLiveDummy &&
+        !isLive && !chatItem.localNote
+    }
+
+    var copyAndShareAllowed: Bool {
+        !chatItem.content.text.isEmpty ||
+        (chatItem.content.msgContent?.isImage == true && fileExists)
+    }
+
+    var editAllowed: Bool {
+        chatItem.meta.editable &&
+        !(chatItem.content.msgContent?.isVoice ?? false) &&
+        !isLive
+    }
+
+    var forwardAllowed: Bool {
+        chatItem.meta.itemDeleted == nil &&
+        (chatItem.file == nil || (fileSource != nil && fileExists)) &&
+        !chatItem.isLiveDummy &&
+        !isLive
+    }
+
+    var infoAllowed: Bool {
+        !chatItem.isLiveDummy
+    }
+
+    var deleteAllowed: Bool {
+        chatItem.meta.itemDeleted == nil &&
+        !chatItem.localNote
+    }
+
+    var isExpanded: Bool {
+        expandedItems.contains(timelineItem.chatItem.id)
+    }
+
+    var isLive: Bool {
+        composeState.liveMessage != nil
+    }
+
+    var chatItem: ChatItem {
+        mergedIndex.flatMap { timelineItem.mergedChatItems[$0] }
+        ?? timelineItem.chatItem
+    }
+
+    var canExpand: Bool {
+        mergedIndex == nil &&
+        !timelineItem.mergedChatItems.isEmpty
+    }
+
+    /// Reactions, which has not been used yet
+    var availableReactions: Array<MsgReaction> {
+        MsgReaction.values
+            .filter { reaction in
+                !chatItem.reactions.contains {
+                    $0.userReacted && $0.reaction == reaction
+                }
+            }
+    }
+
+    var fileSource: CryptoFile? {
+        getLoadedFileSource(chatItem.file)
+    }
+
+    var fileExists: Bool {
+        fileSource
+            .flatMap {
+                FileManager.default.fileExists(
+                    atPath: getAppFilePath($0.filePath).path
+                )
+            } ?? false
+    }
+}

--- a/apps/ios/Shared/Views/Chat/ChatItemMenu/ChatItemMenu.Buttons.swift
+++ b/apps/ios/Shared/Views/Chat/ChatItemMenu/ChatItemMenu.Buttons.swift
@@ -150,12 +150,7 @@ extension ChatItemMenu {
                     let cInfo = chat.chatInfo
                     let ciInfo = try await apiGetChatItemInfo(type: cInfo.chatType, id: cInfo.apiId, itemId: chatItem.id)
                     if case let .group(groupInfo) = chat.chatInfo {
-                        let groupMembers = await apiListMembers(groupInfo.groupId)
-                        await MainActor.run {
-                            if m.chatId == groupInfo.id {
-                                m.groupMembers = groupMembers.map { GMember.init($0) }
-                            }
-                        }
+                        await m.loadGroupMembers(groupInfo: groupInfo)
                     }
                     await MainActor.run { sheet = .itemInfo(chatItem, ciInfo) }
                 } catch let error {
@@ -221,7 +216,7 @@ extension ChatItemMenu {
             expandedItems.remove(timelineItem.chatItem.id)
         } label: {
             Label(
-                NSLocalizedString("Hide", comment: "chat item action"),
+                NSLocalizedString("Collapse", comment: "chat item action"),
                 systemImage: "arrow.down.and.line.horizontal.and.arrow.up"
             )
         }

--- a/apps/ios/Shared/Views/Chat/ChatItemMenu/ChatItemMenu.Buttons.swift
+++ b/apps/ios/Shared/Views/Chat/ChatItemMenu/ChatItemMenu.Buttons.swift
@@ -1,0 +1,229 @@
+//
+//  ChatItemMenu.Buttons.swift
+//  SimpleX (iOS)
+//
+//  Created by Levitating Pineapple on 17/06/2024.
+//  Copyright © 2024 SimpleX Chat. All rights reserved.
+//
+
+import SwiftUI
+import SimpleXChat
+
+extension ChatItemMenu {
+    func reactions(from: Int? = nil, till: Int? = nil) -> some View {
+        ForEach(availableReactions[(from ?? .zero)..<(till ?? availableReactions.count)]) { reaction in
+            Button(reaction.text) {
+                Task {
+                    do {
+                        let cInfo = chat.chatInfo
+                        let chatItem = try await apiChatItemReaction(
+                            type: cInfo.chatType,
+                            id: cInfo.apiId,
+                            itemId: chatItem.id,
+                            add: true,
+                            reaction: reaction
+                        )
+                        await MainActor.run {
+                            m.updateChatItem(chat.chatInfo, chatItem)
+                        }
+                    } catch let error {
+                        logger.error("apiChatItemReaction error: \(responseError(error))")
+                    }
+                }
+            }
+        }
+    }
+
+    var reply: Button<some View> {
+        Button {
+            withAnimation {
+                if composeState.editing {
+                    composeState = ComposeState(contextItem: .quotedItem(chatItem: chatItem))
+                } else {
+                    composeState = composeState.copy(contextItem: .quotedItem(chatItem: chatItem))
+                }
+            }
+        } label: {
+            Label(
+                NSLocalizedString("Reply", comment: "chat item action"),
+                systemImage: "arrowshape.turn.up.left"
+            )
+        }
+    }
+
+    var forward: Button<some View> {
+        Button {
+            sheet = .forward(chatItem)
+        } label: {
+            Label(
+                NSLocalizedString("Forward", comment: "chat item action"),
+                systemImage: "arrowshape.turn.up.forward"
+            )
+        }
+    }
+
+
+    var share: Button<some View> {
+        Button {
+            var shareItems: [Any] = [chatItem.content.text]
+            if case .image = chatItem.content.msgContent, let image = getLoadedImage(chatItem.file) {
+                shareItems.append(image)
+            }
+            showShareSheet(items: shareItems)
+        } label: {
+            Label(
+                NSLocalizedString("Share", comment: "chat item action"),
+                systemImage: "square.and.arrow.up"
+            )
+        }
+    }
+
+    var copy: Button<some View> {
+        Button {
+            if case let .image(text, _) = chatItem.content.msgContent,
+               text == "",
+               let image = getLoadedImage(chatItem.file) {
+                UIPasteboard.general.image = image
+            } else {
+                UIPasteboard.general.string = chatItem.content.text
+            }
+        } label: {
+            Label("Copy", systemImage: "doc.on.doc")
+        }
+    }
+
+    func save(image: UIImage) -> Button<some View> {
+        Button {
+            UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
+        } label: {
+            Label(
+                NSLocalizedString("Save", comment: "chat item action"),
+                systemImage: "square.and.arrow.down"
+            )
+        }
+    }
+
+    func save(file: CryptoFile) -> Button<some View> {
+        Button {
+            saveCryptoFile(file)
+        } label: {
+            Label(
+                NSLocalizedString("Save", comment: "chat item action"),
+                systemImage: file.cryptoArgs == nil ? "square.and.arrow.down" : "lock.open"
+            )
+        }
+    }
+
+    func download(file: CIFile) -> Button<some View> {
+        Button {
+            Task {
+                logger.debug("ChatView downloadFileAction, in Task")
+                if let user = m.currentUser {
+                    await receiveFile(user: user, fileId: file.fileId)
+                }
+            }
+        } label: {
+            Label(
+                NSLocalizedString("Download", comment: "chat item action"),
+                systemImage: "arrow.down.doc"
+            )
+        }
+    }
+
+    var edit: Button<some View> {
+        Button {
+            withAnimation {
+                composeState = ComposeState(editingItem: chatItem)
+            }
+        } label: {
+            Label(
+                NSLocalizedString("Edit", comment: "chat item action"),
+                systemImage: "square.and.pencil"
+            )
+        }
+    }
+
+    var info: Button<some View> {
+        Button {
+            Task {
+                do {
+                    let cInfo = chat.chatInfo
+                    let ciInfo = try await apiGetChatItemInfo(type: cInfo.chatType, id: cInfo.apiId, itemId: chatItem.id)
+                    if case let .group(groupInfo) = chat.chatInfo {
+                        let groupMembers = await apiListMembers(groupInfo.groupId)
+                        await MainActor.run {
+                            if m.chatId == groupInfo.id {
+                                m.groupMembers = groupMembers.map { GMember.init($0) }
+                            }
+                        }
+                    }
+                    await MainActor.run { sheet = .itemInfo(chatItem, ciInfo) }
+                } catch let error {
+                    logger.error("apiGetChatItemInfo error: \(responseError(error))")
+                }
+            }
+        } label: {
+            Label(
+                NSLocalizedString("Info", comment: "chat item action"),
+                systemImage: "info.circle"
+            )
+        }
+    }
+
+    func cancel(action cancelAction: CancelAction, fileId: Int64) -> Button<some View> {
+        Button(role: .destructive) {
+            AlertManager.shared.showAlert(Alert(
+                title: Text(cancelAction.alert.title),
+                message: Text(cancelAction.alert.message),
+                primaryButton: .destructive(Text(cancelAction.alert.confirm)) {
+                    Task {
+                        if let user = m.currentUser {
+                            await cancelFile(user: user, fileId: fileId)
+                        }
+                    }
+                },
+                secondaryButton: .cancel()
+            ))
+        } label: {
+            Label(
+                cancelAction.uiAction,
+                systemImage: "xmark"
+            )
+        }
+    }
+
+    var delete: Button<some View> {
+        Button(role: .destructive) {
+            deleteItems = mergedIndex
+                .flatMap { [timelineItem.mergedChatItems[$0]] }
+                ?? timelineItem.mergedChatItems + [timelineItem.chatItem]
+        } label: {
+            Label(
+                NSLocalizedString("Delete", comment: "chat item action"),
+                systemImage: "trash"
+            )
+        }
+    }
+
+    var expand: Button<some View> {
+        Button {
+            withAnimation { let _ = expandedItems.insert(chatItem.id) }
+        } label: {
+            Label(
+                NSLocalizedString("Expand", comment: "chat item action"),
+                systemImage: "arrow.up.and.line.horizontal.and.arrow.down"
+            )
+        }
+    }
+
+    var collapse: Button<some View> {
+        Button {
+            expandedItems.remove(timelineItem.chatItem.id)
+        } label: {
+            Label(
+                NSLocalizedString("Hide", comment: "chat item action"),
+                systemImage: "arrow.down.and.line.horizontal.and.arrow.up"
+            )
+        }
+    }
+}

--- a/apps/ios/Shared/Views/Chat/ChatItemMenu/ChatItemMenu.swift
+++ b/apps/ios/Shared/Views/Chat/ChatItemMenu/ChatItemMenu.swift
@@ -14,7 +14,7 @@ struct ChatItemMenu: View {
     @Environment(\.colorScheme) var colorScheme
     @ObservedObject var chat: Chat
     let timelineItem: Timeline.Item
-    /// Index, in case this ``ChatItemMenu`` represents to one of the merged items
+    /// Index, in case this ``ChatItemMenu`` if for one of the merged items
     let mergedIndex: Int?
 
     @Binding var composeState: ComposeState

--- a/apps/ios/Shared/Views/Chat/ChatItemMenu/ChatItemMenu.swift
+++ b/apps/ios/Shared/Views/Chat/ChatItemMenu/ChatItemMenu.swift
@@ -1,0 +1,105 @@
+//
+//  ChatItemMenu.swift
+//  SimpleX (iOS)
+//
+//  Created by Levitating Pineapple on 15/06/2024.
+//  Copyright © 2024 SimpleX Chat. All rights reserved.
+//
+
+import SwiftUI
+import SimpleXChat
+
+struct ChatItemMenu: View {
+    @EnvironmentObject var m: ChatModel
+    @Environment(\.colorScheme) var colorScheme
+    @ObservedObject var chat: Chat
+    let timelineItem: Timeline.Item
+    /// Index, in case this ``ChatItemMenu`` represents to one of the merged items
+    let mergedIndex: Int?
+
+    @Binding var composeState: ComposeState
+    @Binding var expandedItems: Set<ChatItem.ID>
+    @Binding var sheet: Timeline.Sheet?
+    @Binding var deleteItems: Array<ChatItem>?
+
+    var body: some View {
+        if chatItem.content.msgContent != nil,
+           chatItem.meta.itemDeleted == nil || isExpanded {
+            if reactionsAllowed { reactionsGroup }
+            if replyAllowed { reply }
+            if copyAndShareAllowed {
+                share
+                copy
+            }
+            fileGroup
+            if editAllowed { edit }
+            if forwardAllowed { forward }
+            if infoAllowed { info }
+            if isExpanded { collapse }
+            if chatItem.meta.itemDeleted == nil && !chatItem.localNote,
+               let file = chatItem.file,
+               let cancelAction = file.cancelAction {
+                cancel(action: cancelAction, fileId: file.fileId)
+            }
+            if !isLive || !chatItem.meta.isLive { delete }
+        } else if chatItem.meta.itemDeleted != nil {
+            if isExpanded {
+                collapse
+            } else if !chatItem.isDeletedContent {
+                expand
+            }
+            info
+            delete
+        } else if chatItem.isDeletedContent {
+            info
+            delete
+        } else if chatItem.mergeCategory != nil && (canExpand || isExpanded) {
+            if isExpanded { collapse } else { expand }
+            delete
+        } else if chatItem.showLocalDelete {
+            delete
+        }
+    }
+
+    private var reactionsGroup: some View {
+        if #available(iOS 16.4, *) {
+            return ControlGroup {
+                if availableReactions.count > 4 {
+                    reactions(till: 3)
+                    Menu {
+                        reactions(from: 3)
+                    } label: {
+                        Image(systemName: "ellipsis")
+                    }
+                } else { reactions() }
+            }.controlGroupStyle(.compactMenu)
+        } else {
+            return Menu {
+                reactions()
+            } label: {
+                Label(
+                    NSLocalizedString("React…", comment: "chat item menu"),
+                    systemImage: "face.smiling"
+                )
+            }
+        }
+    }
+
+    private var fileGroup: some View {
+        Group {
+            if let fileSource = fileSource, fileExists {
+                if case .image = chatItem.content.msgContent, let image = getLoadedImage(chatItem.file) {
+                    if image.imageData != nil {
+                        save(file: fileSource)
+                    } else {
+                        save(image: image)
+                    }
+                } else {
+                    save(file: fileSource)
+                }
+            } else if let file = chatItem.file, case .rcvInvitation = file.fileStatus, fileSizeValid(file) {
+                download(file: file)
+            }
+        }
+    }
+}

--- a/apps/ios/Shared/Views/Chat/ReverseList/ReverseList.Controller.swift
+++ b/apps/ios/Shared/Views/Chat/ReverseList/ReverseList.Controller.swift
@@ -1,0 +1,122 @@
+//
+//  ReverseList.Controller.swift
+//  SimpleX (iOS)
+//
+//  Created by Levitating Pineapple on 12/06/2024.
+//  Copyright © 2024 SimpleX Chat. All rights reserved.
+//
+
+import Combine
+import SwiftUI
+
+extension ReverseList {
+    /// Controller, which hosts SwiftUI cells
+    class Controller: UITableViewController {
+        private enum Section { case main }
+        private let representer: ReverseList
+        private var dataSource: UITableViewDiffableDataSource<Section, Item>!
+        private var itemCount: Int = .zero
+        private var isNearBottom = PassthroughSubject<Bool, Never>()
+        private var bag = Set<AnyCancellable>()
+
+        init(representer: ReverseList) {
+            self.representer = representer
+            super.init(style: .plain)
+
+            // 1. Style
+            tableView.separatorStyle = .none
+            tableView.transform = .verticalFlip
+
+            // 2. Register cells
+            if #available(iOS 16.0, *) {
+                tableView.register(
+                    UITableViewCell.self,
+                    forCellReuseIdentifier: cellReuseId
+                )
+            } else {
+                tableView.register(
+                    HostingCell<Content>.self,
+                    forCellReuseIdentifier: cellReuseId
+                )
+            }
+
+            // 3. Configure data source
+            self.dataSource = UITableViewDiffableDataSource<Section, Item>(
+                tableView: tableView
+            ) { (tableView, indexPath, item) -> UITableViewCell? in
+                self.representer.loadedCell(indexPath)
+                let cell = tableView.dequeueReusableCell(withIdentifier: cellReuseId, for: indexPath)
+                if #available(iOS 16.0, *) {
+                    cell.contentConfiguration = UIHostingConfiguration { self.representer.content(item) }
+                        .margins(.all, .zero)
+                        .minSize(height: 4) // Passing zero will result in system default of 44 points being used
+                } else {
+                    if let cell = cell as? HostingCell<Content> {
+                        cell.set(content: self.representer.content(item), parent: self)
+                    } else {
+                        fatalError("Unexpected Cell Type for: \(item)")
+                    }
+                }
+                cell.transform = .verticalFlip
+                cell.selectionStyle = .none
+                return cell
+            }
+
+            // 4. Manage Scroll State
+            isNearBottom
+                .removeDuplicates()
+                .sink { isNearBottom in
+                    Task(priority: .userInitiated) {
+                        representer.scroll = .isNearBottom(isNearBottom)
+                    }
+                }
+                .store(in: &bag)
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) { fatalError() }
+
+        override func scrollViewDidScroll(_ scrollView: UIScrollView) {
+            isNearBottom.send(scrollView.contentOffset.y < scrollView.frame.height)
+        }
+
+        /// Hides keyboard, when user begins to scroll.
+        /// Equivalent to `.scrollDismissesKeyboard(.immediately)`
+        override func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+            UIApplication.shared
+                .sendAction(
+                    #selector(UIResponder.resignFirstResponder),
+                    to: nil,
+                    from: nil,
+                    for: nil
+                )
+        }
+
+
+        /// Scrolls to Item at index path
+        /// - Parameter indexPath: Item to scroll to - will scroll to beginning of the list, if `nil`
+        func scroll(to indexPath: IndexPath = IndexPath(item: .zero, section: .zero)) {
+            tableView.scrollToRow(
+                at: indexPath,
+                at: .middle,
+                animated: true
+            )
+        }
+
+        func update(items: Array<Item>) {
+            var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
+            snapshot.appendSections([.main])
+            snapshot.appendItems(items)
+            dataSource.defaultRowAnimation = .none
+            dataSource.apply(snapshot, animatingDifferences: itemCount != .zero)
+            itemCount = items.count
+        }
+    }
+}
+
+fileprivate let cellReuseId = "hostingCell"
+
+fileprivate extension CGAffineTransform {
+    /// Transform that vertically flips the view, preserving it's location
+    static let verticalFlip = CGAffineTransform(scaleX: 1, y: -1)
+}

--- a/apps/ios/Shared/Views/Chat/ReverseList/ReverseList.Controller.swift
+++ b/apps/ios/Shared/Views/Chat/ReverseList/ReverseList.Controller.swift
@@ -92,15 +92,16 @@ extension ReverseList {
                 )
         }
 
-
         /// Scrolls to Item at index path
         /// - Parameter indexPath: Item to scroll to - will scroll to beginning of the list, if `nil`
-        func scroll(to indexPath: IndexPath = IndexPath(item: .zero, section: .zero)) {
-            tableView.scrollToRow(
-                at: indexPath,
-                at: .middle,
-                animated: true
-            )
+        func scroll(to index: Int?) {
+            if let index {
+                tableView.scrollToRow(
+                    at: IndexPath(row: index, section: .zero),
+                    at: .middle,
+                    animated: true
+                )
+            }
         }
 
         func update(items: Array<Item>) {
@@ -108,7 +109,11 @@ extension ReverseList {
             snapshot.appendSections([.main])
             snapshot.appendItems(items)
             dataSource.defaultRowAnimation = .none
-            dataSource.apply(snapshot, animatingDifferences: itemCount != .zero)
+            var animatingDifferences = false
+            if #available(iOS 16.0, *) {
+                animatingDifferences = (items.count - itemCount) < Timeline.pageLoad
+            }
+            dataSource.apply(snapshot, animatingDifferences: animatingDifferences)
             itemCount = items.count
         }
     }

--- a/apps/ios/Shared/Views/Chat/ReverseList/ReverseList.HostingCell.swift
+++ b/apps/ios/Shared/Views/Chat/ReverseList/ReverseList.HostingCell.swift
@@ -1,0 +1,44 @@
+//
+//  ReverseList.HostingCell.swift
+//  SimpleX (iOS)
+//
+//  Created by Levitating Pineapple on 12/06/2024.
+//  Copyright © 2024 SimpleX Chat. All rights reserved.
+//
+
+import SwiftUI
+
+extension ReverseList {
+    /// `UIHostingConfiguration` back-port for iOS14 and iOS15
+    /// Implemented as a `UITableViewCell` that wraps and manages a generic `UIHostingController`
+    final class HostingCell<Hosted: View>: UITableViewCell {
+        private let hostingController = UIHostingController<Hosted?>(rootView: nil)
+
+        /// Updates content of the cell
+        /// For reference: https://noahgilmore.com/blog/swiftui-self-sizing-cells/
+        func set(content: Hosted, parent: UIViewController) {
+            hostingController.rootView = content
+            if let hostingView = hostingController.view {
+                hostingView.invalidateIntrinsicContentSize()
+                if hostingController.parent != parent { parent.addChild(hostingController) }
+                if !contentView.subviews.contains(hostingController.view) {
+                    contentView.addSubview(hostingController.view)
+                    hostingView.translatesAutoresizingMaskIntoConstraints = false
+                    NSLayoutConstraint.activate([
+                        hostingView.leadingAnchor
+                            .constraint(equalTo: contentView.leadingAnchor),
+                        hostingView.trailingAnchor
+                            .constraint(equalTo: contentView.trailingAnchor),
+                        hostingView.topAnchor
+                            .constraint(equalTo: contentView.topAnchor),
+                        hostingView.bottomAnchor
+                            .constraint(equalTo: contentView.bottomAnchor)
+                    ])
+                }
+                if hostingController.parent != parent { hostingController.didMove(toParent: parent) }
+            } else {
+                fatalError("Hosting View not loaded \(hostingController)")
+            }
+        }
+    }
+}

--- a/apps/ios/Shared/Views/Chat/ReverseList/ReverseList.swift
+++ b/apps/ios/Shared/Views/Chat/ReverseList/ReverseList.swift
@@ -1,0 +1,50 @@
+//
+//  ReverseList.swift
+//  SimpleX (iOS)
+//
+//  Created by Levitating Pineapple on 11/06/2024.
+//  Copyright © 2024 SimpleX Chat. All rights reserved.
+//
+
+import SwiftUI
+
+/// A List, which displays it's items in reverse order - from bottom to top
+struct ReverseList<Item: Hashable & Sendable, Content: View>: UIViewControllerRepresentable {
+
+    let items: Array<Item>
+
+    @Binding var scroll: Scroll
+
+    /// Closure, that returns user interface for a given item
+    let content: (Item) -> Content
+
+    /// Callback for when a new cell is loaded
+    let loadedCell: (IndexPath) -> Void
+
+    func makeUIViewController(context: Context) -> Controller {
+        Controller(representer: self)
+    }
+
+    func updateUIViewController(_ controller: Controller, context: Context) {
+        if case .scrollingToBottom = scroll {
+            controller.scroll()
+        } else {
+            controller.update(items: items)
+        }
+    }
+}
+
+extension ReverseList {
+    /// Represents Scroll State of ``ReverseList``
+    enum Scroll: Equatable {
+        case scrollingToBottom
+        case isNearBottom(Bool)
+
+        var isAtBottom: Bool {
+            switch self {
+            case .scrollingToBottom: false
+            case let .isNearBottom(bool): bool
+            }
+        }
+    }
+}

--- a/apps/ios/Shared/Views/Chat/Timeline/Timeline.AlignmentContainer.swift
+++ b/apps/ios/Shared/Views/Chat/Timeline/Timeline.AlignmentContainer.swift
@@ -17,8 +17,9 @@ extension Timeline {
 
         /// For larger screens `maxWidth` defines maximum message width,
         /// that still preserves readable line length
-        let maxWidth: Double = 300
-
+        let maxWidth: Double = 320
+        
+        /// Leading or Trailing
         let alignment: Alignment
         @ViewBuilder let content: () -> Content
 

--- a/apps/ios/Shared/Views/Chat/Timeline/Timeline.AlignmentContainer.swift
+++ b/apps/ios/Shared/Views/Chat/Timeline/Timeline.AlignmentContainer.swift
@@ -1,0 +1,36 @@
+//
+//  Timeline.ItemView.AlignmentView.swift
+//  SimpleX (iOS)
+//
+//  Created by Levitating Pineapple on 15/06/2024.
+//  Copyright © 2024 SimpleX Chat. All rights reserved.
+//
+
+import SwiftUI
+
+extension Timeline {
+    /// Aligns ``Timeline.ItemView`` without requiring a `GeometryReader`
+    struct AlignmentContainer<Content: View>: View {
+        /// For small screens `minInset` defines minimum inset,
+        /// which indicates if message is sent or received
+        let minInset: Double = 32
+
+        /// For larger screens `maxWidth` defines maximum message width,
+        /// that still preserves readable line length
+        let maxWidth: Double = 300
+
+        let alignment: Alignment
+        @ViewBuilder let content: () -> Content
+
+        var body: some View {
+            HStack(spacing: minInset) {
+                if alignment == .trailing { Spacer() }
+                content().frame(
+                    maxWidth: maxWidth,
+                    alignment: alignment
+                )
+                if alignment == .leading { Spacer() }
+            }
+        }
+    }
+}

--- a/apps/ios/Shared/Views/Chat/Timeline/Timeline.Item.swift
+++ b/apps/ios/Shared/Views/Chat/Timeline/Timeline.Item.swift
@@ -20,7 +20,24 @@ extension Timeline {
         let isDirectionPersisted: Bool
         /// Defines if merged chat items are expanded and visible
         let isExpanded: Bool
+
+        func markAsRead(chatInfo: ChatInfo) async {
+            await chatItem.markAsRead(chatInfo: chatInfo)
+            for mergeChatItem in mergedChatItems {
+                await mergeChatItem.markAsRead(chatInfo: chatInfo)
+            }
+        }
     }
+}
+
+extension ChatItem {
+    fileprivate func markAsRead(chatInfo: ChatInfo) async {
+        if isRcvNew { await apiMarkChatItemRead(chatInfo, self) }
+    }
+}
+
+extension Timeline.Item: Identifiable {
+    var id: ChatItem.ID { chatItem.id }
 }
 
 extension Array<Timeline.Item> {

--- a/apps/ios/Shared/Views/Chat/Timeline/Timeline.Item.swift
+++ b/apps/ios/Shared/Views/Chat/Timeline/Timeline.Item.swift
@@ -1,0 +1,52 @@
+//
+//  Timeline.Item.swift
+//  SimpleX (iOS)
+//
+//  Created by Levitating Pineapple on 15/06/2024.
+//  Copyright © 2024 SimpleX Chat. All rights reserved.
+//
+
+import Foundation
+import SimpleXChat
+
+extension Timeline {
+    /// Represents a single item in the list
+    struct Item: Hashable {
+        /// The latest `chatItem`
+        let chatItem: ChatItem
+        /// Zero or more ``ChatItem``s which have been coalesced into this ``Timeline.Item``
+        var mergedChatItems: Array<ChatItem>
+        /// Different rendering for ``Item``s that have the same ``CIDirection`` as before
+        let isDirectionPersisted: Bool
+        /// Defines if merged chat items are expanded and visible
+        let isExpanded: Bool
+    }
+}
+
+extension Array<Timeline.Item> {
+    /// Creates an array of ``Timeline.Item``s by coalescing similar ``chatItem``s
+    init(reversedChatItems: Array<ChatItem>, expanded: Set<ChatItem.ID>) {
+        self = reversedChatItems
+            .enumerated()
+            .reduce(into: Array<Timeline.Item>()) { items, enumerated in
+                if let mergeCategory = enumerated.element.mergeCategory,
+                   enumerated.offset > .zero,
+                   mergeCategory == reversedChatItems[enumerated.offset - 1].mergeCategory,
+                   var last = items.popLast() {
+                    last.mergedChatItems.append(enumerated.element)
+                    items.append(last)
+                } else {
+                    items.append(
+                        Timeline.Item(
+                            chatItem: enumerated.element,
+                            mergedChatItems: Array<ChatItem>(),
+                            isDirectionPersisted: enumerated.offset < reversedChatItems.count - 1
+                            ? reversedChatItems[enumerated.offset + 1].chatDir == enumerated.element.chatDir
+                            : false,
+                            isExpanded: expanded.contains(enumerated.element.id)
+                        )
+                    )
+                }
+        }
+    }
+}

--- a/apps/ios/Shared/Views/Chat/Timeline/Timeline.ItemView.swift
+++ b/apps/ios/Shared/Views/Chat/Timeline/Timeline.ItemView.swift
@@ -1,0 +1,167 @@
+//
+//  ReverseList.ContentView.swift
+//  SimpleX (iOS)
+//
+//  Created by Levitating Pineapple on 12/06/2024.
+//  Copyright © 2024 SimpleX Chat. All rights reserved.
+//
+
+import SwiftUI
+import SimpleXChat
+
+extension Timeline {
+    /// Renders a single timeline item
+    struct ItemView: View {
+        let item: Timeline.Item
+        @EnvironmentObject var chatModel: ChatModel
+        @ObservedObject var chat: Chat
+        @Binding var expandedItems: Set<ChatItem.ID>
+        @Binding var composeState: ComposeState
+        @Binding var sheet: Sheet?
+        @Binding var deleteItems: Array<ChatItem>?
+
+        @State var audioPlayer: AudioPlayer?
+        @State var playbackState: VoiceMessagePlaybackState = .noPlayback
+        @State var playbackTime: TimeInterval?
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 4) {
+                memberNames
+                HStack(alignment: .top, spacing: 8) {
+                    profileImageView
+                    VStack {
+                        if item.isExpanded {
+                            ForEach(item.mergedChatItems.reversed()) { chatItem in
+                                view(chatItem: chatItem)
+                            }
+                        }
+                        view(chatItem: item.chatItem)
+                    }
+                }
+            }
+            .padding(.top, item.isDirectionPersisted ? .zero : 8)
+            .padding(.horizontal, 8)
+            .padding(.bottom, 4)
+        }
+
+        // TODO: Clarify merged item member names
+        private var memberNames: some View {
+            Group {
+                if !item.isDirectionPersisted && item.chatItem.content.showMemberName,
+                   let groupMember = item.chatItem.chatDir.groupMember {
+                    Text(groupMember.displayName)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                        .padding(.leading, Double(Timeline.profileImageSize) + 14)
+                        .padding(.top, 8)
+                }
+            }
+        }
+
+        private var profileImageView: some View {
+            Group {
+                if let groupMember = item.chatItem.chatDir.groupMember {
+                    if item.isDirectionPersisted {
+                        Spacer(minLength: Double(Timeline.profileImageSize))
+                    } else {
+                        ProfileImage(
+                            imageStr: groupMember.memberProfile.image,
+                            size: Double(Timeline.profileImageSize)
+                        ).onTapGesture {
+                            Task {
+                                if let gMember = chatModel.getGroupMember(groupMember.groupMemberId) {
+                                    await MainActor.run { sheet = .memberInfo(gMember) }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private func view(chatItem: ChatItem) -> some View {
+            AlignmentContainer(alignment: chatItem.alignment) {
+                VStack(alignment: chatItem.horizontalAlignment, spacing: 2) {
+                    ChatItemView(
+                        chat: chat,
+                        chatItem: chatItem,
+                        revealed: .constant(item.isExpanded),
+                        allowMenu: .constant(true),
+                        audioPlayer: $audioPlayer,
+                        playbackState: $playbackState,
+                        playbackTime: $playbackTime
+                    ).contextMenu {
+                        ChatItemMenu(
+                            chat: chat,
+                            timelineItem: item,
+                            mergedIndex: item.mergedChatItems.firstIndex(of: chatItem),
+                            composeState: $composeState,
+                            expandedItems: $expandedItems,
+                            sheet: $sheet,
+                            deleteItems: $deleteItems
+                        )
+                    }
+                    reactions(chatItem: item.chatItem)
+                }
+            }
+            .task { await chatItem.markAsRead(chatInfo: chat.chatInfo) }
+        }
+
+        private func reactions(chatItem: ChatItem) -> some View {
+            Group {
+                if chatItem.content.msgContent != nil &&
+                  (chatItem.meta.itemDeleted == nil || item.isExpanded) &&
+                   chatItem.reactions.count > 0 {
+                    HStack(spacing: 4) {
+                        ForEach(chatItem.reactions, id: \.reaction) { r in
+                            let v = HStack(spacing: 4) {
+                                switch r.reaction {
+                                case let .emoji(emoji): Text(emoji.rawValue).font(.caption)
+                                case .unknown: EmptyView()
+                                }
+                                if r.totalReacted > 1 {
+                                    Text("\(r.totalReacted)")
+                                        .font(.caption)
+                                        .fontWeight(r.userReacted ? .bold : .light)
+                                        .foregroundColor(r.userReacted ? .accentColor : .secondary)
+                                }
+                            }
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 4)
+                            if chat.chatInfo.featureEnabled(.reactions) && (chatItem.allowAddReaction || r.userReacted) {
+                                v.onTapGesture {
+                                    Task {
+                                        await chatModel.set(
+                                            reaction: r.reaction,
+                                            for: item.chatItem,
+                                            chatInfo: chat.chatInfo,
+                                            add: true
+                                        )
+                                    }
+                                }
+                            } else {
+                                v
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+extension ChatItem {
+    fileprivate var alignment: Alignment {
+        chatDir.sent ? .trailing : .leading
+    }
+
+    fileprivate var horizontalAlignment: HorizontalAlignment {
+        chatDir.sent ? .trailing : .leading
+    }
+
+    fileprivate func markAsRead(chatInfo: ChatInfo) async {
+        // TODO: As there can be many items, these calls sould be debounced
+        if isRcvNew { await apiMarkChatItemRead(chatInfo, self) }
+    }
+}

--- a/apps/ios/Shared/Views/Chat/Timeline/Timeline.Sheet.swift
+++ b/apps/ios/Shared/Views/Chat/Timeline/Timeline.Sheet.swift
@@ -1,0 +1,62 @@
+//
+//  Timeline.Model.swift
+//  SimpleX (iOS)
+//
+//  Created by Levitating Pineapple on 18/06/2024.
+//  Copyright © 2024 SimpleX Chat. All rights reserved.
+//
+
+import SwiftUI
+import SimpleXChat
+
+extension Timeline {
+    enum Sheet: Identifiable {
+        case itemInfo(ChatItem, ChatItemInfo)
+        case memberInfo(GMember)
+        case memberAdd(GroupInfo)
+        case forward(ChatItem)
+
+        var id: String {
+            switch self {
+            case .itemInfo: "itemInfo"
+            case .memberInfo: "memberInfo"
+            case .memberAdd: "memberAdd"
+            case .forward: "forward"
+            }
+        }
+    }
+
+    struct SheetView: View {
+        let sheet: Sheet
+        let chat: Chat
+        @Binding var composeState: ComposeState
+
+        var body: some View {
+            switch sheet {
+            case let .itemInfo(chatItem, chatItemInfo):
+                ChatItemInfoView(
+                    ci: chatItem,
+                    chatItemInfo: .constant(chatItemInfo)
+                )
+            case let .memberInfo(groupMember):
+                if let groupInfo = chat.chatInfo.groupInfo {
+                    GroupMemberInfoView(
+                        groupInfo: groupInfo,
+                        groupMember: groupMember
+                    )
+                }
+            case let .memberAdd(groupInfo):
+                AddGroupMembersView(
+                    chat: chat,
+                    groupInfo: groupInfo
+                )
+            case let .forward(chatItem):
+                ChatItemForwardingView(
+                    ci: chatItem,
+                    fromChatInfo: chat.chatInfo,
+                    composeState: $composeState
+                )
+            }
+        }
+    }
+}

--- a/apps/ios/Shared/Views/Chat/Timeline/Timeline.TimelineView.swift
+++ b/apps/ios/Shared/Views/Chat/Timeline/Timeline.TimelineView.swift
@@ -1,0 +1,220 @@
+//
+//  TimelineView.swift
+//  SimpleX (iOS)
+//
+//  Created by Levitating Pineapple on 16/06/2024.
+//  Copyright © 2024 SimpleX Chat. All rights reserved.
+//
+
+import SwiftUI
+import SimpleXChat
+
+extension Timeline {
+    struct TimelineView: View {
+        @EnvironmentObject var chatModel: ChatModel
+        @ObservedObject var chat: Chat
+        @Binding var composeState: ComposeState
+
+        @State private var items = Array<Item>()
+        @State private var expanded = Set<ChatItem.ID>()
+        @State private var loadState = LoadState.ready
+        @State private var sheet: Sheet?
+        @State private var deleteItems: Array<ChatItem>?
+        @State private var scroll: ReverseList<Item, ItemView>.Scroll = .isNearBottom(true)
+
+        var body: some View {
+            ZStack(alignment: .bottomTrailing) {
+                ReverseList(items: items, scroll: $scroll) { item in
+                    Timeline.ItemView(
+                        item: item,
+                        chat: chat,
+                        expandedItems: $expanded,
+                        composeState: $composeState,
+                        sheet: $sheet,
+                        deleteItems: $deleteItems
+                    )
+                } loadedCell: {
+                    if items.count >= Timeline.pageLoad,
+                       items.count - $0.item < Timeline.pageLoad {
+                        loadPage(chatInfo: chat.chatInfo)
+                    }
+                }
+                if !scroll.isAtBottom { scrollToBottomButton }
+            }
+
+            // Data binding
+            .onChange(of: chatModel.reversedChatItems) { update(chatItems: $0) }
+            .onChange(of: expanded) { update(expanded: $0) }
+            .onAppear { update() }
+
+            // Modals
+            .sheet(item: $sheet) { SheetView(sheet: $0, chat: chat, composeState: $composeState) }
+            .confirmationDialog(
+                "Remove Message?",
+                isPresented: isDialogPresented,
+                presenting: deleteItems
+            ) { deleteButtons(items: $0) }
+        }
+
+        private var scrollToBottomButton: some View {
+            Button {
+                scroll = .scrollingToBottom
+            } label: {
+                Image(systemName: "chevron.down")
+                    .imageScale(.large).offset(y: 1)
+                    .frame(width: 44, height: 44)
+                    .background(Material.ultraThin)
+                    .clipShape(Circle())
+                    .shadow(radius: 2)
+                    .padding()
+            }
+        }
+
+        private func update(
+            chatItems: Array<ChatItem>? = nil,
+            expanded: Set<ChatItem.ID>? = nil
+        ) {
+            Task {
+                let items = Array<Item>(
+                    reversedChatItems: chatItems ?? chatModel.reversedChatItems,
+                    expanded: expanded ?? self.expanded
+                )
+                await MainActor.run { self.items = items }
+            }
+        }
+    }
+}
+
+// MARK: Page Loading
+extension Timeline.TimelineView {
+    /// ┌─────┐ ─► ┌───────┐    ┌──────┐
+    /// │ready│    │loading│ ─► │loaded│
+    /// └─────┘ ◄─ └───────┘    └──────┘
+    enum LoadState: String {
+        /// Ready to load next page
+        case ready
+        /// Page load in progress
+        case loading
+        /// The timeline has been fully loaded
+        case loaded
+    }
+
+    private func loadPage(chatInfo: ChatInfo) {
+        if loadState != .ready { return }
+        Task {
+            do {
+                loadState = .loading
+                let items = try await apiGetChatItems(
+                    type: chatInfo.chatType,
+                    id: chatInfo.apiId,
+                    pagination: chatModel.reversedChatItems.last.flatMap {
+                        ChatPagination .before(chatItemId: $0.id, count: Timeline.pageSize)
+                    } ?? .last(count: Timeline.pageSize)
+                )
+                if items.isEmpty {
+                    loadState = .loaded
+                } else {
+                    await MainActor.run {
+                        chatModel.reversedChatItems.append(contentsOf: items.reversed())
+                        loadState = .ready
+                    }
+                }
+            } catch let error {
+                logger.error("apiGetChat error: \(responseError(error))")
+            }
+        }
+    }
+}
+
+// MARK: Chat Item Deletion
+extension Timeline.TimelineView {
+    @ViewBuilder
+    func deleteButtons(items: Array<ChatItem>) -> some View {
+        // Removes chat item(s) locally
+        Button("Delete for me", role: .destructive) {
+            Task { await delete(items: items, mode: .cidmInternal) }
+        }
+        // Broadcast delete
+        if items.count == 1, let di = items.first, di.meta.deletable && !di.localNote {
+            Button(deleteButtonTitle(chatItem: di, chat: chat), role: .destructive) {
+                Task { await delete(items: [di], mode: .cidmBroadcast) }
+            }
+        }
+    }
+
+    var isDialogPresented: Binding<Bool> {
+        Binding(
+            get: { deleteItems != nil },
+            set: { if !$0 { deleteItems = nil } }
+        )
+    }
+
+    private func deleteButtonTitle(chatItem: ChatItem, chat: Chat) -> String {
+        if let (groupInfo, _) = chatItem.memberToModerate(chat.chatInfo) {
+            // Group chat
+            groupInfo.fullGroupPreferences.fullDelete.on
+            ? "Delete member message"
+            : "Moderate member message"
+        } else {
+            // Direct message
+            chat.chatInfo.featureEnabled(.fullDelete)
+            ? "Delete for everyone"
+            : "Mark deleted for everyone"
+        }
+    }
+
+    private struct Deleted {
+        let item: ChatItem
+        let totem: ChatItem?
+
+        init(_ tuple: (ChatItem, ChatItem?)) {
+            self.item = tuple.0
+            self.totem = tuple.1
+        }
+
+        func update(model: ChatModel, info: ChatInfo) {
+            if let totem {
+                _ = model.upsertChatItem(info, totem)
+            } else {
+                model.removeChatItem(info, item)
+            }
+        }
+    }
+
+    private func delete(items: Array<ChatItem>, mode: CIDeleteMode) async {
+        do {
+            var deleted = Array<Deleted>()
+            for item in items {
+                if case .cidmBroadcast = mode,
+                   let (groupInfo, groupMember) = item.memberToModerate(chat.chatInfo) {
+                    deleted.append(
+                        Deleted(
+                            try await apiDeleteMemberChatItem(
+                                groupId: groupInfo.apiId,
+                                groupMemberId: groupMember.groupMemberId,
+                                itemId: item.id
+                            )
+                        )
+                    )
+
+                } else {
+                    deleted.append(
+                        Deleted(
+                            try await apiDeleteChatItem(
+                                type: chat.chatInfo.chatType,
+                                id: chat.chatInfo.apiId,
+                                itemId: item.id,
+                                mode: mode
+                            )
+                        )
+                    )
+                }
+            }
+            await MainActor.run {
+                deleted.forEach { $0.update(model: chatModel, info: chat.chatInfo) }
+            }
+        } catch {
+            logger.error("ChatView.deleteMessage error: \(error.localizedDescription)")
+        }
+    }
+}

--- a/apps/ios/Shared/Views/Chat/Timeline/Timeline.swift
+++ b/apps/ios/Shared/Views/Chat/Timeline/Timeline.swift
@@ -1,0 +1,19 @@
+//
+//  Timeline.swift
+//  SimpleX (iOS)
+//
+//  Created by Levitating Pineapple on 19/06/2024.
+//  Copyright © 2024 SimpleX Chat. All rights reserved.
+//
+
+import Foundation
+
+/// Timeline Namespace
+enum Timeline {
+    /// The size of each requested page
+    static let pageSize = 50
+    /// Number of items remaining, before next page is requested
+    static let pageLoad = 10
+    /// Hardcoded size of the profile images
+    static let profileImageSize = 34
+}

--- a/apps/ios/Shared/Views/Chat/Timeline/Timeline.swift
+++ b/apps/ios/Shared/Views/Chat/Timeline/Timeline.swift
@@ -16,4 +16,6 @@ enum Timeline {
     static let pageLoad = 10
     /// Hardcoded size of the profile images
     static let profileImageSize = 34
+
+    typealias Scroll = ReverseList<Item, ItemView>.Scroll
 }

--- a/apps/ios/SimpleX.xcodeproj/project.pbxproj
+++ b/apps/ios/SimpleX.xcodeproj/project.pbxproj
@@ -186,6 +186,18 @@
 		8C81482C2BD91CD4002CBEC3 /* AudioDevicePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C81482B2BD91CD4002CBEC3 /* AudioDevicePicker.swift */; };
 		8CC4ED902BD7B8530078AEE8 /* CallAudioDeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC4ED8F2BD7B8530078AEE8 /* CallAudioDeviceManager.swift */; };
 		8CC956EE2BC0041000412A11 /* NetworkObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC956ED2BC0041000412A11 /* NetworkObserver.swift */; };
+		CEDC28A92C260B5900B1B1E1 /* ChatItemMenu.Buttons.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDC28A52C260B5900B1B1E1 /* ChatItemMenu.Buttons.swift */; };
+		CEDC28AA2C260B5900B1B1E1 /* ChatItemMenu.Allowed.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDC28A62C260B5900B1B1E1 /* ChatItemMenu.Allowed.swift */; };
+		CEDC28AB2C260B5900B1B1E1 /* ChatItemMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDC28A72C260B5900B1B1E1 /* ChatItemMenu.swift */; };
+		CEDC28B02C260B7900B1B1E1 /* ReverseList.Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDC28AC2C260B7900B1B1E1 /* ReverseList.Controller.swift */; };
+		CEDC28B12C260B7900B1B1E1 /* ReverseList.HostingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDC28AD2C260B7900B1B1E1 /* ReverseList.HostingCell.swift */; };
+		CEDC28B22C260B7900B1B1E1 /* ReverseList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDC28AE2C260B7900B1B1E1 /* ReverseList.swift */; };
+		CEDC28BB2C260B8100B1B1E1 /* Timeline.AlignmentContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDC28B32C260B8100B1B1E1 /* Timeline.AlignmentContainer.swift */; };
+		CEDC28BC2C260B8100B1B1E1 /* Timeline.Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDC28B42C260B8100B1B1E1 /* Timeline.Item.swift */; };
+		CEDC28BD2C260B8100B1B1E1 /* Timeline.ItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDC28B52C260B8100B1B1E1 /* Timeline.ItemView.swift */; };
+		CEDC28BE2C260B8100B1B1E1 /* Timeline.Sheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDC28B62C260B8100B1B1E1 /* Timeline.Sheet.swift */; };
+		CEDC28BF2C260B8100B1B1E1 /* Timeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDC28B72C260B8100B1B1E1 /* Timeline.swift */; };
+		CEDC28C12C260B8100B1B1E1 /* Timeline.TimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDC28B92C260B8100B1B1E1 /* Timeline.TimelineView.swift */; };
 		D7197A1829AE89660055C05A /* WebRTC in Frameworks */ = {isa = PBXBuildFile; productRef = D7197A1729AE89660055C05A /* WebRTC */; };
 		D72A9088294BD7A70047C86D /* NativeTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D72A9087294BD7A70047C86D /* NativeTextEditor.swift */; };
 		D741547829AF89AF0022400A /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D741547729AF89AF0022400A /* StoreKit.framework */; };
@@ -483,6 +495,18 @@
 		8C81482B2BD91CD4002CBEC3 /* AudioDevicePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDevicePicker.swift; sourceTree = "<group>"; };
 		8CC4ED8F2BD7B8530078AEE8 /* CallAudioDeviceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallAudioDeviceManager.swift; sourceTree = "<group>"; };
 		8CC956ED2BC0041000412A11 /* NetworkObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkObserver.swift; sourceTree = "<group>"; };
+		CEDC28A52C260B5900B1B1E1 /* ChatItemMenu.Buttons.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatItemMenu.Buttons.swift; sourceTree = "<group>"; };
+		CEDC28A62C260B5900B1B1E1 /* ChatItemMenu.Allowed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatItemMenu.Allowed.swift; sourceTree = "<group>"; };
+		CEDC28A72C260B5900B1B1E1 /* ChatItemMenu.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatItemMenu.swift; sourceTree = "<group>"; };
+		CEDC28AC2C260B7900B1B1E1 /* ReverseList.Controller.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReverseList.Controller.swift; sourceTree = "<group>"; };
+		CEDC28AD2C260B7900B1B1E1 /* ReverseList.HostingCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReverseList.HostingCell.swift; sourceTree = "<group>"; };
+		CEDC28AE2C260B7900B1B1E1 /* ReverseList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReverseList.swift; sourceTree = "<group>"; };
+		CEDC28B32C260B8100B1B1E1 /* Timeline.AlignmentContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Timeline.AlignmentContainer.swift; sourceTree = "<group>"; };
+		CEDC28B42C260B8100B1B1E1 /* Timeline.Item.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Timeline.Item.swift; sourceTree = "<group>"; };
+		CEDC28B52C260B8100B1B1E1 /* Timeline.ItemView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Timeline.ItemView.swift; sourceTree = "<group>"; };
+		CEDC28B62C260B8100B1B1E1 /* Timeline.Sheet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Timeline.Sheet.swift; sourceTree = "<group>"; };
+		CEDC28B72C260B8100B1B1E1 /* Timeline.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Timeline.swift; sourceTree = "<group>"; };
+		CEDC28B92C260B8100B1B1E1 /* Timeline.TimelineView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Timeline.TimelineView.swift; sourceTree = "<group>"; };
 		D72A9087294BD7A70047C86D /* NativeTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeTextEditor.swift; sourceTree = "<group>"; };
 		D741547729AF89AF0022400A /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS16.1.sdk/System/Library/Frameworks/StoreKit.framework; sourceTree = DEVELOPER_DIR; };
 		D741547929AF90B00022400A /* PushKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PushKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS16.1.sdk/System/Library/Frameworks/PushKit.framework; sourceTree = DEVELOPER_DIR; };
@@ -583,7 +607,10 @@
 			children = (
 				6440CA01288AEC770062C672 /* Group */,
 				5CE4407427ADB657007B033A /* ChatItem */,
+				CEDC28A82C260B5900B1B1E1 /* ChatItemMenu */,
 				5CEACCE527DE977C000BD591 /* ComposeMessage */,
+				CEDC28AF2C260B7900B1B1E1 /* ReverseList */,
+				CEDC28BA2C260B8100B1B1E1 /* Timeline */,
 				5C2E260E27A30FDC00F70299 /* ChatView.swift */,
 				5C7505A727B6D34800BE3227 /* ChatInfoToolbar.swift */,
 				5C971E1C27AEBEF600C8A3CE /* ChatInfoView.swift */,
@@ -922,6 +949,39 @@
 			path = Migration;
 			sourceTree = "<group>";
 		};
+		CEDC28A82C260B5900B1B1E1 /* ChatItemMenu */ = {
+			isa = PBXGroup;
+			children = (
+				CEDC28A72C260B5900B1B1E1 /* ChatItemMenu.swift */,
+				CEDC28A62C260B5900B1B1E1 /* ChatItemMenu.Allowed.swift */,
+				CEDC28A52C260B5900B1B1E1 /* ChatItemMenu.Buttons.swift */,
+			);
+			path = ChatItemMenu;
+			sourceTree = "<group>";
+		};
+		CEDC28AF2C260B7900B1B1E1 /* ReverseList */ = {
+			isa = PBXGroup;
+			children = (
+				CEDC28AE2C260B7900B1B1E1 /* ReverseList.swift */,
+				CEDC28AC2C260B7900B1B1E1 /* ReverseList.Controller.swift */,
+				CEDC28AD2C260B7900B1B1E1 /* ReverseList.HostingCell.swift */,
+			);
+			path = ReverseList;
+			sourceTree = "<group>";
+		};
+		CEDC28BA2C260B8100B1B1E1 /* Timeline */ = {
+			isa = PBXGroup;
+			children = (
+				CEDC28B72C260B8100B1B1E1 /* Timeline.swift */,
+				CEDC28B32C260B8100B1B1E1 /* Timeline.AlignmentContainer.swift */,
+				CEDC28B42C260B8100B1B1E1 /* Timeline.Item.swift */,
+				CEDC28B52C260B8100B1B1E1 /* Timeline.ItemView.swift */,
+				CEDC28B62C260B8100B1B1E1 /* Timeline.Sheet.swift */,
+				CEDC28B92C260B8100B1B1E1 /* Timeline.TimelineView.swift */,
+			);
+			path = Timeline;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -1137,6 +1197,7 @@
 				64C06EB52A0A4A7C00792D4D /* ChatItemInfoView.swift in Sources */,
 				640417CE2B29B8C200CCB412 /* NewChatView.swift in Sources */,
 				6440CA03288AECA70062C672 /* AddGroupMembersView.swift in Sources */,
+				CEDC28A92C260B5900B1B1E1 /* ChatItemMenu.Buttons.swift in Sources */,
 				5C3F1D58284363C400EC8A82 /* PrivacySettings.swift in Sources */,
 				5C55A923283CEDE600C4E99E /* SoundPlayer.swift in Sources */,
 				5C93292F29239A170090FFF9 /* ProtocolServersView.swift in Sources */,
@@ -1148,6 +1209,7 @@
 				5CB0BA9A2827FD8800B3292C /* HowItWorks.swift in Sources */,
 				5C13730B28156D2700F43030 /* ContactConnectionView.swift in Sources */,
 				644EFFE0292CFD7F00525D5B /* CIVoiceView.swift in Sources */,
+				CEDC28C12C260B8100B1B1E1 /* Timeline.TimelineView.swift in Sources */,
 				6432857C2925443C00FBE5C8 /* GroupPreferencesView.swift in Sources */,
 				5C93293129239BED0090FFF9 /* ProtocolServerView.swift in Sources */,
 				5C9CC7AD28C55D7800BEF955 /* DatabaseEncryptionView.swift in Sources */,
@@ -1180,10 +1242,13 @@
 				64D0C2C629FAC1EC00B38D5F /* AddContactLearnMore.swift in Sources */,
 				5C3A88D127DF57800060F1C2 /* FramedItemView.swift in Sources */,
 				5C65F343297D45E100B67AF3 /* VersionView.swift in Sources */,
+				CEDC28BF2C260B8100B1B1E1 /* Timeline.swift in Sources */,
 				64F1CC3B28B39D8600CD1FB1 /* IncognitoHelp.swift in Sources */,
 				5CB0BA90282713D900B3292C /* SimpleXInfo.swift in Sources */,
 				5C063D2727A4564100AEC577 /* ChatPreviewView.swift in Sources */,
 				5CC868F329EB540C0017BBFD /* CIRcvDecryptionError.swift in Sources */,
+				CEDC28AB2C260B5900B1B1E1 /* ChatItemMenu.swift in Sources */,
+				CEDC28BB2C260B8100B1B1E1 /* Timeline.AlignmentContainer.swift in Sources */,
 				5C35CFCB27B2E91D00FB6C6D /* NtfManager.swift in Sources */,
 				5C9D13A3282187BB00AB8B43 /* WebRTC.swift in Sources */,
 				5C9A5BDB2871E05400A5B906 /* SetNotificationsMode.swift in Sources */,
@@ -1194,6 +1259,7 @@
 				5C9FD96E27A5D6ED0075386C /* SendMessageView.swift in Sources */,
 				5CA7DFC329302AF000F7FDDE /* AppSheet.swift in Sources */,
 				64E972072881BB22008DBC02 /* CIGroupInvitationView.swift in Sources */,
+				CEDC28AA2C260B5900B1B1E1 /* ChatItemMenu.Allowed.swift in Sources */,
 				5CC1C99227A6C7F5000D9FF6 /* QRCode.swift in Sources */,
 				5C116CDC27AABE0400E66D01 /* ContactRequestView.swift in Sources */,
 				5CB9250D27A9432000ACCCDD /* ChatListNavLink.swift in Sources */,
@@ -1203,11 +1269,14 @@
 				640417CD2B29B8C200CCB412 /* NewChatMenuButton.swift in Sources */,
 				5CFE0921282EEAF60002594B /* ZoomableScrollView.swift in Sources */,
 				5C3A88CE27DF50170060F1C2 /* DetermineWidth.swift in Sources */,
+				CEDC28BE2C260B8100B1B1E1 /* Timeline.Sheet.swift in Sources */,
 				5C7505A527B679EE00BE3227 /* NavLinkPlain.swift in Sources */,
 				5C58BCD6292BEBE600AF9E4F /* CIChatFeatureView.swift in Sources */,
 				5CB346E72868D76D001FD2EF /* NotificationsView.swift in Sources */,
 				647F090E288EA27B00644C40 /* GroupMemberInfoView.swift in Sources */,
+				CEDC28B22C260B7900B1B1E1 /* ReverseList.swift in Sources */,
 				646BB38E283FDB6D001CE359 /* LocalAuthenticationUtils.swift in Sources */,
+				CEDC28B02C260B7900B1B1E1 /* ReverseList.Controller.swift in Sources */,
 				5C7505A227B65FDB00BE3227 /* CIMetaView.swift in Sources */,
 				5CEBD7462A5C0A8F00665FE2 /* KeyboardPadding.swift in Sources */,
 				5C35CFC827B2782E00FB6C6D /* BGManager.swift in Sources */,
@@ -1217,6 +1286,7 @@
 				5C2E260B27A30CFA00F70299 /* ChatListView.swift in Sources */,
 				6442E0BA287F169300CEC0F9 /* AddGroupView.swift in Sources */,
 				5CF937232B2503D000E1D781 /* NSESubscriber.swift in Sources */,
+				CEDC28BD2C260B8100B1B1E1 /* Timeline.ItemView.swift in Sources */,
 				6419EC582AB97507004A607A /* CIMemberCreatedContactView.swift in Sources */,
 				64D0C2C229FA57AB00B38D5F /* UserAddressLearnMore.swift in Sources */,
 				64466DCC29FFE3E800E3D48D /* MailView.swift in Sources */,
@@ -1239,6 +1309,8 @@
 				5CFA59D12864782E00863A68 /* ChatArchiveView.swift in Sources */,
 				649BCDA22805D6EF00C3A862 /* CIImageView.swift in Sources */,
 				8C05382E2B39887E006436DC /* VideoUtils.swift in Sources */,
+				CEDC28B12C260B7900B1B1E1 /* ReverseList.HostingCell.swift in Sources */,
+				CEDC28BC2C260B8100B1B1E1 /* Timeline.Item.swift in Sources */,
 				5CADE79C292131E900072E13 /* ContactPreferencesView.swift in Sources */,
 				5CB346E52868AA7F001FD2EF /* SuspendChat.swift in Sources */,
 				5C9C2DA52894777E00CC63B1 /* GroupProfileView.swift in Sources */,

--- a/apps/ios/SimpleXChat/ChatTypes.swift
+++ b/apps/ios/SimpleXChat/ChatTypes.swift
@@ -2625,6 +2625,13 @@ public enum CIDirection: Decodable {
             }
         }
     }
+
+    public var groupMember: GroupMember? {
+        switch self {
+        case let .groupRcv(groupMember): groupMember
+        default: nil
+        }
+    }
 }
 
 public struct CIMeta: Decodable {


### PR DESCRIPTION
Part of `Timeline` feature:

1. [Hashable Conformance](https://github.com/simplex-chat/simplex-chat/pull/4348)
2. [Views](https://github.com/simplex-chat/simplex-chat/pull/4350)
3. [Integration](https://github.com/simplex-chat/simplex-chat/pull/4351)

## Motivation

The current timeline implementation has high CPU and battery usage during scrolling,
which can result in dropped frames.
This is especially evident:

- In [Low Power Mode](https://support.apple.com/en-us/101604)
- On an Older Device (The app still supports [1st gen iPhone SE](https://en.wikipedia.org/wiki/IPhone_SE_(1st_generation)))
- When ChatItems include media or files

There are two main causes:

### 1. State Management

The current cell dequeuing implementation causes the whole view hierarchy to be reevaluated, for every loaded cell. 
While SwiftUI will reuse the underlying views, it still needs to recompute `body` of all of the views for diffing. 
This can be observed, by setting a random colour as cell background. 
Notice, how (on the left side) every cell changes colour, when a new one comes into the view:

https://github.com/simplex-chat/simplex-chat/assets/28978251/41f3434b-8662-4e89-8275-d0dcbb61f0ee

### 2. Chat Item Merging

The app will merge similar `ChatItem`s. 
Current implementation will still render a zero width cell with an [empty ZStack](https://github.com/simplex-chat/simplex-chat/blob/85dc467f74a46b88112bcb20a2b909eb82846923/apps/ios/Shared/Views/Chat/ChatView.swift#L560). 
This means - when there are many merged items, 
the app will have to process all of the zero height cells at once causing a lag spike.

## Implementation

### Solving State Management

The first issue is addressed, by replacing custom cell dequeuing with standard [UITableViewController](https://developer.apple.com/documentation/uikit/uitableviewcontroller) paired with [UIHostingConfiguration](https://developer.apple.com/documentation/SwiftUI/UIHostingConfiguration). This approach facilitates good performance and additional flexibility, 
while still reusing existing SwiftUI views for rendering `ChatItem`s.

Unfortunately, this approach is not compatible with existing `UIKit` backed context menu,
which increases scope of this PR. 
However, I believe - the additional stability and ease of iteration should offset
the cost of reimplementing the context menu in SwiftUI.

### Solving Item Merging

The second issue can be solved by adding an additional layer of `Timeline.Item` abstraction,
which handles the relationship between cells and chat items. 
`Timeline.Item` represents a single timeline cell, which contains at least one `ChatItem` 
with any additional chat items, which have been merged together.

Additionally this approach allows us to have required data available in a single structure,
and avoid index calculations, which can be error prone.

## Regressions

While the solution is working great, there are few features that might be better solved separately:

- Media Previews are too large
In SwiftUI views are expected to determine their own size, given parent views [ProposeViewSize](https://developer.apple.com/documentation/swiftui/proposedviewsize), 
so the current approach with passing `maxWidth` trough the view hierarchy won't work.
While this is a fairly straight forward task (since we don't need to use UIKit context menu anymore),
I think it would be better solved in a separate PR, as to not increase the scope even further.

- Simpler "scroll to unread" button
The new implementation does not distinguish between unread items above or below visible cells, 
and simply scrolls to the oldest unread item.
There is some additional complexity in making this work, 
so it could be done together with implementing non-contiguous timeline 
(a.k.a. jumping chat items, that have not been yet loaded)

Let me know.

## Result

Heres a demo of two iPhone 12mini's side-by-side:

https://github.com/simplex-chat/simplex-chat/assets/28978251/82cfe3e0-d3da-4dd6-9962-774b8c788f68

