### PR TITLE
android, desktop: hide new chat sheet action buttons when search text…

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/contacts/ContactsView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/contacts/ContactsView.kt
@@ -73,14 +73,12 @@ import chat.simplex.common.views.helpers.ModalView
 import chat.simplex.common.views.helpers.SearchTextField
 import chat.simplex.common.views.helpers.generalGetString
 import chat.simplex.common.views.helpers.hostDevice
-import chat.simplex.common.views.helpers.withApi
 import chat.simplex.common.views.helpers.withBGApi
 import chat.simplex.common.views.newchat.planAndConnect
 import chat.simplex.common.views.newchat.strHasSingleSimplexLink
 import chat.simplex.res.MR
 import dev.icerock.moko.resources.compose.painterResource
 import dev.icerock.moko.resources.compose.stringResource
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import java.net.URI
 
@@ -213,14 +211,9 @@ private fun ContactsSearchBar(
     searchText: MutableState<TextFieldValue>,
     searchShowingSimplexLink: MutableState<Boolean>,
     searchChatFilteredBySimplexLink: MutableState<String?>,
-    onFocusChanged: (hasFocus: Boolean) -> Unit,
     close: () -> Unit
 ) {
     var focused by remember { mutableStateOf(false) }
-
-    LaunchedEffect(focused) {
-        onFocusChanged(focused)
-    }
 
     Row(verticalAlignment = Alignment.CenterVertically) {
         val focusRequester = remember { FocusRequester() }
@@ -326,7 +319,6 @@ private fun ContactsList(
     ) }
     val searchShowingSimplexLink = remember { mutableStateOf(false) }
     val searchChatFilteredBySimplexLink = remember { mutableStateOf<String?>(null) }
-    var searchFocused by remember { mutableStateOf(false) }
 
     DisposableEffect(Unit) {
         onDispose {
@@ -361,19 +353,12 @@ private fun ContactsList(
                     searchText = searchText,
                     searchShowingSimplexLink = searchShowingSimplexLink,
                     searchChatFilteredBySimplexLink = searchChatFilteredBySimplexLink,
-                    onFocusChanged = {
-                        withApi {
-                            // Adding a small delay to avoid focus based re-render cancelling click events on contacts.
-                            delay(300)
-                            searchFocused = it
-                        }
-                    },
                     close = close
                 )
                 Divider()
             }
 
-            if (!searchFocused) {
+            if (searchText.value.text.isEmpty()) {
                 contactActions()
             }
 


### PR DESCRIPTION
… is not empty instead of when search is focused