### PR TITLE
ios: make theme wallpaper visible on iOS15, further improve scrolling

### DIFF
--- a/apps/ios/Shared/Model/ChatModel.swift
+++ b/apps/ios/Shared/Model/ChatModel.swift
@@ -702,7 +702,7 @@ final class ChatModel: ObservableObject {
             }
             i += 1
         }
-        return UnreadChatItemCounts(totalBelow: totalBelow, unreadBelow: unreadBelow)
+        return UnreadChatItemCounts(isNearBottom: totalBelow < 16, unreadBelow: unreadBelow)
     }
 
     func topItemInView(itemsInView: Set<String>) -> ChatItem? {
@@ -740,7 +740,7 @@ struct NTFContactRequest {
 }
 
 struct UnreadChatItemCounts: Equatable {
-    var totalBelow: Int
+    var isNearBottom: Bool
     var unreadBelow: Int
 }
 

--- a/apps/ios/Shared/Views/Chat/ChatView.swift
+++ b/apps/ios/Shared/Views/Chat/ChatView.swift
@@ -410,7 +410,7 @@ struct ChatView: View {
 
         init() {
             unreadChatItemCounts = UnreadChatItemCounts(
-                totalBelow: .zero,
+                isNearBottom: true,
                 unreadBelow: .zero
             )
             events
@@ -425,9 +425,9 @@ struct ChatView: View {
                         itemsInView
                     }
                 }
-                .throttle(for: .seconds(0.2), scheduler: DispatchQueue.main, latest: true)
                 .map { ChatModel.shared.unreadChatItemCounts(itemsInView: $0) }
                 .removeDuplicates()
+                .throttle(for: .seconds(0.2), scheduler: DispatchQueue.main, latest: true)
                 .assign(to: \.unreadChatItemCounts, on: self)
                 .store(in: &bag)
         }
@@ -479,7 +479,7 @@ struct ChatView: View {
                         scrollModel.scrollToItem(id: latestUnreadItem.id)
                     }
                 }
-            } else if counts.totalBelow > 16 {
+            } else if !counts.isNearBottom {
                 circleButton {
                     Image(systemName: "chevron.down")
                         .foregroundColor(theme.colors.primary)

--- a/apps/ios/Shared/Views/Chat/ReverseList.swift
+++ b/apps/ios/Shared/Views/Chat/ReverseList.swift
@@ -181,6 +181,7 @@ struct ReverseList<Item: Identifiable & Hashable & Sendable, Content: View>: UIV
         /// Updates content of the cell
         /// For reference: https://noahgilmore.com/blog/swiftui-self-sizing-cells/
         func set(content: Hosted, parent: UIViewController) {
+            hostingController.view.backgroundColor = .clear
             hostingController.rootView = content
             if let hostingView = hostingController.view {
                 hostingView.invalidateIntrinsicContentSize()


### PR DESCRIPTION
Small fixes after additional testing iOS15 after theme merge:
- Makes the background clear - so theme wallpapers are visible
- Reduces redundant chatView calculations