### PR TITLE
ios: UI to translate chat messages

### DIFF
--- a/apps/ios/Shared/Views/Chat/ChatView.swift
+++ b/apps/ios/Shared/Views/Chat/ChatView.swift
@@ -839,7 +839,7 @@ struct ChatView: View {
                     shareButton(ci)
                     copyButton(ci)
                 }
-                if mc.isText {
+                if !mc.text.isEmpty {
                     translateButton(text: mc.text)
                 }
                 if let fileSource = fileSource, fileExists {

--- a/apps/ios/Shared/Views/Chat/ChatView.swift
+++ b/apps/ios/Shared/Views/Chat/ChatView.swift
@@ -611,6 +611,7 @@ struct ChatView: View {
         @State private var showChatItemInfoSheet: Bool = false
         @State private var chatItemInfo: ChatItemInfo?
         @State private var showForwardingSheet: Bool = false
+        @State private var translateText: String?
 
         @State private var allowMenu: Bool = true
 
@@ -781,6 +782,7 @@ struct ChatView: View {
                         ChatItemForwardingView(ci: ci, fromChatInfo: chat.chatInfo, composeState: $composeState)
                     }
                 }
+                .translateSheet(text: $translateText)
         }
 
         private func showMemberImage(_ member: GroupMember, _ prevItem: ChatItem?) -> Bool {
@@ -836,6 +838,9 @@ struct ChatView: View {
                 if copyAndShareAllowed {
                     shareButton(ci)
                     copyButton(ci)
+                }
+                if mc.isText {
+                    translateButton(text: mc.text)
                 }
                 if let fileSource = fileSource, fileExists {
                     if case .image = ci.content.msgContent, let image = getLoadedImage(ci.file) {
@@ -1014,6 +1019,17 @@ struct ChatView: View {
                 }
             } label: {
                 Label("Copy", systemImage: "doc.on.doc")
+            }
+        }
+
+        private func translateButton(text: String) -> Button<some View> {
+            Button {
+                translateText = text
+            } label: {
+                Label(
+                    NSLocalizedString("Translate", comment: "chat item action"),
+                    systemImage: "globe"
+                )
             }
         }
 

--- a/apps/ios/Shared/Views/Chat/ChatView.swift
+++ b/apps/ios/Shared/Views/Chat/ChatView.swift
@@ -1028,7 +1028,7 @@ struct ChatView: View {
             } label: {
                 Label(
                     NSLocalizedString("Translate", comment: "chat item action"),
-                    systemImage: "globe"
+                    systemImage: "character"
                 )
             }
         }

--- a/apps/ios/Shared/Views/Helpers/TranslateSheet.swift
+++ b/apps/ios/Shared/Views/Helpers/TranslateSheet.swift
@@ -1,0 +1,26 @@
+//
+//  TranslateSheet.swift
+//  SimpleX (iOS)
+//
+//  Created by Levitating Pineapple on 03/07/2024.
+//  Copyright © 2024 SimpleX Chat. All rights reserved.
+//
+
+import SwiftUI
+import Translation
+
+extension View {
+    @ViewBuilder func translateSheet(text: Binding<String?>) -> some View {
+        if #available(iOS 17.4, *) {
+            translationPresentation(
+                isPresented: Binding(
+                    get: { text.wrappedValue != nil },
+                    set: { if !$0 { text.wrappedValue = nil } }
+                ),
+                text: text.wrappedValue ?? String()
+            )
+        } else {
+            self
+        }
+    }
+}

--- a/apps/ios/SimpleX.xcodeproj/project.pbxproj
+++ b/apps/ios/SimpleX.xcodeproj/project.pbxproj
@@ -185,6 +185,7 @@
 		8C81482C2BD91CD4002CBEC3 /* AudioDevicePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C81482B2BD91CD4002CBEC3 /* AudioDevicePicker.swift */; };
 		8CC4ED902BD7B8530078AEE8 /* CallAudioDeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC4ED8F2BD7B8530078AEE8 /* CallAudioDeviceManager.swift */; };
 		8CC956EE2BC0041000412A11 /* NetworkObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC956ED2BC0041000412A11 /* NetworkObserver.swift */; };
+		CE81DF912C355E3C001C0A02 /* TranslateSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE81DF902C355E3C001C0A02 /* TranslateSheet.swift */; };
 		CEEA861D2C2ABCB50084E1EA /* ReverseList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEA861C2C2ABCB50084E1EA /* ReverseList.swift */; };
 		D7197A1829AE89660055C05A /* WebRTC in Frameworks */ = {isa = PBXBuildFile; productRef = D7197A1729AE89660055C05A /* WebRTC */; };
 		D72A9088294BD7A70047C86D /* NativeTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D72A9087294BD7A70047C86D /* NativeTextEditor.swift */; };
@@ -482,6 +483,7 @@
 		8C81482B2BD91CD4002CBEC3 /* AudioDevicePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDevicePicker.swift; sourceTree = "<group>"; };
 		8CC4ED8F2BD7B8530078AEE8 /* CallAudioDeviceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallAudioDeviceManager.swift; sourceTree = "<group>"; };
 		8CC956ED2BC0041000412A11 /* NetworkObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkObserver.swift; sourceTree = "<group>"; };
+		CE81DF902C355E3C001C0A02 /* TranslateSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslateSheet.swift; sourceTree = "<group>"; };
 		CEEA861C2C2ABCB50084E1EA /* ReverseList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReverseList.swift; sourceTree = "<group>"; };
 		D72A9087294BD7A70047C86D /* NativeTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeTextEditor.swift; sourceTree = "<group>"; };
 		D741547729AF89AF0022400A /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS16.1.sdk/System/Library/Frameworks/StoreKit.framework; sourceTree = DEVELOPER_DIR; };
@@ -660,6 +662,7 @@
 				64C3B0202A0D359700E19930 /* CustomTimePicker.swift */,
 				5CEBD7452A5C0A8F00665FE2 /* KeyboardPadding.swift */,
 				8C05382D2B39887E006436DC /* VideoUtils.swift */,
+				CE81DF902C355E3C001C0A02 /* TranslateSheet.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1138,6 +1141,7 @@
 				64C06EB52A0A4A7C00792D4D /* ChatItemInfoView.swift in Sources */,
 				640417CE2B29B8C200CCB412 /* NewChatView.swift in Sources */,
 				6440CA03288AECA70062C672 /* AddGroupMembersView.swift in Sources */,
+				CE81DF912C355E3C001C0A02 /* TranslateSheet.swift in Sources */,
 				5C3F1D58284363C400EC8A82 /* PrivacySettings.swift in Sources */,
 				5C55A923283CEDE600C4E99E /* SoundPlayer.swift in Sources */,
 				5C93292F29239A170090FFF9 /* ProtocolServersView.swift in Sources */,


### PR DESCRIPTION
# Contents

Adds translate sheet to chat item menu.

# Privacy Considerations

While iOS has on-device translation, it is not enabled by default.
On initial use the OS will present a popup, informing user that text for translation will be sent to apple.
We might consider additional prompt, informing that on-device translation can be enabled in:
`Settings -> Translate -> On-Device Mode`

# Screenshots

https://github.com/simplex-chat/simplex-chat/assets/28978251/fc98bfed-edf7-44f5-8ff6-cf4ecbb77381

<img src="https://github.com/simplex-chat/simplex-chat/assets/28978251/7d20352d-4dc2-4eb1-bc34-16cecb9e1a5a" width="360">
