### PR TITLE
ios: optimise mark-as-read performance

### DIFF
--- a/apps/ios/Shared/Model/ChatModel.swift
+++ b/apps/ios/Shared/Model/ChatModel.swift
@@ -73,6 +73,7 @@ final class ChatModel: ObservableObject {
     var chatItemStatuses: Dictionary<Int64, CIStatus> = [:]
     @Published var chatToTop: String?
     @Published var groupMembers: [GMember] = []
+    @Published var membersLoaded = false
     // items in the terminal view
     @Published var showingTerminal = false
     @Published var terminalItems: [TerminalItem] = []
@@ -182,6 +183,17 @@ final class ChatModel: ObservableObject {
 
     func getGroupMember(_ groupMemberId: Int64) -> GMember? {
         groupMembers.first { $0.groupMemberId == groupMemberId }
+    }
+
+    func loadGroupMembers(_ groupInfo: GroupInfo, updateView: @escaping () -> Void = {}) async {
+        let groupMembers = await apiListMembers(groupInfo.groupId)
+        await MainActor.run {
+            if chatId == groupInfo.id {
+                self.groupMembers = groupMembers.map { GMember.init($0) }
+                self.membersLoaded = true
+                updateView()
+            }
+        }
     }
 
     private func getChatIndex(_ id: String) -> Int? {
@@ -379,8 +391,8 @@ final class ChatModel: ObservableObject {
     }
 
     func removeChatItem(_ cInfo: ChatInfo, _ cItem: ChatItem) {
-        if cItem.isRcvNew {
-            decreaseUnreadCounter(cInfo)
+        if cItem.isRcvNew, let chatIndex = getChatIndex(cInfo.id) {
+            decreaseUnreadCounter(chatIndex)
         }
         // update previews
         if let chat = getChat(cInfo.id) {
@@ -525,13 +537,18 @@ final class ChatModel: ObservableObject {
         }
     }
 
-    func markChatItemRead(_ cInfo: ChatInfo, _ cItem: ChatItem) {
-        if chatId == cInfo.id, let i = getChatItemIndex(cItem) {
-            if reversedChatItems[i].isRcvNew {
-                // update current chat
-                markChatItemRead_(i)
-                // update preview
-                decreaseUnreadCounter(cInfo)
+    func markChatItemRead(_ cInfo: ChatInfo, _ cItem: ChatItem) async {
+        if chatId == cInfo.id,
+           let itemIndex = getChatItemIndex(cItem),
+           let chatIndex = getChatIndex(cInfo.id),
+           reversedChatItems[itemIndex].isRcvNew {
+            await MainActor.run {
+                withTransaction(Transaction()) {
+                    // update current chat
+                    markChatItemRead_(itemIndex)
+                    // update preview
+                    decreaseUnreadCounter(chatIndex)
+                }
             }
         }
     }
@@ -547,11 +564,9 @@ final class ChatModel: ObservableObject {
         }
     }
 
-    func decreaseUnreadCounter(_ cInfo: ChatInfo) {
-        if let i = getChatIndex(cInfo.id) {
-            chats[i].chatStats.unreadCount = chats[i].chatStats.unreadCount - 1
-            decreaseUnreadCounter(user: currentUser!)
-        }
+    func decreaseUnreadCounter(_ chatIndex: Int) {
+        chats[chatIndex].chatStats.unreadCount = chats[chatIndex].chatStats.unreadCount - 1
+        decreaseUnreadCounter(user: currentUser!)
     }
 
     func increaseUnreadCounter(user: any UserLike) {

--- a/apps/ios/Shared/Model/ChatModel.swift
+++ b/apps/ios/Shared/Model/ChatModel.swift
@@ -201,6 +201,7 @@ final class ChatModel: ObservableObject {
         await MainActor.run {
             if chatId == groupInfo.id {
                 self.groupMembers = groupMembers.map { GMember.init($0) }
+                self.populateGroupMembersIndexes()
                 self.membersLoaded = true
                 updateView()
             }

--- a/apps/ios/Shared/Model/SimpleXAPI.swift
+++ b/apps/ios/Shared/Model/SimpleXAPI.swift
@@ -1207,7 +1207,7 @@ func apiMarkChatItemRead(_ cInfo: ChatInfo, _ cItem: ChatItem) async {
     do {
         logger.debug("apiMarkChatItemRead: \(cItem.id)")
         try await apiChatRead(type: cInfo.chatType, id: cInfo.apiId, itemRange: (cItem.id, cItem.id))
-        await MainActor.run { ChatModel.shared.markChatItemRead(cInfo, cItem) }
+        await ChatModel.shared.markChatItemRead(cInfo, cItem)
     } catch {
         logger.error("apiMarkChatItemRead apiChatRead error: \(responseError(error))")
     }

--- a/apps/ios/Shared/Views/Chat/ChatView.swift
+++ b/apps/ios/Shared/Views/Chat/ChatView.swift
@@ -597,10 +597,10 @@ struct ChatView: View {
 
     private struct ChatItemWithMenu: View {
         let m = ChatModel.shared
-        let chat: Chat
+        @EnvironmentObject var theme: AppTheme
+        @ObservedObject var chat: Chat
         let chatItem: ChatItem
         let maxWidth: CGFloat
-        @EnvironmentObject var theme: AppTheme
         @Binding var composeState: ComposeState
         @Binding var selectedMember: GMember?
         @Binding var revealedChatItem: ChatItem?

--- a/apps/ios/Shared/Views/Chat/ChatView.swift
+++ b/apps/ios/Shared/Views/Chat/ChatView.swift
@@ -249,22 +249,7 @@ struct ChatView: View {
             }
         }
     }
-
-<<<<<<< HEAD
-=======
-    private func loadGroupMembers(_ groupInfo: GroupInfo, updateView: @escaping () -> Void = {}) async {
-        let groupMembers = await apiListMembers(groupInfo.groupId)
-        await MainActor.run {
-            if chatModel.chatId == groupInfo.id {
-                chatModel.groupMembers = groupMembers.map { GMember.init($0) }
-                chatModel.populateGroupMembersIndexes()
-                membersLoaded = true
-                updateView()
-            }
-        }
-    }
-
->>>>>>> master
+    
     private func initChatView() {
         let cInfo = chat.chatInfo
         // This check prevents the call to apiContactInfo after the app is suspended, and the database is closed.

--- a/apps/ios/Shared/Views/Chat/ChatView.swift
+++ b/apps/ios/Shared/Views/Chat/ChatView.swift
@@ -596,7 +596,7 @@ struct ChatView: View {
     }
 
     private struct ChatItemWithMenu: View {
-        let m = ChatModel.shared
+        @EnvironmentObject var m: ChatModel
         @EnvironmentObject var theme: AppTheme
         @ObservedObject var chat: Chat
         let chatItem: ChatItem


### PR DESCRIPTION
This PR includes two optimisations that improve the performance when marking items as read:

1. Precalculate indices, which is `O(n)` operation on a background thread.
2. Remove unnecessary `@State`, from `ChatItemWithMenu` what was causing additional `body` re-evaluations.
3. Remove `chatView` reference, because structs are passed as copy - so we where essentially creating a copy of `ChatView` for each loaded `ChatItemWithMenu` view.

* Also revert the scroll to bottom behaviour to always scroll till the end of the list.
