### PR TITLE
android, desktop: streamlined delete actions based on contact type

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatInfoView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatInfoView.kt
@@ -288,24 +288,26 @@ private fun deleteActiveContactDialog(chat: Chat, contact: Contact, chatModel: C
   AlertManager.shared.showAlertDialogButtonsColumn(
     title = generalGetString(MR.strings.delete_contact_question),
     text = generalGetString(MR.strings.delete_contact_cannot_undo_warning),
-    belowTextContent = {
-      Row(
-        Modifier.fillMaxWidth().padding(start = DEFAULT_PADDING, top = DEFAULT_PADDING, end = DEFAULT_PADDING),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween
-      ) {
-        Text(stringResource(MR.strings.keep_conversation))
-        DefaultSwitch(
-          checked = contactDeleteMode.value is ContactDeleteMode.Entity,
-          onCheckedChange = {
-            contactDeleteMode.value =
-              if (it) ContactDeleteMode.Entity() else ContactDeleteMode.Full()
-          },
-        )
-      }
-    },
     buttons = {
       Column {
+        // Keep conversation toggle
+        SectionItemView {
+          Row(
+            Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
+          ) {
+            Text(stringResource(MR.strings.keep_conversation))
+            Spacer(Modifier.width(DEFAULT_PADDING))
+            DefaultSwitch(
+              checked = contactDeleteMode.value is ContactDeleteMode.Entity,
+              onCheckedChange = {
+                contactDeleteMode.value =
+                  if (it) ContactDeleteMode.Entity() else ContactDeleteMode.Full()
+              },
+            )
+          }
+        }
         // Delete without notification
         SectionItemView({
           AlertManager.shared.hideAlert()

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatInfoView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatInfoView.kt
@@ -50,17 +50,6 @@ import kotlinx.datetime.Clock
 import kotlinx.serialization.encodeToString
 import java.io.File
 
-sealed class ContactDeleteMode {
-  class Full: ContactDeleteMode()
-  class Entity: ContactDeleteMode()
-
-  fun toChatDeleteMode(notify: Boolean): ChatDeleteMode =
-    when (this) {
-      is Full -> ChatDeleteMode.Full(notify)
-      is Entity -> ChatDeleteMode.Entity(notify)
-    }
-}
-
 @Composable
 fun ChatInfoView(
   chatModel: ChatModel,
@@ -282,6 +271,17 @@ private fun showDeleteConversationNotice(contact: Contact) {
   )
 }
 
+sealed class ContactDeleteMode {
+  class Full: ContactDeleteMode()
+  class Entity: ContactDeleteMode()
+
+  fun toChatDeleteMode(notify: Boolean): ChatDeleteMode =
+    when (this) {
+      is Full -> ChatDeleteMode.Full(notify)
+      is Entity -> ChatDeleteMode.Entity(notify)
+    }
+}
+
 private fun deleteActiveContactDialog(chat: Chat, contact: Contact, chatModel: ChatModel, close: (() -> Unit)? = null) {
   val contactDeleteMode = mutableStateOf<ContactDeleteMode>(ContactDeleteMode.Full())
 
@@ -342,7 +342,7 @@ private fun deleteActiveContactDialog(chat: Chat, contact: Contact, chatModel: C
 private fun deleteContactWithoutConversation(chat: Chat, chatModel: ChatModel, close: (() -> Unit)?) {
   AlertManager.shared.showAlertDialogButtonsColumn(
     title = generalGetString(MR.strings.confirm_delete_contact_question),
-    text = generalGetString(MR.strings.delete_contact_all_messages_deleted_cannot_undo_warning),
+    text = generalGetString(MR.strings.delete_contact_cannot_undo_warning),
     buttons = {
       Column {
         // Delete and notify contact
@@ -400,7 +400,7 @@ private fun deleteNotReadyContact(chat: Chat, chatModel: ChatModel, close: (() -
     title = generalGetString(MR.strings.confirm_delete_contact_question),
     text = generalGetString(MR.strings.delete_contact_cannot_undo_warning),
     buttons = {
-      // Delete without notification
+      // Confirm
       SectionItemView({
         AlertManager.shared.hideAlert()
         deleteContact(

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListNavLinkView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListNavLinkView.kt
@@ -417,70 +417,10 @@ fun DeleteContactAction(chat: Chat, chatModel: ChatModel, showMenu: MutableState
     stringResource(MR.strings.delete_contact_menu_action),
     painterResource(MR.images.ic_delete),
     onClick = {
-      deleteContactConversationDialog(chat, chatModel)
+      deleteContactDialog(chat, chatModel)
       showMenu.value = false
     },
     color = Color.Red
-  )
-}
-
-fun deleteContactConversationDialog(chat: Chat, chatModel: ChatModel, close: (() -> Unit)? = null) {
-  val chatInfo = chat.chatInfo
-  if (chatInfo is ChatInfo.Direct) {
-    val contactDeletedByUser = chatInfo.contact.contactStatus == ContactStatus.DeletedByUser
-    AlertManager.shared.showAlertDialogButtonsColumn(
-      title = if (contactDeletedByUser) generalGetString(MR.strings.delete_conversation_question) else generalGetString(MR.strings.delete_contact_question),
-      text = if (contactDeletedByUser) generalGetString(MR.strings.delete_conversation_all_messages_deleted_cannot_undo_warning) else null,
-      buttons = {
-        Column {
-          if (contactDeletedByUser) {
-            // Delete conversation
-            SectionItemView({
-              AlertManager.shared.hideAlert()
-              deleteContact(chat, chatModel, close, chatDeleteMode = ChatDeleteMode.Full(notify = false))
-            }) {
-              Text(generalGetString(MR.strings.delete_conversation), Modifier.fillMaxWidth(), textAlign = TextAlign.Center, color = MaterialTheme.colors.error)
-            }
-          } else {
-            // Delete contact
-            SectionItemView({
-              AlertManager.shared.hideAlert()
-              notifyDeleteContactDialog(chat, chatModel, close)
-            }) {
-              Text(generalGetString(MR.strings.button_delete_contact), Modifier.fillMaxWidth(), textAlign = TextAlign.Center, color = MaterialTheme.colors.error)
-            }
-            // Only delete conversation
-            SectionItemView({
-              AlertManager.shared.hideAlert()
-              deleteContact(chat, chatModel, close, chatDeleteMode = ChatDeleteMode.Messages())
-              if (chatModel.controller.appPrefs.showDeleteConversationNotice.get()) {
-                showDeleteConversationNotice(chatInfo.contact)
-              }
-            }) {
-              Text(generalGetString(MR.strings.only_delete_conversation), Modifier.fillMaxWidth(), textAlign = TextAlign.Center, color = MaterialTheme.colors.error)
-            }
-          }
-          // Cancel
-          SectionItemView({
-            AlertManager.shared.hideAlert()
-          }) {
-            Text(stringResource(MR.strings.cancel_verb), Modifier.fillMaxWidth(), textAlign = TextAlign.Center, color = MaterialTheme.colors.primary)
-          }
-        }
-      }
-    )
-  }
-}
-
-private fun showDeleteConversationNotice(contact: Contact) {
-  AlertManager.shared.showAlertDialog(
-    title = generalGetString(MR.strings.conversation_deleted),
-    text = String.format(generalGetString(MR.strings.you_can_still_send_messages_to_contact), contact.displayName),
-    confirmText = generalGetString(MR.strings.ok),
-    dismissText = generalGetString(MR.strings.dont_show_again),
-    onDismiss = {
-      chatModel.controller.appPrefs.showDeleteConversationNotice.set(false)
-    },
   )
 }
 

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/contacts/ContactListNavView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/contacts/ContactListNavView.kt
@@ -14,16 +14,12 @@ import chat.simplex.res.MR
 import kotlinx.coroutines.delay
 
 private fun onRequestAccepted(chat: Chat) {
-    when (val chatInfo = chat.chatInfo) {
-        is ChatInfo.Direct -> {
-            if (chatInfo.contact.sndReady) {
-                openLoadedChat(chat, chatModel)
-            } else {
-                ModalManager.center.closeModals()
-            }
+    val chatInfo = chat.chatInfo
+    if (chatInfo is ChatInfo.Direct) {
+        ModalManager.center.closeModals()
+        if (chatInfo.contact.sndReady) {
+            openLoadedChat(chat, chatModel)
         }
-
-        else -> ModalManager.center.closeModals()
     }
 }
 

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/contacts/ContactsView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/contacts/ContactsView.kt
@@ -150,7 +150,10 @@ private fun ContactActionsSection(contactActions: @Composable () -> Unit, rh: Re
     contactActions()
     Spacer(Modifier.height(DEFAULT_PADDING))
 
-    val archived = remember { contactChats(chatModel.chats, listOf(ContactType.REMOVED)) }
+    val contactTypes = listOf(ContactType.REMOVED)
+    val archived by remember(chatModel.chats, contactTypes) {
+        derivedStateOf { contactChats(chatModel.chats, contactTypes) }
+    }
 
     if (archived.isNotEmpty()) {
         SectionView(padding = PaddingValues(bottom = DEFAULT_PADDING)) {

--- a/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
@@ -315,7 +315,6 @@
   <string name="delete_message__question">Delete message?</string>
   <string name="delete_messages__question">Delete %d messages?</string>
   <string name="delete_message_cannot_be_undone_warning">Message will be deleted - this cannot be undone!</string>
-  <string name="delete_contact_or_messages_cannot_undo_warning">Message and contact deletion are permanent operations - this cannot be undone!</string>
   <string name="delete_message_mark_deleted_warning">Message will be marked for deletion. The recipient(s) will be able to reveal this message.</string>
   <string name="delete_member_message__question">Delete member message?</string>
   <string name="moderate_message_will_be_deleted_warning">The message will be deleted for all members.</string>
@@ -451,15 +450,11 @@
   <string name="info_view_search_button">search</string>
   <string name="info_view_video_button">video</string>
   <string name="delete_contact_question">Delete contact?</string>
+  <string name="delete_contact_or_messages_cannot_undo_warning">Message and contact deletion are permanent operations - this cannot be undone!</string>
   <string name="delete_contact_all_messages_deleted_cannot_undo_warning">Contact and all messages will be deleted - this cannot be undone!</string>
   <string name="delete_contact_cannot_undo_warning">Contact will be deleted - this cannot be undone!</string>
-  <string name="delete_conversation_question">Delete conversation?</string>
   <string name="keep_conversation">Keep conversation</string>
-  <string name="delete_conversation_all_messages_deleted_cannot_undo_warning">Conversation and all messages will be deleted - this cannot be undone!</string>
-  <string name="delete_conversation">Delete conversation</string>
   <string name="only_delete_conversation">Only delete conversation</string>
-  <string name="delete_contact_keep_conversation">Delete contact, keep conversation</string>
-  <string name="notify_delete_contact_question">Notify contact?</string>
   <string name="confirm_delete_contact_question">Confirm contact deletion?</string>
   <string name="delete_and_notify_contact">Delete and notify contact</string>
   <string name="delete_without_notification">Delete without notification</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
@@ -315,6 +315,7 @@
   <string name="delete_message__question">Delete message?</string>
   <string name="delete_messages__question">Delete %d messages?</string>
   <string name="delete_message_cannot_be_undone_warning">Message will be deleted - this cannot be undone!</string>
+  <string name="delete_contact_or_messages_cannot_undo_warning">Message and contact deletion are permanent operations - this cannot be undone!</string>
   <string name="delete_message_mark_deleted_warning">Message will be marked for deletion. The recipient(s) will be able to reveal this message.</string>
   <string name="delete_member_message__question">Delete member message?</string>
   <string name="moderate_message_will_be_deleted_warning">The message will be deleted for all members.</string>
@@ -453,6 +454,7 @@
   <string name="delete_contact_all_messages_deleted_cannot_undo_warning">Contact and all messages will be deleted - this cannot be undone!</string>
   <string name="delete_contact_cannot_undo_warning">Contact will be deleted - this cannot be undone!</string>
   <string name="delete_conversation_question">Delete conversation?</string>
+  <string name="keep_conversation">Keep conversation</string>
   <string name="delete_conversation_all_messages_deleted_cannot_undo_warning">Conversation and all messages will be deleted - this cannot be undone!</string>
   <string name="delete_conversation">Delete conversation</string>
   <string name="only_delete_conversation">Only delete conversation</string>
@@ -463,7 +465,7 @@
   <string name="delete_without_notification">Delete without notification</string>
   <string name="button_delete_contact">Delete contact</string>
   <string name="conversation_deleted">Conversation deleted!</string>
-  <string name="you_can_still_send_messages_to_contact">You can still send messages to %1$s from the Contacts tab.</string>
+  <string name="you_can_still_send_messages_to_contact">You can still send messages to %1$s from the new chat screen "delete chats" section.</string>
   <string name="contact_deleted">Contact deleted!</string>
   <string name="you_can_still_view_conversation_with_contact">You can still view conversation with %1$s in the Chats tab.</string>
   <string name="text_field_set_contact_placeholder">Set contact name…</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
@@ -450,7 +450,6 @@
   <string name="info_view_search_button">search</string>
   <string name="info_view_video_button">video</string>
   <string name="delete_contact_question">Delete contact?</string>
-  <string name="delete_contact_or_messages_cannot_undo_warning">Message and contact deletion are permanent operations - this cannot be undone!</string>
   <string name="delete_contact_all_messages_deleted_cannot_undo_warning">Contact and all messages will be deleted - this cannot be undone!</string>
   <string name="delete_contact_cannot_undo_warning">Contact will be deleted - this cannot be undone!</string>
   <string name="keep_conversation">Keep conversation</string>
@@ -460,9 +459,9 @@
   <string name="delete_without_notification">Delete without notification</string>
   <string name="button_delete_contact">Delete contact</string>
   <string name="conversation_deleted">Conversation deleted!</string>
-  <string name="you_can_still_send_messages_to_contact">You can still send messages to %1$s from the new chat screen "delete chats" section.</string>
+  <string name="you_can_still_send_messages_to_contact">You can still send messages to %1$s from the Deleted chats.</string>
   <string name="contact_deleted">Contact deleted!</string>
-  <string name="you_can_still_view_conversation_with_contact">You can still view conversation with %1$s in the Chats tab.</string>
+  <string name="you_can_still_view_conversation_with_contact">You can still view conversation with %1$s in the list of chats.</string>
   <string name="text_field_set_contact_placeholder">Set contact name…</string>
   <string name="icon_descr_server_status_connected">Connected</string>
   <string name="icon_descr_server_status_disconnected">Disconnected</string>


### PR DESCRIPTION
### Objective
Drive deletion logic by contact type across screen (chat list, contact card, contact list) as opposed to based on screen context.

### Streamlined logic
#### For normal contacts (ready, not deleted, active and chat not deleted):

Delete bring up 2 options:
1. Only delete conversation (show text saying that It can be recovered in new chat sheet)
2. Delete contact
2a) Keep conversation toggle, should be off by default
2b) Buttons delete and notify contact and delete without notification


#### Active contact with deleted conversation (accessible via new chat sheet):
Delete brings confirmation
1) Buttons delete and notify contact and delete without notification


#### Deleted contact:
(Can be someone that deleted me, can be a contact deleted with conversation kept)

Delete brings alert
1) Confirm deletion (Confirm/Delete button)

### Screenshots

![image](https://github.com/user-attachments/assets/e41f9ef1-6ef3-46e0-b599-b8f3cb141ab7)
![image](https://github.com/user-attachments/assets/290f7cf6-a869-40e8-9ed8-c330f983b14d)
![image](https://github.com/user-attachments/assets/945fc722-1af1-4d7f-a576-f0bd1c481b29)
![image](https://github.com/user-attachments/assets/a7bc48b3-6e8f-4988-bcd0-b41f695af931)
![image](https://github.com/user-attachments/assets/24a07702-c4f0-49b7-b80a-b6dce3ca5711)
![image](https://github.com/user-attachments/assets/12c93ff7-a1e4-4f9f-9f42-f1e3fca50ca6)
