### PR TITLE
android, desktop: contacts, groups and group member action buttons

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
@@ -62,7 +62,6 @@ object ChatModel {
   // current chat
   val chatId = mutableStateOf<String?>(null)
   val chatItems = mutableStateOf(SnapshotStateList<ChatItem>())
-  val chatViewMode = mutableStateOf(ChatViewMode.Message)
   // rhId, chatId
   val deletedChats = mutableStateOf<List<Pair<Long?, String>>>(emptyList())
   val chatItemStatuses = mutableMapOf<Long, CIStatus>()
@@ -1752,11 +1751,6 @@ class PendingContactConnection(
         updatedAt = Clock.System.now()
       )
   }
-}
-
-enum class ChatViewMode {
-  Message,
-  Search,
 }
 
 @Serializable

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
@@ -62,6 +62,7 @@ object ChatModel {
   // current chat
   val chatId = mutableStateOf<String?>(null)
   val chatItems = mutableStateOf(SnapshotStateList<ChatItem>())
+  val chatViewMode = mutableStateOf(ChatViewMode.Message)
   // rhId, chatId
   val deletedChats = mutableStateOf<List<Pair<Long?, String>>>(emptyList())
   val chatItemStatuses = mutableMapOf<Long, CIStatus>()
@@ -1751,6 +1752,11 @@ class PendingContactConnection(
         updatedAt = Clock.System.now()
       )
   }
+}
+
+enum class ChatViewMode {
+  Message,
+  Search,
 }
 
 @Serializable

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatInfoView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatInfoView.kt
@@ -664,7 +664,7 @@ fun LocalAliasEditor(
 @Composable
 private fun ConnectButton(openedFromChatView: Boolean, chat: Chat, contact: Contact, close: () -> Unit) {
   InfoViewActionButton(
-    icon = painterResource(MR.images.ic_chat_bubble_filled),
+    icon = painterResource(MR.images.ic_chat_bubble),
     title = generalGetString(MR.strings.info_view_connect_button),
     disabled = false,
     onClick = {
@@ -717,35 +717,13 @@ private fun infoConnectContactViaAddress(openedFromChatView: Boolean, chat: Chat
 @Composable
 private fun OpenButton(openedFromChatView: Boolean, chat: Chat, contact: Contact, close: () -> Unit) {
   InfoViewActionButton(
-    icon = painterResource(MR.images.ic_chat_bubble_filled),
+    icon = painterResource(MR.images.ic_chat_bubble),
     title = generalGetString(MR.strings.info_view_open_button),
     disabled = false,
     onClick = {
       if (openedFromChatView) {
         close.invoke()
       } else {
-        close.invoke()
-        withBGApi {
-          openDirectChat(chat.remoteHostId, contact.contactId, chatModel)
-        }
-      }
-    }
-  )
-}
-
-@Composable
-private fun MessageButton(openedFromChatView: Boolean, chat: Chat, contact: Contact, close: () -> Unit) {
-  InfoViewActionButton(
-    icon = painterResource(MR.images.ic_chat_bubble_filled),
-    title = generalGetString(MR.strings.info_view_message_button),
-    disabled = !contact.sendMsgEnabled,
-    onClick = {
-      if (openedFromChatView) {
-        close.invoke()
-      } else {
-        if (contact.chatDeleted) {
-          chatModel.updateContact(chat.remoteHostId, contact.copy(chatDeleted = false))
-        }
         close.invoke()
         withBGApi {
           openDirectChat(chat.remoteHostId, contact.contactId, chatModel)

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatInfoView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatInfoView.kt
@@ -71,6 +71,7 @@ fun ChatInfoView(
   localAlias: String,
   connectionCode: String?,
   close: () -> Unit,
+  onSearchClicked: () -> Unit
 ) {
   BackHandler(onBack = close)
   val contact = rememberUpdatedState(contact).value
@@ -185,7 +186,8 @@ fun ChatInfoView(
           }
         }
       },
-      close = close
+      close = close,
+      onSearchClicked = onSearchClicked
     )
   }
 }
@@ -395,6 +397,7 @@ fun ChatInfoLayout(
   syncContactConnectionForce: () -> Unit,
   verifyClicked: () -> Unit,
   close: () -> Unit,
+  onSearchClicked: () -> Unit
 ) {
   val cStats = connStats.value
   val scrollState = rememberScrollState()
@@ -431,7 +434,7 @@ fun ChatInfoLayout(
         OpenButton(openedFromChatView, chat, contact, close)
         Spacer(Modifier.width(DEFAULT_PADDING))
       }
-      SearchButton(chat, contact, close)
+      SearchButton(chat, contact, close, onSearchClicked)
       Spacer(Modifier.width(DEFAULT_PADDING))
       CallButton(chat, contact)
       Spacer(Modifier.width(DEFAULT_PADDING))
@@ -753,17 +756,14 @@ private fun MessageButton(openedFromChatView: Boolean, chat: Chat, contact: Cont
 }
 
 @Composable
-fun SearchButton(chat: Chat, contact: Contact, close: () -> Unit) {
+fun SearchButton(chat: Chat, contact: Contact, close: () -> Unit, onSearchClicked: () -> Unit) {
   InfoViewActionButton(
     icon = painterResource(MR.images.ic_search),
     title = generalGetString(MR.strings.info_view_search_button),
     disabled = !contact.ready || chat.chatItems.isEmpty(),
     onClick = {
       close.invoke()
-      withBGApi {
-        openDirectChat(chat.remoteHostId, contact.contactId, chatModel)
-        chatModel.chatViewMode.value = ChatViewMode.Search
-      }
+      onSearchClicked()
     }
   )
 }
@@ -1155,6 +1155,7 @@ fun PreviewChatInfoLayout() {
       syncContactConnectionForce = {},
       verifyClicked = {},
       close = {},
+      onSearchClicked = {}
     )
   }
 }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatInfoView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatInfoView.kt
@@ -819,7 +819,7 @@ fun InfoViewActionButton(icon: Painter, title: String, disabled: Boolean, onClic
       Box(
         modifier = Modifier
           .background(
-            if (disabled) MaterialTheme.colors.secondary else MaterialTheme.colors.primary,
+            if (disabled) MaterialTheme.colors.secondaryVariant else MaterialTheme.colors.primary,
             shape = CircleShape
           )
           .padding(16.dp)
@@ -828,7 +828,7 @@ fun InfoViewActionButton(icon: Painter, title: String, disabled: Boolean, onClic
           icon,
           contentDescription = null,
           Modifier.size(24.dp * fontSizeSqrtMultiplier),
-          tint = if (disabled) MaterialTheme.colors.onSecondary else MaterialTheme.colors.onPrimary
+          tint = if (disabled) MaterialTheme.colors.secondary else MaterialTheme.colors.onPrimary
         )
       }
     }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatInfoView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatInfoView.kt
@@ -426,17 +426,17 @@ fun ChatInfoLayout(
     ) {
       if (contact.activeConn == null && contact.profile.contactLink != null && contact.active) {
         ConnectButton(openedFromChatView, chat, contact, close)
-        Spacer(Modifier.width(10.dp))
+        Spacer(Modifier.width(DEFAULT_PADDING))
       } else if (!contact.active && !contact.chatDeleted) {
         OpenButton(openedFromChatView, chat, contact, close)
-        Spacer(Modifier.width(10.dp))
+        Spacer(Modifier.width(DEFAULT_PADDING))
       }
       SearchButton(chat, contact, close)
-      Spacer(Modifier.width(10.dp))
+      Spacer(Modifier.width(DEFAULT_PADDING))
       CallButton(chat, contact)
-      Spacer(Modifier.width(10.dp))
+      Spacer(Modifier.width(DEFAULT_PADDING))
       VideoButton(chat, contact)
-      Spacer(Modifier.width(10.dp))
+      Spacer(Modifier.width(DEFAULT_PADDING))
       MuteButton(chat, contact)
     }
 
@@ -785,7 +785,7 @@ fun MuteButton(chat: Chat, contact: Contact) {
 @Composable
 fun CallButton(chat: Chat, contact: Contact) {
   InfoViewActionButton(
-    icon = painterResource(MR.images.ic_call_filled),
+    icon = painterResource(MR.images.ic_call),
     title = generalGetString(MR.strings.info_view_call_button),
     disabled = !contact.ready || !contact.active || !contact.mergedPreferences.calls.enabled.forUser || chatModel.activeCall.value != null,
     onClick = {
@@ -797,7 +797,7 @@ fun CallButton(chat: Chat, contact: Contact) {
 @Composable
 fun VideoButton(chat: Chat, contact: Contact) {
   InfoViewActionButton(
-    icon = painterResource(MR.images.ic_videocam_filled),
+    icon = painterResource(MR.images.ic_videocam),
     title = generalGetString(MR.strings.info_view_video_button),
     disabled = !contact.ready || !contact.active || !contact.mergedPreferences.calls.enabled.forUser || chatModel.activeCall.value != null,
     onClick = {
@@ -822,7 +822,7 @@ fun InfoViewActionButton(icon: Painter, title: String, disabled: Boolean, onClic
             if (disabled) MaterialTheme.colors.secondary else MaterialTheme.colors.primary,
             shape = CircleShape
           )
-          .padding(DEFAULT_PADDING)
+          .padding(16.dp)
       ) {
         Icon(
           icon,
@@ -835,7 +835,8 @@ fun InfoViewActionButton(icon: Painter, title: String, disabled: Boolean, onClic
     Text(
       title.capitalize(Locale.current),
       style = MaterialTheme.typography.subtitle2.copy(fontWeight = FontWeight.Normal),
-      color = MaterialTheme.colors.secondary
+      color = MaterialTheme.colors.secondary,
+      modifier = Modifier.padding(top = DEFAULT_SPACE_AFTER_ICON)
     )
   }
 }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatInfoView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatInfoView.kt
@@ -12,7 +12,7 @@ import SectionView
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.*
 import androidx.compose.material.*
 import androidx.compose.runtime.*
@@ -774,31 +774,35 @@ fun VideoButton(chat: Chat, contact: Contact) {
 
 @Composable
 fun InfoViewActionButton(icon: Painter, title: String, disabled: Boolean, onClick: () -> Unit) {
-  Surface(
-    Modifier
-      .width(96.dp)
-      .height(66.dp),
-    shape = RoundedCornerShape(20.dp),
-    color = MaterialTheme.colors.secondaryVariant,
+  Column(
+    horizontalAlignment = Alignment.CenterHorizontally,
+    verticalArrangement = Arrangement.Center
   ) {
-    val modifier = if (disabled) Modifier else Modifier.clickable { onClick () }
-    Column(
-      modifier,
-      horizontalAlignment = Alignment.CenterHorizontally,
-      verticalArrangement = Arrangement.Center
+    IconButton(
+      onClick = onClick,
+      enabled = !disabled
     ) {
-      Icon(
-        icon,
-        contentDescription = null,
-        Modifier.size(26.dp),
-        tint = if (disabled) MaterialTheme.colors.secondary else MaterialTheme.colors.primary
-      )
-      Text(
-        title,
-        style = MaterialTheme.typography.subtitle2.copy(fontWeight = FontWeight.Normal),
-        color = if (disabled) MaterialTheme.colors.secondary else MaterialTheme.colors.primary
-      )
+      Box(
+        modifier = Modifier
+          .background(
+            if (disabled) MaterialTheme.colors.secondary else MaterialTheme.colors.primary,
+            shape = CircleShape
+          )
+          .padding(DEFAULT_PADDING)
+      ) {
+        Icon(
+          icon,
+          contentDescription = null,
+          Modifier.size(24.dp * fontSizeSqrtMultiplier),
+          tint = if (disabled) MaterialTheme.colors.onSecondary else MaterialTheme.colors.onPrimary
+        )
+      }
     }
+    Text(
+      title,
+      style = MaterialTheme.typography.subtitle2.copy(fontWeight = FontWeight.Normal),
+      color = MaterialTheme.colors.secondary
+    )
   }
 }
 

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatInfoView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatInfoView.kt
@@ -759,10 +759,10 @@ fun SearchButton(chat: Chat, contact: Contact, close: () -> Unit) {
     title = generalGetString(MR.strings.info_view_search_button),
     disabled = !contact.ready || chat.chatItems.isEmpty(),
     onClick = {
-      chatModel.chatViewMode.value = ChatViewMode.Search
       close.invoke()
       withBGApi {
         openDirectChat(chat.remoteHostId, contact.contactId, chatModel)
+        chatModel.chatViewMode.value = ChatViewMode.Search
       }
     }
   )

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
@@ -435,8 +435,8 @@ fun ChatView(chatId: String, chatModel: ChatModel, onComposed: suspend (chatId: 
                 }
               }
             },
-            addMembers = { groupInfo -> addGroupMembers(view = view, groupInfo = groupInfo, rhId = chatRh) },
-            openGroupLink = { groupInfo -> openGroupLink(view = view, groupInfo = groupInfo, rhId = chatRh) },
+            addMembers = { groupInfo -> addGroupMembers(view = view, groupInfo = groupInfo, rhId = chatRh, close = { ModalManager.end.closeModals() }) },
+            openGroupLink = { groupInfo -> openGroupLink(view = view, groupInfo = groupInfo, rhId = chatRh, close = { ModalManager.end.closeModals() }) },
             markRead = { range, unreadCountAfter ->
               chatModel.markChatItemsRead(chat, range, unreadCountAfter)
               ntfManager.cancelNotificationsForChat(chat.id)
@@ -1266,22 +1266,22 @@ private fun TopEndFloatingButton(
 
 val chatViewScrollState = MutableStateFlow(false)
 
-fun addGroupMembers(groupInfo: GroupInfo, rhId: Long?, view: Any? = null) {
+fun addGroupMembers(groupInfo: GroupInfo, rhId: Long?, view: Any? = null, close: (() -> Unit)? = null) {
   hideKeyboard(view)
   withBGApi {
     setGroupMembers(rhId, groupInfo, chatModel)
-    ModalManager.end.closeModals()
+    close?.invoke()
     ModalManager.end.showModalCloseable(true) { close ->
       AddGroupMembersView(rhId, groupInfo, false, chatModel, close)
     }
   }
 }
 
-fun openGroupLink(groupInfo: GroupInfo, rhId: Long?, view: Any? = null) {
+fun openGroupLink(groupInfo: GroupInfo, rhId: Long?, view: Any? = null, close: (() -> Unit)? = null) {
   hideKeyboard(view)
   withBGApi {
     val link = chatModel.controller.apiGetGroupLink(rhId, groupInfo.groupId)
-    ModalManager.end.closeModals()
+    close?.invoke()
     ModalManager.end.showModalCloseable(true) {
       GroupLinkView(chatModel, rhId, groupInfo, link?.first, link?.second, onGroupLinkUpdated = null)
     }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
@@ -436,26 +436,8 @@ fun ChatView(chatId: String, chatModel: ChatModel, onComposed: suspend (chatId: 
                 }
               }
             },
-            addMembers = { groupInfo ->
-              hideKeyboard(view)
-              withBGApi {
-                setGroupMembers(chatRh, groupInfo, chatModel)
-                ModalManager.end.closeModals()
-                ModalManager.end.showModalCloseable(true) { close ->
-                  AddGroupMembersView(chatRh, groupInfo, false, chatModel, close)
-                }
-              }
-            },
-            openGroupLink = { groupInfo ->
-              hideKeyboard(view)
-              withBGApi {
-                val link = chatModel.controller.apiGetGroupLink(chatRh, groupInfo.groupId)
-                ModalManager.end.closeModals()
-                ModalManager.end.showModalCloseable(true) {
-                  GroupLinkView(chatModel, chatRh, groupInfo, link?.first, link?.second, onGroupLinkUpdated = null)
-                }
-              }
-            },
+            addMembers = { groupInfo -> addGroupMembers(view = view, groupInfo = groupInfo, rhId = chatRh) },
+            openGroupLink = { groupInfo -> openGroupLink(view = view, groupInfo = groupInfo, rhId = chatRh) },
             markRead = { range, unreadCountAfter ->
               chatModel.markChatItemsRead(chat, range, unreadCountAfter)
               ntfManager.cancelNotificationsForChat(chat.id)
@@ -1338,6 +1320,28 @@ private fun TopEndFloatingButton(
 }
 
 val chatViewScrollState = MutableStateFlow(false)
+
+fun addGroupMembers(groupInfo: GroupInfo, rhId: Long?, view: Any? = null) {
+  hideKeyboard(view)
+  withBGApi {
+    setGroupMembers(rhId, groupInfo, chatModel)
+    ModalManager.end.closeModals()
+    ModalManager.end.showModalCloseable(true) { close ->
+      AddGroupMembersView(rhId, groupInfo, false, chatModel, close)
+    }
+  }
+}
+
+fun openGroupLink(groupInfo: GroupInfo, rhId: Long?, view: Any? = null) {
+  hideKeyboard(view)
+  withBGApi {
+    val link = chatModel.controller.apiGetGroupLink(rhId, groupInfo.groupId)
+    ModalManager.end.closeModals()
+    ModalManager.end.showModalCloseable(true) {
+      GroupLinkView(chatModel, rhId, groupInfo, link?.first, link?.second, onGroupLinkUpdated = null)
+    }
+  }
+}
 
 private fun bottomEndFloatingButton(
   unreadCount: Int,

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
@@ -569,6 +569,10 @@ fun ChatLayout(
 ) {
   val scope = rememberCoroutineScope()
   val attachmentDisabled = remember { derivedStateOf { composeState.value.attachmentDisabled } }
+  DisposableEffect(Unit) {
+    onDispose { chatModel.chatViewMode.value = ChatViewMode.Message }
+  }
+
   Box(
     Modifier
       .fillMaxWidth()
@@ -657,13 +661,12 @@ fun ChatInfoToolbar(
 ) {
   val scope = rememberCoroutineScope()
   val showMenu = rememberSaveable { mutableStateOf(false) }
-  var showSearch by rememberSaveable { mutableStateOf(false) }
   val onBackClicked = {
-    if (!showSearch) {
+    if (chatModel.chatViewMode.value == ChatViewMode.Message) {
       back()
     } else {
       onSearchValueChanged("")
-      showSearch = false
+      chatModel.chatViewMode.value = ChatViewMode.Message
     }
   }
   if (appPlatform.isAndroid) {
@@ -676,7 +679,7 @@ fun ChatInfoToolbar(
     barButtons.add {
       IconButton({
         showMenu.value = false
-        showSearch = true
+        chatModel.chatViewMode.value = ChatViewMode.Search
         }, enabled = chat.chatInfo.noteFolder.ready
       ) {
         Icon(
@@ -690,7 +693,7 @@ fun ChatInfoToolbar(
     menuItems.add {
       ItemAction(stringResource(MR.strings.search_verb), painterResource(MR.images.ic_search), onClick = {
         showMenu.value = false
-        showSearch = true
+        chatModel.chatViewMode.value = ChatViewMode.Search
       })
     }
   }
@@ -816,10 +819,10 @@ fun ChatInfoToolbar(
   }
 
   DefaultTopAppBar(
-    navigationButton = { if (appPlatform.isAndroid || showSearch) { NavigationButtonBack(onBackClicked) }  },
+    navigationButton = { if (appPlatform.isAndroid ||  chatModel.chatViewMode.value == ChatViewMode.Search) { NavigationButtonBack(onBackClicked) }  },
     title = { ChatInfoToolbarTitle(chat.chatInfo) },
     onTitleClick = if (chat.chatInfo is ChatInfo.Local) null else info,
-    showSearch = showSearch,
+    showSearch = chatModel.chatViewMode.value == ChatViewMode.Search,
     onSearchValueChanged = onSearchValueChanged,
     buttons = barButtons
   )

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
@@ -73,6 +73,7 @@ fun ChatView(chatId: String, chatModel: ChatModel, onComposed: suspend (chatId: 
           if (activeChat.value?.id != chatId) {
             // Redisplay the whole hierarchy if the chat is different to make going from groups to direct chat working correctly
             // Also for situation when chatId changes after clicking in notification, etc
+            chatModel.chatViewMode.value = ChatViewMode.Message
             activeChat.value = chatModel.getChat(chatId)
           }
           markUnreadChatAsRead(activeChat, chatModel)
@@ -550,9 +551,6 @@ fun ChatLayout(
 ) {
   val scope = rememberCoroutineScope()
   val attachmentDisabled = remember { derivedStateOf { composeState.value.attachmentDisabled } }
-  DisposableEffect(Unit) {
-    onDispose { chatModel.chatViewMode.value = ChatViewMode.Message }
-  }
 
   Box(
     Modifier

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupChatInfoView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupChatInfoView.kt
@@ -211,7 +211,7 @@ fun MuteButton(chat: Chat, groupInfo: GroupInfo) {
 fun AddGroupMembersButton(chat: Chat, groupInfo: GroupInfo) {
   InfoViewActionButton(
     icon =  if (groupInfo.incognito) painterResource(MR.images.ic_add_link) else painterResource(MR.images.ic_person_add_500),
-    title = if (groupInfo.incognito) stringResource(MR.strings.group_link) else stringResource(MR.strings.action_button_add_members),
+    title = stringResource(MR.strings.action_button_add_members),
     disabled = !groupInfo.ready,
     onClick = {
       if (groupInfo.incognito) {
@@ -275,10 +275,10 @@ fun GroupChatInfoLayout(
         verticalAlignment = Alignment.CenterVertically
       ) {
         SearchButton(chat, groupInfo, close)
-        Spacer(Modifier.width(10.dp))
+        Spacer(Modifier.width(DEFAULT_PADDING))
         MuteButton(chat, groupInfo)
         if (groupInfo.canAddMembers) {
-          Spacer(Modifier.width(10.dp))
+          Spacer(Modifier.width(DEFAULT_PADDING))
           AddGroupMembersButton(chat, groupInfo)
         }
       }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupChatInfoView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupChatInfoView.kt
@@ -274,12 +274,12 @@ fun GroupChatInfoLayout(
         verticalAlignment = Alignment.CenterVertically
       ) {
         SearchButton(chat, groupInfo, close, onSearchClicked)
-        Spacer(Modifier.width(DEFAULT_PADDING))
-        MuteButton(chat, groupInfo)
         if (groupInfo.canAddMembers) {
           Spacer(Modifier.width(DEFAULT_PADDING))
           AddGroupMembersButton(chat, groupInfo)
         }
+        Spacer(Modifier.width(DEFAULT_PADDING))
+        MuteButton(chat, groupInfo)
       }
 
       SectionSpacer()

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupChatInfoView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupChatInfoView.kt
@@ -40,7 +40,7 @@ import kotlinx.coroutines.launch
 const val SMALL_GROUPS_RCPS_MEM_LIMIT: Int = 20
 
 @Composable
-fun GroupChatInfoView(chatModel: ChatModel, rhId: Long?, chatId: String, groupLink: String?, groupLinkMemberRole: GroupMemberRole?, onGroupLinkUpdated: (Pair<String, GroupMemberRole>?) -> Unit, close: () -> Unit) {
+fun GroupChatInfoView(chatModel: ChatModel, rhId: Long?, chatId: String, groupLink: String?, groupLinkMemberRole: GroupMemberRole?, onGroupLinkUpdated: (Pair<String, GroupMemberRole>?) -> Unit, close: () -> Unit, onSearchClicked: () -> Unit) {
   BackHandler(onBack = close)
   // TODO derivedStateOf?
   val chat = chatModel.chats.firstOrNull { ch -> ch.id == chatId && ch.remoteHostId == rhId }
@@ -113,7 +113,8 @@ fun GroupChatInfoView(chatModel: ChatModel, rhId: Long?, chatId: String, groupLi
       leaveGroup = { leaveGroupDialog(rhId, groupInfo, chatModel, close) },
       manageGroupLink = {
           ModalManager.end.showModal { GroupLinkView(chatModel, rhId, groupInfo, groupLink, groupLinkMemberRole, onGroupLinkUpdated) }
-      }
+      },
+      onSearchClicked = onSearchClicked
     )
   }
 }
@@ -178,17 +179,14 @@ private fun removeMemberAlert(rhId: Long?, groupInfo: GroupInfo, mem: GroupMembe
 }
 
 @Composable
-fun SearchButton(chat: Chat, group: GroupInfo, close: () -> Unit) {
+fun SearchButton(chat: Chat, group: GroupInfo, close: () -> Unit, onSearchClicked: () -> Unit) {
   InfoViewActionButton(
     icon = painterResource(MR.images.ic_search),
     title = generalGetString(MR.strings.info_view_search_button),
     disabled = !group.ready || chat.chatItems.isEmpty(),
     onClick = {
-      chatModel.chatViewMode.value = ChatViewMode.Search
+      onSearchClicked()
       close.invoke()
-      withBGApi {
-        openGroupChat(chat.remoteHostId, group.groupId, chatModel)
-      }
     }
   )
 }
@@ -243,7 +241,8 @@ fun GroupChatInfoLayout(
   clearChat: () -> Unit,
   leaveGroup: () -> Unit,
   manageGroupLink: () -> Unit,
-  close: () -> Unit = { ModalManager.closeAllModalsEverywhere()}
+  close: () -> Unit = { ModalManager.closeAllModalsEverywhere()},
+  onSearchClicked: () -> Unit
 ) {
   val listState = rememberLazyListState()
   val scope = rememberCoroutineScope()
@@ -274,7 +273,7 @@ fun GroupChatInfoLayout(
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically
       ) {
-        SearchButton(chat, groupInfo, close)
+        SearchButton(chat, groupInfo, close, onSearchClicked)
         Spacer(Modifier.width(DEFAULT_PADDING))
         MuteButton(chat, groupInfo)
         if (groupInfo.canAddMembers) {
@@ -650,7 +649,7 @@ fun PreviewGroupChatInfoLayout() {
       members = listOf(GroupMember.sampleData, GroupMember.sampleData, GroupMember.sampleData),
       developerTools = false,
       groupLink = null,
-      addMembers = {}, showMemberInfo = {}, editGroupProfile = {}, addOrEditWelcomeMessage = {}, openPreferences = {}, deleteGroup = {}, clearChat = {}, leaveGroup = {}, manageGroupLink = {},
+      addMembers = {}, showMemberInfo = {}, editGroupProfile = {}, addOrEditWelcomeMessage = {}, openPreferences = {}, deleteGroup = {}, clearChat = {}, leaveGroup = {}, manageGroupLink = {}, onSearchClicked = {},
     )
   }
 }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupMemberInfoView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupMemberInfoView.kt
@@ -320,9 +320,9 @@ fun GroupMemberInfoLayout(
       if (knownChat != null) {
         val (chat, contact) = knownChat
         OpenChatButton(onClick = { openDirectChat(contact.contactId) })
-        Spacer(Modifier.width(10.dp))
+        Spacer(Modifier.width(DEFAULT_PADDING))
         CallButton(chat, contact)
-        Spacer(Modifier.width(10.dp))
+        Spacer(Modifier.width(DEFAULT_PADDING))
         VideoButton(chat, contact)
       } else if (groupInfo.fullGroupPreferences.directMessages.on(groupInfo.membership)) {
         if (contactId != null) {
@@ -330,9 +330,9 @@ fun GroupMemberInfoLayout(
         } else {
           OpenChatButton(onClick = { createMemberContact() })
         }
-        Spacer(Modifier.width(10.dp))
+        Spacer(Modifier.width(DEFAULT_PADDING))
         InfoViewActionButton(painterResource(MR.images.ic_call_filled), generalGetString(MR.strings.info_view_call_button), disabled = true, onClick = {})
-        Spacer(Modifier.width(10.dp))
+        Spacer(Modifier.width(DEFAULT_PADDING))
         InfoViewActionButton(painterResource(MR.images.ic_videocam_filled), generalGetString(MR.strings.info_view_video_button), disabled = true, onClick = {})
       }
     }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupMemberInfoView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupMemberInfoView.kt
@@ -331,9 +331,9 @@ fun GroupMemberInfoLayout(
           OpenChatButton(onClick = { createMemberContact() })
         }
         Spacer(Modifier.width(DEFAULT_PADDING))
-        InfoViewActionButton(painterResource(MR.images.ic_call_filled), generalGetString(MR.strings.info_view_call_button), disabled = true, onClick = {})
+        InfoViewActionButton(painterResource(MR.images.ic_call), generalGetString(MR.strings.info_view_call_button), disabled = true, onClick = {})
         Spacer(Modifier.width(DEFAULT_PADDING))
-        InfoViewActionButton(painterResource(MR.images.ic_videocam_filled), generalGetString(MR.strings.info_view_video_button), disabled = true, onClick = {})
+        InfoViewActionButton(painterResource(MR.images.ic_videocam), generalGetString(MR.strings.info_view_video_button), disabled = true, onClick = {})
       }
     }
     SectionSpacer()
@@ -534,7 +534,7 @@ fun RemoveMemberButton(onClick: () -> Unit) {
 @Composable
 fun OpenChatButton(onClick: () -> Unit) {
   InfoViewActionButton(
-    icon = painterResource(MR.images.ic_chat_bubble_filled),
+    icon = painterResource(MR.images.ic_chat_bubble),
     title = generalGetString(MR.strings.info_view_message_button),
     disabled = false,
     onClick = onClick

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/contacts/ContactsView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/contacts/ContactsView.kt
@@ -270,8 +270,8 @@ private fun ContactsSearchBar(
                         connect(
                             link = link.text,
                             searchChatFilteredBySimplexLink = searchChatFilteredBySimplexLink,
-                            cleanup = { searchText.value = TextFieldValue() },
-                            close = close
+                            close = close,
+                            cleanup = { searchText.value = TextFieldValue() }
                         )
                     } else if (!searchShowingSimplexLink.value || it.isEmpty()) {
                         if (it.isNotEmpty()) {
@@ -440,7 +440,7 @@ private fun filteredContactChats(
 private fun viewNameContains(cInfo: ChatInfo, s: String): Boolean =
     cInfo.chatViewName.lowercase().contains(s.lowercase())
 
-private fun connect(link: String, searchChatFilteredBySimplexLink: MutableState<String?>, cleanup: (() -> Unit)?, close: () -> Unit) {
+private fun connect(link: String, searchChatFilteredBySimplexLink: MutableState<String?>, close: () -> Unit, cleanup: (() -> Unit)?) {
     withBGApi {
         planAndConnect(
             chatModel.remoteHostId(),

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/contacts/ContactsView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/contacts/ContactsView.kt
@@ -267,9 +267,12 @@ private fun ContactsSearchBar(
                         }
                         searchShowingSimplexLink.value = true
                         searchChatFilteredBySimplexLink.value = null
-                        connect(link.text, searchChatFilteredBySimplexLink, close) {
-                            searchText.value = TextFieldValue()
-                        }
+                        connect(
+                            link = link.text,
+                            searchChatFilteredBySimplexLink = searchChatFilteredBySimplexLink,
+                            cleanup = { searchText.value = TextFieldValue() },
+                            close = close
+                        )
                     } else if (!searchShowingSimplexLink.value || it.isEmpty()) {
                         if (it.isNotEmpty()) {
                             // if some other text is pasted, enter search mode

--- a/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
@@ -1472,6 +1472,7 @@
   <string name="send_receipts_disabled">disabled</string>
   <string name="send_receipts_disabled_alert_title">Receipts are disabled</string>
   <string name="send_receipts_disabled_alert_msg">This group has over %1$d members, delivery receipts are not sent.</string>
+  <string name="action_button_add_members">Invite</string>
 
   <!-- Chat / Chat item info -->
   <string name="section_title_for_console">FOR CONSOLE</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
@@ -447,6 +447,7 @@
   <string name="info_view_open_button">open</string>
   <string name="info_view_message_button">message</string>
   <string name="info_view_call_button">call</string>
+  <string name="info_view_search_button">search</string>
   <string name="info_view_video_button">video</string>
   <string name="delete_contact_question">Delete contact?</string>
   <string name="delete_contact_all_messages_deleted_cannot_undo_warning">Contact and all messages will be deleted - this cannot be undone!</string>


### PR DESCRIPTION
### Background

Current context menus (...) on individual chats and groups have been a source of confusion for users and are generally missed as valuable features.

### Objective

Remove confusion and complication associated with ... menus and increase interaction speed.

### Plan

#### Remove ... menus
Keep only 1 action button per chat type (add member for groups, phone call for individual chats

#### New action buttons to be displayed for contacts
- search
- call
- video
- mute

#### New action buttons to be displayed for members
- message
- call
- video

#### New action buttons to be displayed for groups
- search
- add member
- mute

### Demos

https://github.com/user-attachments/assets/d3324fe7-9a9d-41a1-902e-1a6a25efe9c7

https://github.com/user-attachments/assets/271e102f-7e49-405b-a954-c8296c7eb8c6

