### PR TITLE
cli: option to only use SOCKS5 proxy with onion-only relays

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -12,7 +12,7 @@ constraints: zip +disable-bzip2 +disable-zstd
 source-repository-package
     type: git
     location: https://github.com/simplex-chat/simplexmq.git
-    tag: 77878f98939cb28e059726b93fb59f347814b4c5
+    tag: 784d36d691381290e72884cc30c59ce646166134
 
 source-repository-package
     type: git

--- a/cabal.project
+++ b/cabal.project
@@ -12,7 +12,7 @@ constraints: zip +disable-bzip2 +disable-zstd
 source-repository-package
     type: git
     location: https://github.com/simplex-chat/simplexmq.git
-    tag: e56bd0b47b22781f9b5936e3b8a9d51cc3f9e8d5
+    tag: 77878f98939cb28e059726b93fb59f347814b4c5
 
 source-repository-package
     type: git

--- a/scripts/nix/sha256map.nix
+++ b/scripts/nix/sha256map.nix
@@ -1,5 +1,5 @@
 {
-  "https://github.com/simplex-chat/simplexmq.git"."77878f98939cb28e059726b93fb59f347814b4c5" = "0kwzlhmn6941ksbahpri4zlaxqrl7s6mxv3mf15w55jnxk5znrdw";
+  "https://github.com/simplex-chat/simplexmq.git"."784d36d691381290e72884cc30c59ce646166134" = "17qg39xfsn8fxajylpggxwb916013m1xgpz1kpd4qfy5rdpn6gp3";
   "https://github.com/simplex-chat/hs-socks.git"."a30cc7a79a08d8108316094f8f2f82a0c5e1ac51" = "0yasvnr7g91k76mjkamvzab2kvlb1g5pspjyjn2fr6v83swjhj38";
   "https://github.com/simplex-chat/direct-sqlcipher.git"."f814ee68b16a9447fbb467ccc8f29bdd3546bfd9" = "1ql13f4kfwkbaq7nygkxgw84213i0zm7c1a8hwvramayxl38dq5d";
   "https://github.com/simplex-chat/sqlcipher-simple.git"."a46bd361a19376c5211f1058908fc0ae6bf42446" = "1z0r78d8f0812kxbgsm735qf6xx8lvaz27k1a0b4a2m0sshpd5gl";

--- a/scripts/nix/sha256map.nix
+++ b/scripts/nix/sha256map.nix
@@ -1,5 +1,5 @@
 {
-  "https://github.com/simplex-chat/simplexmq.git"."e56bd0b47b22781f9b5936e3b8a9d51cc3f9e8d5" = "11ghsddgyrlnddxqvvb0xlqvnnhnnsbixz1kg01x3gd6vpdqkz47";
+  "https://github.com/simplex-chat/simplexmq.git"."77878f98939cb28e059726b93fb59f347814b4c5" = "0kwzlhmn6941ksbahpri4zlaxqrl7s6mxv3mf15w55jnxk5znrdw";
   "https://github.com/simplex-chat/hs-socks.git"."a30cc7a79a08d8108316094f8f2f82a0c5e1ac51" = "0yasvnr7g91k76mjkamvzab2kvlb1g5pspjyjn2fr6v83swjhj38";
   "https://github.com/simplex-chat/direct-sqlcipher.git"."f814ee68b16a9447fbb467ccc8f29bdd3546bfd9" = "1ql13f4kfwkbaq7nygkxgw84213i0zm7c1a8hwvramayxl38dq5d";
   "https://github.com/simplex-chat/sqlcipher-simple.git"."a46bd361a19376c5211f1058908fc0ae6bf42446" = "1z0r78d8f0812kxbgsm735qf6xx8lvaz27k1a0b4a2m0sshpd5gl";

--- a/src/Simplex/Chat/Controller.hs
+++ b/src/Simplex/Chat/Controller.hs
@@ -76,7 +76,7 @@ import Simplex.Messaging.Agent.Protocol
 import Simplex.Messaging.Agent.Store.SQLite (MigrationConfirmation, SQLiteStore, UpMigration, withTransaction)
 import Simplex.Messaging.Agent.Store.SQLite.DB (SlowQueryStats (..))
 import qualified Simplex.Messaging.Agent.Store.SQLite.DB as DB
-import Simplex.Messaging.Client (SMPProxyFallback (..), SMPProxyMode (..))
+import Simplex.Messaging.Client (SMPProxyFallback (..), SMPProxyMode (..), SocksMode (..))
 import qualified Simplex.Messaging.Crypto as C
 import Simplex.Messaging.Crypto.File (CryptoFile (..))
 import qualified Simplex.Messaging.Crypto.File as CF
@@ -966,6 +966,7 @@ data AppFilePathsConfig = AppFilePathsConfig
 
 data SimpleNetCfg = SimpleNetCfg
   { socksProxy :: Maybe SocksProxy,
+    socksMode :: SocksMode,
     smpProxyMode_ :: Maybe SMPProxyMode,
     smpProxyFallback_ :: Maybe SMPProxyFallback,
     tcpTimeout_ :: Maybe Int,
@@ -974,7 +975,7 @@ data SimpleNetCfg = SimpleNetCfg
   deriving (Show)
 
 defaultSimpleNetCfg :: SimpleNetCfg
-defaultSimpleNetCfg = SimpleNetCfg Nothing Nothing Nothing Nothing False
+defaultSimpleNetCfg = SimpleNetCfg Nothing SMAlways Nothing Nothing Nothing False
 
 data ContactSubStatus = ContactSubStatus
   { contact :: Contact,

--- a/src/Simplex/Chat/Options.hs
+++ b/src/Simplex/Chat/Options.hs
@@ -145,7 +145,7 @@ coreChatOptsP appDir defaultDbFileName = do
         strParse
         ( long "smp-proxy"
             <> metavar "SMP_PROXY_MODE"
-            <> help "Use private message routing: always, unknown, unprotected, never (default)"
+            <> help "Use private message routing: always, unknown (default), unprotected, never"
         )
   smpProxyFallback_ <-
     optional $
@@ -153,7 +153,7 @@ coreChatOptsP appDir defaultDbFileName = do
         strParse
         ( long "smp-proxy-fallback"
             <> metavar "SMP_PROXY_FALLBACK_MODE"
-            <> help "Allow downgrade and connect directly: no, [when IP address is] protected, yes (default)"
+            <> help "Allow downgrade and connect directly: no, [when IP address is] protected (default), yes"
         )
   t <-
     option

--- a/src/Simplex/Chat/Options.hs
+++ b/src/Simplex/Chat/Options.hs
@@ -27,6 +27,7 @@ import Numeric.Natural (Natural)
 import Options.Applicative
 import Simplex.Chat.Controller (ChatLogLevel (..), SimpleNetCfg (..), updateStr, versionNumber, versionString)
 import Simplex.FileTransfer.Description (mb)
+import Simplex.Messaging.Client (SocksMode (..))
 import Simplex.Messaging.Encoding.String
 import Simplex.Messaging.Parsers (parseAll)
 import Simplex.Messaging.Protocol (ProtoServerWithAuth, ProtocolTypeI, SMPServerWithAuth, XFTPServerWithAuth)
@@ -130,6 +131,14 @@ coreChatOptsP appDir defaultDbFileName = do
             <> help "Use SOCKS5 proxy at `ipv4:port` or `:port`"
             <> value Nothing
         )
+  socksMode <-
+    option
+      strParse
+      ( long "socks-mode"
+          <> metavar "SOCKS_MODE"
+          <> help "Use SOCKS5 proxy: always (default), onion (with onion-only relays)"
+          <> value SMAlways
+      )
   smpProxyMode_ <-
     optional $
       option
@@ -137,7 +146,7 @@ coreChatOptsP appDir defaultDbFileName = do
         ( long "smp-proxy"
             <> metavar "SMP_PROXY_MODE"
             <> help "Use private message routing: always, unknown, unprotected, never (default)"
-        ) 
+        )
   smpProxyFallback_ <-
     optional $
       option
@@ -217,7 +226,7 @@ coreChatOptsP appDir defaultDbFileName = do
         dbKey,
         smpServers,
         xftpServers,
-        simpleNetCfg = SimpleNetCfg {socksProxy, smpProxyMode_, smpProxyFallback_, tcpTimeout_ = Just $ useTcpTimeout socksProxy t, logTLSErrors},
+        simpleNetCfg = SimpleNetCfg {socksProxy, socksMode, smpProxyMode_, smpProxyFallback_, tcpTimeout_ = Just $ useTcpTimeout socksProxy t, logTLSErrors},
         logLevel,
         logConnections = logConnections || logLevel <= CLLInfo,
         logServerHosts = logServerHosts || logLevel <= CLLInfo,

--- a/src/Simplex/Chat/Terminal.hs
+++ b/src/Simplex/Chat/Terminal.hs
@@ -22,7 +22,7 @@ import Simplex.Chat.Terminal.Input
 import Simplex.Chat.Terminal.Output
 import Simplex.FileTransfer.Client.Presets (defaultXFTPServers)
 import Simplex.Messaging.Agent.Env.SQLite (presetServerCfg)
-import Simplex.Messaging.Client (defaultNetworkConfig)
+import Simplex.Messaging.Client (NetworkConfig (..), SMPProxyFallback (..), SMPProxyMode (..), defaultNetworkConfig)
 import Simplex.Messaging.Util (raceAny_)
 import System.IO (hFlush, hSetEcho, stdin, stdout)
 
@@ -41,7 +41,11 @@ terminalChatConfig =
                   ],
             ntf = ["ntf://FB-Uop7RTaZZEG0ZLD2CIaTjsPh-Fw0zFAnb7QyA8Ks=@ntf2.simplex.im,ntg7jdjy2i3qbib3sykiho3enekwiaqg3icctliqhtqcg6jmoh6cxiad.onion"],
             xftp = L.map (presetServerCfg True) defaultXFTPServers,
-            netCfg = defaultNetworkConfig
+            netCfg =
+              defaultNetworkConfig
+                { smpProxyMode = SPMUnknown,
+                  smpProxyFallback = SPFAllowProtected
+                }
           },
       deviceNameForRemote = "SimpleX CLI"
     }

--- a/src/Simplex/Chat/Terminal/Main.hs
+++ b/src/Simplex/Chat/Terminal/Main.hs
@@ -10,12 +10,12 @@ import Data.Maybe (fromMaybe)
 import Data.Time.Clock (getCurrentTime)
 import Data.Time.LocalTime (getCurrentTimeZone)
 import Network.Socket
-import Simplex.Chat.Controller (ChatConfig, ChatController (..), ChatResponse (..), SimpleNetCfg (..), currentRemoteHost, versionNumber, versionString)
+import Simplex.Chat.Controller (ChatConfig (..), ChatController (..), ChatResponse (..), DefaultAgentServers (DefaultAgentServers, netCfg), SimpleNetCfg (..), currentRemoteHost, versionNumber, versionString)
 import Simplex.Chat.Core
 import Simplex.Chat.Options
 import Simplex.Chat.Terminal
 import Simplex.Chat.View (serializeChatResponse, smpProxyModeStr)
-import Simplex.Messaging.Client (NetworkConfig (..), defaultNetworkConfig)
+import Simplex.Messaging.Client (NetworkConfig (..), SocksMode (..))
 import System.Directory (getAppUserDataDirectory)
 import System.Exit (exitFailure)
 import System.Terminal (withTerminal)
@@ -33,7 +33,7 @@ simplexChatCLI cfg server_ = do
     else simplexChatCore cfg opts $ runCommand opts
   where
     runCLI opts = do
-      welcome opts
+      welcome cfg opts
       t <- withTerminal pure
       simplexChatTerminal cfg opts t
     runCommand ChatOpts {chatCmd, chatCmdLog, chatCmdDelay} user cc = do
@@ -51,18 +51,18 @@ simplexChatCLI cfg server_ = do
           rh <- readTVarIO $ currentRemoteHost cc
           putStrLn $ serializeChatResponse (rh, Just user) ts tz rh r
 
-welcome :: ChatOpts -> IO ()
-welcome ChatOpts {coreOptions = CoreChatOpts {dbFilePrefix, simpleNetCfg = SimpleNetCfg {socksProxy, smpProxyMode_, smpProxyFallback_}}} =
+welcome :: ChatConfig -> ChatOpts -> IO ()
+welcome ChatConfig {defaultServers = DefaultAgentServers {netCfg}} ChatOpts {coreOptions = CoreChatOpts {dbFilePrefix, simpleNetCfg = SimpleNetCfg {socksProxy, socksMode, smpProxyMode_, smpProxyFallback_}}} =
   mapM_
     putStrLn
     [ versionString versionNumber,
       "db: " <> dbFilePrefix <> "_chat.db, " <> dbFilePrefix <> "_agent.db",
       maybe
         "direct network connection - use `/network` command or `-x` CLI option to connect via SOCKS5 at :9050"
-        (("using SOCKS5 proxy " <>) . show)
+        ((\sp -> "using SOCKS5 proxy " <> sp <> if socksMode == SMOnion then " for onion servers ONLY." else " for ALL servers.") . show)
         socksProxy,
       smpProxyModeStr
-        (fromMaybe (smpProxyMode defaultNetworkConfig) smpProxyMode_)
-        (fromMaybe (smpProxyFallback defaultNetworkConfig) smpProxyFallback_),
+        (fromMaybe (smpProxyMode netCfg) smpProxyMode_)
+        (fromMaybe (smpProxyFallback netCfg) smpProxyFallback_),
       "type \"/help\" or \"/h\" for usage info"
     ]

--- a/src/Simplex/Chat/View.hs
+++ b/src/Simplex/Chat/View.hs
@@ -55,7 +55,7 @@ import Simplex.Messaging.Agent.Client (ProtocolTestFailure (..), ProtocolTestSte
 import Simplex.Messaging.Agent.Env.SQLite (NetworkConfig (..), ServerCfg (..))
 import Simplex.Messaging.Agent.Protocol
 import Simplex.Messaging.Agent.Store.SQLite.DB (SlowQueryStats (..))
-import Simplex.Messaging.Client (SMPProxyFallback, SMPProxyMode (..))
+import Simplex.Messaging.Client (SMPProxyFallback, SMPProxyMode (..), SocksMode (..))
 import qualified Simplex.Messaging.Crypto as C
 import Simplex.Messaging.Crypto.File (CryptoFile (..), CryptoFileArgs (..))
 import qualified Simplex.Messaging.Crypto.Ratchet as CR
@@ -1217,11 +1217,11 @@ viewChatItemTTL = \case
     deletedAfter ttlStr = ["old messages are set to be deleted after: " <> ttlStr]
 
 viewNetworkConfig :: NetworkConfig -> [StyledString]
-viewNetworkConfig NetworkConfig {socksProxy, tcpTimeout, smpProxyMode, smpProxyFallback} =
-  [ plain $ maybe "direct network connection" (("using SOCKS5 proxy " <>) . show) socksProxy,
+viewNetworkConfig NetworkConfig {socksProxy, socksMode, tcpTimeout, smpProxyMode, smpProxyFallback} =
+  [ plain $ maybe "direct network connection" ((\sp -> "using SOCKS5 proxy " <> sp <> if socksMode == SMOnion then " for onion servers ONLY." else " for ALL servers.") . show) socksProxy,
     "TCP timeout: " <> sShow tcpTimeout,
     plain $ smpProxyModeStr smpProxyMode smpProxyFallback,
-    "use " <> highlight' "/network socks=<on/off/[ipv4]:port>[ timeout=<seconds>][ smp-proxy=always/unknown/unprotected/never][ smp-proxy-fallback=no/protected/yes]" <> " to change settings"
+    "use " <> highlight' "/network socks=<on/off/[ipv4]:port>[ socks-mode=always/onion][ smp-proxy=always/unknown/unprotected/never][ smp-proxy-fallback=no/protected/yes][ timeout=<seconds>]" <> " to change settings"
   ]
 
 smpProxyModeStr :: SMPProxyMode -> SMPProxyFallback -> String


### PR DESCRIPTION
Enabling socks proxy with --socks-mode=onion in directory service bot will allow users with onion-only relays joining the groups