### PR TITLE
ios: make image utilities accessible from extensions

### DIFF
--- a/apps/ios/Shared/Theme/Theme.swift
+++ b/apps/ios/Shared/Theme/Theme.swift
@@ -102,8 +102,7 @@ extension ThemeWallpaper {
     public func importFromString() -> ThemeWallpaper {
         if preset == nil, let image {
             // Need to save image from string and to save its path
-            if let data = Data(base64Encoded: dropImagePrefix(image)),
-               let parsed = UIImage(data: data),
+            if let parsed = UIImage(imageString: image),
                let filename = saveWallpaperFile(image: parsed) {
                 var copy = self
                 copy.image = nil

--- a/apps/ios/Shared/Views/Chat/ChatItem/CILinkView.swift
+++ b/apps/ios/Shared/Views/Chat/ChatItem/CILinkView.swift
@@ -15,8 +15,7 @@ struct CILinkView: View {
 
     var body: some View {
         VStack(alignment: .center, spacing: 6) {
-            if let data = Data(base64Encoded: dropImagePrefix(linkPreview.image)),
-               let uiImage = UIImage(data: data) {
+            if let uiImage = UIImage(imageString: linkPreview.image) {
                 Image(uiImage: uiImage)
                     .resizable()
                     .scaledToFit()

--- a/apps/ios/Shared/Views/Chat/ChatItem/FramedItemView.swift
+++ b/apps/ios/Shared/Views/Chat/ChatItem/FramedItemView.swift
@@ -188,8 +188,7 @@ struct FramedItemView: View {
         let v = ZStack(alignment: .topTrailing) {
             switch (qi.content) {
             case let .image(_, image):
-                if let data = Data(base64Encoded: dropImagePrefix(image)),
-                   let uiImage = UIImage(data: data) {
+                if let uiImage = UIImage(imageString: image) {
                     ciQuotedMsgView(qi)
                         .padding(.trailing, 70).frame(minWidth: msgWidth, alignment: .leading)
                     Image(uiImage: uiImage)
@@ -201,8 +200,7 @@ struct FramedItemView: View {
                     ciQuotedMsgView(qi)
                 }
             case let .video(_, image, _):
-                if let data = Data(base64Encoded: dropImagePrefix(image)),
-                   let uiImage = UIImage(data: data) {
+                if let uiImage = UIImage(imageString: image) {
                     ciQuotedMsgView(qi)
                     .padding(.trailing, 70).frame(minWidth: msgWidth, alignment: .leading)
                     Image(uiImage: uiImage)

--- a/apps/ios/Shared/Views/Chat/ChatItemView.swift
+++ b/apps/ios/Shared/Views/Chat/ChatItemView.swift
@@ -68,9 +68,7 @@ struct ChatItemView: View {
                 default: nil
                 }
             }
-            .map { dropImagePrefix($0) }
-            .flatMap { Data(base64Encoded: $0) }
-            .flatMap { UIImage(data: $0) }
+            .flatMap { UIImage(imageString: $0) }
         let adjustedMaxWidth = {
             if let preview, preview.size.width <= preview.size.height {
                 maxWidth * 0.75

--- a/apps/ios/Shared/Views/Chat/ComposeMessage/ComposeImageView.swift
+++ b/apps/ios/Shared/Views/Chat/ComposeMessage/ComposeImageView.swift
@@ -18,10 +18,7 @@ struct ComposeImageView: View {
     var body: some View {
         HStack(alignment: .center, spacing: 8) {
             let imgs: [UIImage] = images.compactMap { image in
-                if let data = Data(base64Encoded: dropImagePrefix(image)) {
-                    return UIImage(data: data)
-                }
-                return nil
+                UIImage(imageString: image)
             }
             if imgs.count == 0 {
                 ProgressView()

--- a/apps/ios/Shared/Views/Chat/ComposeMessage/ComposeLinkView.swift
+++ b/apps/ios/Shared/Views/Chat/ComposeMessage/ComposeLinkView.swift
@@ -69,8 +69,7 @@ struct ComposeLinkView: View {
 
     private func linkPreviewView(_ linkPreview: LinkPreview) -> some View {
         HStack(alignment: .center, spacing: 8) {
-            if let data = Data(base64Encoded: dropImagePrefix(linkPreview.image)),
-               let uiImage = UIImage(data: data) {
+            if let uiImage = UIImage(imageString: linkPreview.image) {
                 Image(uiImage: uiImage)
                     .resizable()
                     .aspectRatio(contentMode: .fit)

--- a/apps/ios/Shared/Views/Chat/ComposeMessage/ComposeView.swift
+++ b/apps/ios/Shared/Views/Chat/ComposeMessage/ComposeView.swift
@@ -849,6 +849,7 @@ struct ComposeView: View {
         func sendVideo(_ imageData: (String, UploadContent?), text: String = "", quoted: Int64? = nil, live: Bool = false, ttl: Int?) async -> ChatItem? {
             let (image, data) = imageData
             if case let .video(_, url, duration) = data, let savedFile = moveTempFileFromURL(url) {
+                ChatModel.shared.filesToDelete.remove(url)
                 return await send(.video(text: text, image: image, duration: duration), quoted: quoted, file: savedFile, live: live, ttl: ttl)
             }
             return nil

--- a/apps/ios/Shared/Views/Helpers/ProfileImage.swift
+++ b/apps/ios/Shared/Views/Helpers/ProfileImage.swift
@@ -21,9 +21,7 @@ struct ProfileImage: View {
     @AppStorage(DEFAULT_PROFILE_IMAGE_CORNER_RADIUS) private var radius = defaultProfileImageCorner
 
     var body: some View {
-        if let image = imageStr,
-           let data = Data(base64Encoded: dropImagePrefix(image)),
-           let uiImage = UIImage(data: data) {
+        if let uiImage = UIImage(imageString: imageStr) {
             clipProfileImage(Image(uiImage: uiImage), size: size, radius: radius)
         } else {
             let c = color.asAnotherColorFromSecondaryVariant(theme)

--- a/apps/ios/SimpleX.xcodeproj/project.pbxproj
+++ b/apps/ios/SimpleX.xcodeproj/project.pbxproj
@@ -100,7 +100,6 @@
 		5CB924D727A8563F00ACCCDD /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB924D627A8563F00ACCCDD /* SettingsView.swift */; };
 		5CB924E127A867BA00ACCCDD /* UserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB924E027A867BA00ACCCDD /* UserProfile.swift */; };
 		5CB9250D27A9432000ACCCDD /* ChatListNavLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB9250C27A9432000ACCCDD /* ChatListNavLink.swift */; };
-		5CBD285A295711D700EC2CF4 /* ImageUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CBD2859295711D700EC2CF4 /* ImageUtils.swift */; };
 		5CBD285C29575B8E00EC2CF4 /* WhatsNewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CBD285B29575B8E00EC2CF4 /* WhatsNewView.swift */; };
 		5CBE6C12294487F7002D9531 /* VerifyCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CBE6C11294487F7002D9531 /* VerifyCodeView.swift */; };
 		5CBE6C142944CC12002D9531 /* ScanCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CBE6C132944CC12002D9531 /* ScanCodeView.swift */; };
@@ -195,6 +194,8 @@
 		8C9BC2652C240D5200875A27 /* ThemeModeEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C9BC2642C240D5100875A27 /* ThemeModeEditor.swift */; };
 		8CC4ED902BD7B8530078AEE8 /* CallAudioDeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC4ED8F2BD7B8530078AEE8 /* CallAudioDeviceManager.swift */; };
 		8CC956EE2BC0041000412A11 /* NetworkObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC956ED2BC0041000412A11 /* NetworkObserver.swift */; };
+		CE38A29A2C3FCA54005ED185 /* ImageUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CBD2859295711D700EC2CF4 /* ImageUtils.swift */; };
+		CE38A29C2C3FCD72005ED185 /* SwiftyGif in Frameworks */ = {isa = PBXBuildFile; productRef = CE38A29B2C3FCD72005ED185 /* SwiftyGif */; };
 		CE984D4B2C36C5D500E3AEFF /* ChatItemClipShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE984D4A2C36C5D500E3AEFF /* ChatItemClipShape.swift */; };
 		CEEA861D2C2ABCB50084E1EA /* ReverseList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEA861C2C2ABCB50084E1EA /* ReverseList.swift */; };
 		D7197A1829AE89660055C05A /* WebRTC in Frameworks */ = {isa = PBXBuildFile; productRef = D7197A1729AE89660055C05A /* WebRTC */; };
@@ -560,6 +561,7 @@
 				E50581022C3DDD7F009C3F71 /* libHSsimplex-chat-6.0.0.0-IhofDzGnTMcDdW5i3Fb7xN-ghc9.6.3.a in Frameworks */,
 				E50581062C3DDD9D009C3F71 /* Yams in Frameworks */,
 				E50581042C3DDD7F009C3F71 /* libHSsimplex-chat-6.0.0.0-IhofDzGnTMcDdW5i3Fb7xN.a in Frameworks */,
+				CE38A29C2C3FCD72005ED185 /* SwiftyGif in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -658,7 +660,6 @@
 				5CF937212B25034A00E1D781 /* NSESubscriber.swift */,
 				5CB346E82869E8BA001FD2EF /* PushEnvironment.swift */,
 				5C93293E2928E0FD0090FFF9 /* AudioRecPlay.swift */,
-				5CBD2859295711D700EC2CF4 /* ImageUtils.swift */,
 				8CC956ED2BC0041000412A11 /* NetworkObserver.swift */,
 			);
 			path = Model;
@@ -858,6 +859,7 @@
 				5C9FD96A27A56D4D0075386C /* JSON.swift */,
 				5CDCAD7D2818941F00503DA2 /* API.swift */,
 				5CDCAD80281A7E2700503DA2 /* Notifications.swift */,
+				5CBD2859295711D700EC2CF4 /* ImageUtils.swift */,
 				64DAE1502809D9F5000DA960 /* FileUtils.swift */,
 				5C9D81182AA7A4F1001D49FD /* CryptoFile.swift */,
 				5C00168028C4FE760094D739 /* KeyChain.swift */,
@@ -1068,6 +1070,7 @@
 			name = SimpleXChat;
 			packageProductDependencies = (
 				E50581052C3DDD9D009C3F71 /* Yams */,
+				CE38A29B2C3FCD72005ED185 /* SwiftyGif */,
 			);
 			productName = SimpleXChat;
 			productReference = 5CE2BA682845308900EC33A6 /* SimpleXChat.framework */;
@@ -1205,7 +1208,6 @@
 				6432857C2925443C00FBE5C8 /* GroupPreferencesView.swift in Sources */,
 				5C93293129239BED0090FFF9 /* ProtocolServerView.swift in Sources */,
 				5C9CC7AD28C55D7800BEF955 /* DatabaseEncryptionView.swift in Sources */,
-				5CBD285A295711D700EC2CF4 /* ImageUtils.swift in Sources */,
 				8C74C3EC2C1B92A900039E77 /* Theme.swift in Sources */,
 				6419EC562AB8BC8B004A607A /* ContextInvitingContactMemberView.swift in Sources */,
 				5CE4407927ADB701007B033A /* EmojiItemView.swift in Sources */,
@@ -1376,6 +1378,7 @@
 				5CE2BA90284533A300EC33A6 /* JSON.swift in Sources */,
 				5CE2BA8B284533A300EC33A6 /* ChatTypes.swift in Sources */,
 				5CE2BA8F284533A300EC33A6 /* APITypes.swift in Sources */,
+				CE38A29A2C3FCA54005ED185 /* ImageUtils.swift in Sources */,
 				5C9D811A2AA8727A001D49FD /* CryptoFile.swift in Sources */,
 				5CE2BA8C284533A300EC33A6 /* AppGroup.swift in Sources */,
 				8C74C3E52C1B900600039E77 /* ThemeTypes.swift in Sources */,
@@ -2022,6 +2025,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 8C73C1162C21E17B00892670 /* XCRemoteSwiftPackageReference "Yams" */;
 			productName = Yams;
+		};
+		CE38A29B2C3FCD72005ED185 /* SwiftyGif */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D77B92DA2952372200A5A1CC /* XCRemoteSwiftPackageReference "SwiftyGif" */;
+			productName = SwiftyGif;
 		};
 		D7197A1729AE89660055C05A /* WebRTC */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/apps/ios/SimpleXChat/ImageUtils.swift
+++ b/apps/ios/SimpleXChat/ImageUtils.swift
@@ -7,18 +7,18 @@
 //
 
 import Foundation
-import SimpleXChat
 import SwiftUI
 import AVKit
+import SwiftyGif
 
-func getLoadedFileSource(_ file: CIFile?) -> CryptoFile? {
+public func getLoadedFileSource(_ file: CIFile?) -> CryptoFile? {
     if let file = file, file.loaded {
         return file.fileSource
     }
     return nil
 }
 
-func getLoadedImage(_ file: CIFile?) -> UIImage? {
+public func getLoadedImage(_ file: CIFile?) -> UIImage? {
     if let fileSource = getLoadedFileSource(file) {
         let filePath = getAppFilePath(fileSource.filePath)
         do {
@@ -37,7 +37,7 @@ func getLoadedImage(_ file: CIFile?) -> UIImage? {
     return nil
 }
 
-func getFileData(_ path: URL, _ cfArgs: CryptoFileArgs?) throws -> Data {
+public func getFileData(_ path: URL, _ cfArgs: CryptoFileArgs?) throws -> Data {
     if let cfArgs = cfArgs {
         return try readCryptoFile(path: path.path, cryptoArgs: cfArgs)
     } else {
@@ -45,7 +45,7 @@ func getFileData(_ path: URL, _ cfArgs: CryptoFileArgs?) throws -> Data {
     }
 }
 
-func getLoadedVideo(_ file: CIFile?) -> URL? {
+public func getLoadedVideo(_ file: CIFile?) -> URL? {
     if let fileSource = getLoadedFileSource(file) {
         let filePath = getAppFilePath(fileSource.filePath)
         if FileManager.default.fileExists(atPath: filePath.path) {
@@ -55,13 +55,13 @@ func getLoadedVideo(_ file: CIFile?) -> URL? {
     return nil
 }
 
-func saveAnimImage(_ image: UIImage) -> CryptoFile? {
+public func saveAnimImage(_ image: UIImage) -> CryptoFile? {
     let fileName = generateNewFileName("IMG", "gif")
     guard let imageData = image.imageData else { return nil }
     return saveFile(imageData, fileName, encrypted: privacyEncryptLocalFilesGroupDefault.get())
 }
 
-func saveImage(_ uiImage: UIImage) -> CryptoFile? {
+public func saveImage(_ uiImage: UIImage) -> CryptoFile? {
     let hasAlpha = imageHasAlpha(uiImage)
     let ext = hasAlpha ? "png" : "jpg"
     if let imageDataResized = resizeImageToDataSize(uiImage, maxDataSize: MAX_IMAGE_SIZE, hasAlpha: hasAlpha) {
@@ -71,7 +71,7 @@ func saveImage(_ uiImage: UIImage) -> CryptoFile? {
     return nil
 }
 
-func cropToSquare(_ image: UIImage) -> UIImage {
+public func cropToSquare(_ image: UIImage) -> UIImage {
     let size = image.size
     let side = min(size.width, size.height)
     let newSize = CGSize(width: side, height: side)
@@ -84,7 +84,7 @@ func cropToSquare(_ image: UIImage) -> UIImage {
     return resizeImage(image, newBounds: CGRect(origin: .zero, size: newSize), drawIn: CGRect(origin: origin, size: size), hasAlpha: imageHasAlpha(image))
 }
 
-func resizeImageToDataSize(_ image: UIImage, maxDataSize: Int64, hasAlpha: Bool) -> Data? {
+public func resizeImageToDataSize(_ image: UIImage, maxDataSize: Int64, hasAlpha: Bool) -> Data? {
     var img = image
     var data = hasAlpha ? img.pngData() : img.jpegData(compressionQuality: 0.85)
     var dataSize = data?.count ?? 0
@@ -99,7 +99,7 @@ func resizeImageToDataSize(_ image: UIImage, maxDataSize: Int64, hasAlpha: Bool)
     return data
 }
 
-func resizeImageToStrSize(_ image: UIImage, maxDataSize: Int64) -> String? {
+public func resizeImageToStrSize(_ image: UIImage, maxDataSize: Int64) -> String? {
     var img = image
     let hasAlpha = imageHasAlpha(image)
     var str = compressImageStr(img, hasAlpha: hasAlpha)
@@ -115,7 +115,7 @@ func resizeImageToStrSize(_ image: UIImage, maxDataSize: Int64) -> String? {
     return str
 }
 
-func compressImageStr(_ image: UIImage, _ compressionQuality: CGFloat = 0.85, hasAlpha: Bool) -> String? {
+public func compressImageStr(_ image: UIImage, _ compressionQuality: CGFloat = 0.85, hasAlpha: Bool) -> String? {
     let ext = hasAlpha ? "png" : "jpg"
     if let data = hasAlpha ? image.pngData() : image.jpegData(compressionQuality: compressionQuality) {
         return "data:image/\(ext);base64,\(data.base64EncodedString())"
@@ -138,7 +138,7 @@ private func resizeImage(_ image: UIImage, newBounds: CGRect, drawIn: CGRect, ha
     }
 }
 
-func imageHasAlpha(_ img: UIImage) -> Bool {
+public func imageHasAlpha(_ img: UIImage) -> Bool {
     if let cgImage = img.cgImage {
         let colorSpace = CGColorSpaceCreateDeviceRGB()
         let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedFirst.rawValue)
@@ -158,7 +158,7 @@ func imageHasAlpha(_ img: UIImage) -> Bool {
     return false
 }
 
-func saveFileFromURL(_ url: URL) -> CryptoFile? {
+public func saveFileFromURL(_ url: URL) -> CryptoFile? {
     let encrypted = privacyEncryptLocalFilesGroupDefault.get()
     let savedFile: CryptoFile?
     if url.startAccessingSecurityScopedResource() {
@@ -184,7 +184,7 @@ func saveFileFromURL(_ url: URL) -> CryptoFile? {
     return savedFile
 }
 
-func moveTempFileFromURL(_ url: URL) -> CryptoFile? {
+public func moveTempFileFromURL(_ url: URL) -> CryptoFile? {
     do {
         let encrypted = privacyEncryptLocalFilesGroupDefault.get()
         let fileName = uniqueCombine(url.lastPathComponent)
@@ -197,7 +197,6 @@ func moveTempFileFromURL(_ url: URL) -> CryptoFile? {
             try FileManager.default.moveItem(at: url, to: getAppFilePath(fileName))
             savedFile = CryptoFile.plain(fileName)
         }
-        ChatModel.shared.filesToDelete.remove(url)
         return savedFile
     } catch {
         logger.error("ImageUtils.moveTempFileFromURL error: \(error.localizedDescription)")
@@ -205,7 +204,7 @@ func moveTempFileFromURL(_ url: URL) -> CryptoFile? {
     }
 }
 
-func saveWallpaperFile(url: URL) -> String? {
+public func saveWallpaperFile(url: URL) -> String? {
     let destFile = URL(fileURLWithPath: generateNewFileName(getWallpaperDirectory().path + "/" + "wallpaper", "jpg", fullPath: true))
     do {
         try FileManager.default.copyItem(atPath: url.path, toPath: destFile.path)
@@ -216,7 +215,7 @@ func saveWallpaperFile(url: URL) -> String? {
     }
 }
 
-func saveWallpaperFile(image: UIImage) -> String? {
+public func saveWallpaperFile(image: UIImage) -> String? {
     let hasAlpha = imageHasAlpha(image)
     let destFile = URL(fileURLWithPath: generateNewFileName(getWallpaperDirectory().path + "/" + "wallpaper", hasAlpha ? "png" : "jpg", fullPath: true))
     let dataResized = resizeImageToDataSize(image, maxDataSize: 5_000_000, hasAlpha: hasAlpha)
@@ -229,7 +228,7 @@ func saveWallpaperFile(image: UIImage) -> String? {
     }
 }
 
-func removeWallpaperFile(fileName: String? = nil) {
+public func removeWallpaperFile(fileName: String? = nil) {
     do {
         try FileManager.default.contentsOfDirectory(atPath: getWallpaperDirectory().path).forEach {
             if URL(fileURLWithPath: $0).lastPathComponent == fileName { try FileManager.default.removeItem(atPath: $0) }
@@ -242,7 +241,7 @@ func removeWallpaperFile(fileName: String? = nil) {
     }
 }
 
-func generateNewFileName(_ prefix: String, _ ext: String, fullPath: Bool = false) -> String {
+public func generateNewFileName(_ prefix: String, _ ext: String, fullPath: Bool = false) -> String {
     uniqueCombine("\(prefix)_\(getTimestamp()).\(ext)", fullPath: fullPath)
 }
 
@@ -274,7 +273,7 @@ private func getTimestamp() -> String {
     return df.string(from: Date())
 }
 
-func dropImagePrefix(_ s: String) -> String {
+public func dropImagePrefix(_ s: String) -> String {
     dropPrefix(dropPrefix(s, "data:image/png;base64,"), "data:image/jpg;base64,")
 }
 
@@ -283,7 +282,7 @@ private func dropPrefix(_ s: String, _ prefix: String) -> String {
 }
 
 extension AVAsset {
-    func generatePreview() -> (UIImage, Int)? {
+    public func generatePreview() -> (UIImage, Int)? {
         let generator = AVAssetImageGenerator(asset: self)
         generator.appliesPreferredTrackTransform = true
         var actualTime = CMTimeMake(value: 0, timescale: 0)
@@ -295,7 +294,7 @@ extension AVAsset {
 }
 
 extension UIImage {
-    func replaceColor(_ from: UIColor, _ to: UIColor) -> UIImage {
+    public func replaceColor(_ from: UIColor, _ to: UIColor) -> UIImage {
         if let cgImage = cgImage {
             let colorSpace = CGColorSpaceCreateDeviceRGB()
             let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedFirst.rawValue)
@@ -339,5 +338,13 @@ extension UIImage {
             }
         }
         return self
+    }
+
+    public convenience init?(imageString: String?) {
+        if let imageString, let data = Data(base64Encoded: dropImagePrefix(imageString)) {
+            self.init(data: data)
+        } else {
+            return nil
+        }
     }
 }


### PR DESCRIPTION
- Moves `ImageUtils` to the framework to allow access from extensions
- Adds convenience `intit` to create `UIImage` from base64 encoded string