### PR TITLE
ios: add image message sending to share extension

### DIFF
--- a/apps/ios/SimpleX SE/ShareAPI.swift
+++ b/apps/ios/SimpleX SE/ShareAPI.swift
@@ -102,6 +102,9 @@ enum ShareError: LocalizedError {
     case missingAttachment
     case unsupportedFormat
     case encryptFile
+    case imageDownsampling
+    case previewGeneration
+    case mediaLoading
     case loadFileRepresentation(Error)
 
     public var errorDescription: String? {
@@ -120,6 +123,12 @@ enum ShareError: LocalizedError {
             "This file format is not supported"
         case .encryptFile:
             "File encryption has failed"
+        case .imageDownsampling:
+            "Failed to downsample selected image"
+        case .previewGeneration:
+            "Failed to generate Preview"
+        case .mediaLoading:
+            "Unable to load media"
         case .loadFileRepresentation(let error):
             "File could not be loaded: \(String(describing: error))"
         }

--- a/apps/ios/SimpleXChat/ImageUtils.swift
+++ b/apps/ios/SimpleXChat/ImageUtils.swift
@@ -158,6 +158,34 @@ public func imageHasAlpha(_ img: UIImage) -> Bool {
     return false
 }
 
+/// Reduces image size, while consuming less RAM
+///
+/// Used by ShareExtension to downsize large images
+/// before passing them to regular image processing pipeline
+/// to avoid exceeding 120MB memory
+///
+/// - Parameters:
+///   - url: Location of the image data
+///   - size: Maximum dimension (width or height)
+/// - Returns: Downsampled image or `nil`, if the image can't be located
+public func downsampleImage(at url: URL, to size: Int64) -> UIImage? {
+    autoreleasepool {
+        if let source = CGImageSourceCreateWithURL(url as CFURL, nil) {
+            CGImageSourceCreateThumbnailAtIndex(
+                    source,
+                    Int.zero,
+                    [
+                        kCGImageSourceCreateThumbnailFromImageAlways: true,
+                        kCGImageSourceShouldCacheImmediately: true,
+                        kCGImageSourceCreateThumbnailWithTransform: true,
+                        kCGImageSourceThumbnailMaxPixelSize: String(size) as CFString
+                    ] as CFDictionary
+                )
+            .map { UIImage(cgImage: $0) }
+        } else { nil }
+    }
+}
+
 public func saveFileFromURL(_ url: URL) -> CryptoFile? {
     let encrypted = privacyEncryptLocalFilesGroupDefault.get()
     let savedFile: CryptoFile?


### PR DESCRIPTION
- Adds utility for downsampling an image directly from disk instead of loading the original image in memory
- Adds support for sending image messages from share extension

# Comparing image compression


https://github.com/user-attachments/assets/7fd2e161-d8d1-4d65-8d49-85a116d506a9