### PR TITLE
android: smaller new chat button in 1-hand UI mode, line on the correct side of the bar

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListNavLinkView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListNavLinkView.kt
@@ -27,6 +27,7 @@ import chat.simplex.common.views.chat.*
 import chat.simplex.common.views.chat.group.deleteGroupDialog
 import chat.simplex.common.views.chat.group.leaveGroupDialog
 import chat.simplex.common.views.chat.item.ItemAction
+import chat.simplex.common.views.contacts.onRequestAccepted
 import chat.simplex.common.views.helpers.*
 import chat.simplex.common.views.newchat.*
 import chat.simplex.res.MR
@@ -129,7 +130,7 @@ fun ChatListNavLinkView(chat: Chat, nextChatSelected: State<Boolean>, oneHandUI:
             ContactRequestView(chat.chatInfo)
           }
         },
-        click = { contactRequestAlertDialog(chat.remoteHostId, chat.chatInfo, chatModel) },
+        click = { contactRequestAlertDialog(chat.remoteHostId, chat.chatInfo, chatModel) { onRequestAccepted(it) } },
         dropdownMenuItems = {
           tryOrShowError("${chat.id}ChatListNavLinkDropdown", error = {}) {
             ContactRequestMenuItems(chat.remoteHostId, chat.chatInfo, chatModel, showMenu)

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
@@ -88,19 +88,21 @@ fun ChatListView(chatModel: ChatModel, settingsState: SettingsViewState, setPerf
   Scaffold(
     topBar = {
       if (!oneHandUI.state.value) {
-        Box(Modifier.padding(end = endPadding)) {
+        Column(Modifier.padding(end = endPadding)) {
           ChatListToolbar(
             scaffoldState.drawerState,
             userPickerState,
             stopped,
             oneHandUI
           )
+          Divider()
         }
       }
     },
     bottomBar = {
       if (oneHandUI.state.value) {
-        Box(Modifier.padding(end = endPadding)) {
+        Column(Modifier.padding(end = endPadding)) {
+          Divider()
           ChatListToolbar(
             scaffoldState.drawerState,
             userPickerState,
@@ -227,9 +229,10 @@ private fun ChatListToolbar(drawerState: DrawerState, userPickerState: MutableSt
         },
       ) {
         Box(
+          contentAlignment = Alignment.Center,
           modifier = Modifier
             .background(if (!stopped) MaterialTheme.colors.primary else MaterialTheme.colors.secondary, shape = CircleShape)
-            .padding(DEFAULT_PADDING_HALF)
+            .size(33.dp * fontSizeSqrtMultiplier) // 26 = 37 * 0.7
         ){
           Icon(
             painterResource(MR.images.ic_edit_filled),
@@ -327,7 +330,6 @@ private fun ChatListToolbar(drawerState: DrawerState, userPickerState: MutableSt
     onSearchValueChanged = {},
     buttons = barButtons
   )
-  Divider(Modifier.padding(top = AppBarHeight * fontSizeSqrtMultiplier))
 }
 
 @Composable

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
@@ -232,7 +232,7 @@ private fun ChatListToolbar(drawerState: DrawerState, userPickerState: MutableSt
           contentAlignment = Alignment.Center,
           modifier = Modifier
             .background(if (!stopped) MaterialTheme.colors.primary else MaterialTheme.colors.secondary, shape = CircleShape)
-            .size(33.dp * fontSizeSqrtMultiplier) // 26 = 37 * 0.7
+            .size(33.dp * fontSizeSqrtMultiplier)
         ){
           Icon(
             painterResource(MR.images.ic_edit_filled),

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
@@ -43,14 +43,12 @@ import kotlinx.serialization.json.Json
 import java.net.URI
 import kotlin.time.Duration.Companion.seconds
 
-private fun showNewChatSheet(oneHandUI: State<Boolean>, barTitle: String) {
+private fun showNewChatSheet(oneHandUI: State<Boolean>) {
   ModalManager.start.closeModals()
   ModalManager.end.closeModals()
   chatModel.newChatSheetVisible.value = true
   ModalManager.start.showModalCloseable(
     closeOnTop = !oneHandUI.value,
-    closeBarTitle = if (oneHandUI.value) barTitle else null,
-    endButtons = { Spacer(Modifier.minimumInteractiveComponentSize()) }
   ) { close ->
     NewChatSheet(rh = chatModel.currentRemoteHost.value, close)
     DisposableEffect(Unit) {
@@ -127,7 +125,7 @@ fun ChatListView(chatModel: ChatModel, settingsState: SettingsViewState, setPerf
         FloatingActionButton(
           onClick = {
             if (!stopped) {
-              showNewChatSheet(oneHandUI.state, generalGetString(MR.strings.new_chat))
+              showNewChatSheet(oneHandUI.state)
             }
           },
           Modifier
@@ -224,7 +222,7 @@ private fun ChatListToolbar(drawerState: DrawerState, userPickerState: MutableSt
       IconButton(
         onClick = {
           if (!stopped) {
-            showNewChatSheet(oneHandUI.state, generalGetString(MR.strings.new_chat))
+            showNewChatSheet(oneHandUI.state)
           }
         },
       ) {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
@@ -553,6 +553,7 @@ private fun ChatList(chatModel: ChatModel, searchText: MutableState<TextFieldVal
   var scrollDirection by remember { mutableStateOf(ScrollDirection.Idle) }
   var previousIndex by remember { mutableStateOf(0) }
   var previousScrollOffset by remember { mutableStateOf(0) }
+  val keyboardState by getKeyboardState()
 
   LaunchedEffect(listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset) {
     val currentIndex = listState.firstVisibleItemIndex
@@ -592,7 +593,10 @@ private fun ChatList(chatModel: ChatModel, searchText: MutableState<TextFieldVal
         Modifier
           .offset {
             val y = if (searchText.value.text.isEmpty()) {
-              if (oneHandUI.state.value && scrollDirection == ScrollDirection.Up) {
+              if (
+                (oneHandUI.state.value && scrollDirection == ScrollDirection.Up) ||
+                (appPlatform.isAndroid && keyboardState == KeyboardState.Opened)
+              ) {
                 0
               } else if (listState.firstVisibleItemIndex == 0) -listState.firstVisibleItemScrollOffset else -1000
             } else {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/UserPicker.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/UserPicker.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.unit.*
 import chat.simplex.common.model.*
+import chat.simplex.common.model.ChatController.appPrefs
 import chat.simplex.common.model.ChatController.stopRemoteHostAndReloadHosts
 import chat.simplex.common.model.ChatModel.controller
 import chat.simplex.common.ui.theme.*
@@ -149,7 +150,7 @@ fun UserPicker(
     .padding(bottom = 10.dp, top = 10.dp)
     .graphicsLayer {
       alpha = animatedFloat.value
-      translationY = (if (chatModel.controller.appPrefs.oneHandUI.state.value) -1 else 1) * (animatedFloat.value - 1) * xOffset
+      translationY = (if (appPrefs.oneHandUI.state.value) -1 else 1) * (animatedFloat.value - 1) * xOffset
     },
     contentAlignment = contentAlignment
   ) {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/UserPicker.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/UserPicker.kt
@@ -149,7 +149,7 @@ fun UserPicker(
     .padding(bottom = 10.dp, top = 10.dp)
     .graphicsLayer {
       alpha = animatedFloat.value
-      translationY = (animatedFloat.value - 1) * xOffset
+      translationY = (if (chatModel.controller.appPrefs.oneHandUI.state.value) -1 else 1) * (animatedFloat.value - 1) * xOffset
     },
     contentAlignment = contentAlignment
   ) {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/contacts/ContactListNavView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/contacts/ContactListNavView.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.Color
 import dev.icerock.moko.resources.compose.painterResource
 import dev.icerock.moko.resources.compose.stringResource
 import chat.simplex.common.model.*
+import chat.simplex.common.model.ChatController.appPrefs
 import chat.simplex.common.model.ChatModel.withChats
 import chat.simplex.common.platform.*
 import chat.simplex.common.views.chat.*
@@ -27,7 +28,8 @@ fun onRequestAccepted(chat: Chat) {
 }
 
 @Composable
-fun ContactListNavLinkView(chat: Chat, nextChatSelected: State<Boolean>, oneHandUI: State<Boolean>) {
+fun ContactListNavLinkView(chat: Chat, nextChatSelected: State<Boolean>) {
+    val oneHandUI = remember { appPrefs.oneHandUI.state }
     val showMenu = remember { mutableStateOf(false) }
     val rhId = chat.remoteHostId
     val disabled = chatModel.chatRunning.value == false || chatModel.deletedChats.value.contains(rhId to chat.chatInfo.id)

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/contacts/ContactListNavView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/contacts/ContactListNavView.kt
@@ -16,7 +16,7 @@ import chat.simplex.common.views.newchat.chatContactType
 import chat.simplex.res.MR
 import kotlinx.coroutines.delay
 
-private fun onRequestAccepted(chat: Chat) {
+fun onRequestAccepted(chat: Chat) {
     val chatInfo = chat.chatInfo
     if (chatInfo is ChatInfo.Direct) {
         ModalManager.start.closeModals()

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/CloseSheetBar.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/CloseSheetBar.kt
@@ -20,7 +20,7 @@ import chat.simplex.res.MR
 import dev.icerock.moko.resources.compose.painterResource
 
 @Composable
-fun CloseSheetBar(close: (() -> Unit)?, showClose: Boolean = true, tintColor: Color = if (close != null) MaterialTheme.colors.primary else MaterialTheme.colors.secondary,  arrangement: Arrangement.Vertical = Arrangement.Top, closeBarTitle: String? = null, endButtons: @Composable RowScope.() -> Unit = {}) {
+fun CloseSheetBar(close: (() -> Unit)?, showClose: Boolean = true, tintColor: Color = if (close != null) MaterialTheme.colors.primary else MaterialTheme.colors.secondary,  arrangement: Arrangement.Vertical = Arrangement.Top, closeBarTitle: String? = null, barPaddingValues: PaddingValues = PaddingValues(horizontal = AppBarHorizontalPadding), endButtons: @Composable RowScope.() -> Unit = {}) {
   var rowModifier = Modifier
     .fillMaxWidth()
     .height(AppBarHeight * fontSizeSqrtMultiplier)
@@ -36,7 +36,7 @@ fun CloseSheetBar(close: (() -> Unit)?, showClose: Boolean = true, tintColor: Co
       .heightIn(min = AppBarHeight * fontSizeSqrtMultiplier)
   ) {
     Row(
-      modifier = Modifier.padding(horizontal = AppBarHorizontalPadding),
+      modifier = Modifier.padding(barPaddingValues),
       content = {
         Row(
           rowModifier,

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/ModalView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/ModalView.kt
@@ -26,7 +26,6 @@ fun ModalView(
   background: Color = MaterialTheme.colors.background,
   modifier: Modifier = Modifier,
   closeOnTop: Boolean = true,
-  closeBarTitle: String? = null,
   endButtons: @Composable RowScope.() -> Unit = {},
   content: @Composable () -> Unit,
 ) {
@@ -38,13 +37,9 @@ fun ModalView(
       if (closeOnTop) {
         CloseSheetBar(if (enableClose) close else null, showClose, endButtons = endButtons)
       }
-      Box(if (closeOnTop) modifier else modifier.padding(bottom = AppBarHeight * fontSizeSqrtMultiplier)) {
+      Box(modifier = modifier) {
         content()
       }
-    }
-
-    if (!closeOnTop) {
-      CloseSheetBar(if (enableClose) close else null, showClose, endButtons = endButtons, arrangement = Arrangement.Bottom, closeBarTitle = closeBarTitle)
     }
   }
 }
@@ -72,17 +67,17 @@ class ModalManager(private val placement: ModalPlacement? = null) {
   // java.lang.IllegalStateException: Reading a state that was created after the snapshot was taken or in a snapshot that has not yet been applied
   private var passcodeView: MutableStateFlow<(@Composable (close: () -> Unit) -> Unit)?> = MutableStateFlow(null)
 
-  fun showModal(settings: Boolean = false, showClose: Boolean = true, closeOnTop: Boolean = true, closeBarTitle: String? = null,endButtons: @Composable RowScope.() -> Unit = {}, content: @Composable ModalData.() -> Unit) {
+  fun showModal(settings: Boolean = false, showClose: Boolean = true, closeOnTop: Boolean = true, endButtons: @Composable RowScope.() -> Unit = {}, content: @Composable ModalData.() -> Unit) {
     val data = ModalData()
     showCustomModal { close ->
-      ModalView(close, showClose = showClose, closeOnTop = closeOnTop, closeBarTitle = closeBarTitle, endButtons = endButtons, content = { data.content() })
+      ModalView(close, showClose = showClose, closeOnTop = closeOnTop, endButtons = endButtons, content = { data.content() })
     }
   }
 
-  fun showModalCloseable(settings: Boolean = false, showClose: Boolean = true, closeOnTop: Boolean = true, closeBarTitle: String? = null, endButtons: @Composable RowScope.() -> Unit = {}, content: @Composable ModalData.(close: () -> Unit) -> Unit) {
+  fun showModalCloseable(settings: Boolean = false, showClose: Boolean = true, closeOnTop: Boolean = true, endButtons: @Composable RowScope.() -> Unit = {}, content: @Composable ModalData.(close: () -> Unit) -> Unit) {
     val data = ModalData()
     showCustomModal { close ->
-      ModalView(close, showClose = showClose, endButtons = endButtons, closeOnTop = closeOnTop, closeBarTitle = closeBarTitle, content = { data.content(close) })
+      ModalView(close, showClose = showClose, endButtons = endButtons, closeOnTop = closeOnTop, content = { data.content(close) })
     }
   }
 

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatSheet.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatSheet.kt
@@ -44,17 +44,6 @@ fun NewChatSheet(rh: RemoteHostInfo?, close: () -> Unit) {
   Column(
     modifier = Modifier.fillMaxSize()
   ) {
-    if (!oneHandUI.state.value) {
-      Box(contentAlignment = Alignment.Center) {
-        val bottomPadding = DEFAULT_PADDING
-        AppBarTitle(
-          stringResource(MR.strings.new_chat),
-          hostDevice(rh?.remoteHostId),
-          bottomPadding = bottomPadding
-        )
-      }
-    }
-
     val closeAll = { ModalManager.start.closeModals() }
 
     var modifier = Modifier.fillMaxSize()
@@ -171,6 +160,18 @@ private fun NewChatSheetLayout(
     Modifier.fillMaxWidth(),
     listState
   ) {
+    if (!oneHandUI.state.value) {
+      item {
+        Box(contentAlignment = Alignment.Center) {
+          val bottomPadding = DEFAULT_PADDING
+          AppBarTitle(
+            stringResource(MR.strings.new_chat),
+            hostDevice(rh?.remoteHostId),
+            bottomPadding = bottomPadding
+          )
+        }
+      }
+    }
     stickyHeader {
       Column(
         Modifier

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatSheet.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatSheet.kt
@@ -225,7 +225,7 @@ private fun NewChatSheetLayout(
       }
     }
     item {
-      Spacer(Modifier.padding(bottom = DEFAULT_PADDING))
+      Spacer(Modifier.padding(bottom = 27.dp))
 
       if (searchText.value.text.isEmpty()) {
         Row {
@@ -283,7 +283,7 @@ private fun NewChatSheetLayout(
               }
             }
           }
-          SectionDividerSpaced()
+          SectionDividerSpaced(maxBottomPadding = false)
         }
       }
     }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatSheet.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatSheet.kt
@@ -49,7 +49,8 @@ fun NewChatSheet(rh: RemoteHostInfo?, close: () -> Unit) {
           showClose = true,
           endButtons = { Spacer(Modifier.minimumInteractiveComponentSize()) },
           arrangement = Arrangement.Bottom,
-          closeBarTitle = generalGetString(MR.strings.new_chat)
+          closeBarTitle = generalGetString(MR.strings.new_chat),
+          barPaddingValues = PaddingValues(horizontal = 0.dp)
         )
         Divider()
       }
@@ -541,7 +542,8 @@ private fun DeletedContactsView(rh: RemoteHostInfo?, closeDeletedChats: () -> Un
           showClose = true,
           endButtons = { Spacer(Modifier.minimumInteractiveComponentSize()) },
           arrangement = Arrangement.Bottom,
-          closeBarTitle = generalGetString(MR.strings.deleted_chats)
+          closeBarTitle = generalGetString(MR.strings.deleted_chats),
+          barPaddingValues = PaddingValues(horizontal = 0.dp)
         )
         Divider()
       }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatSheet.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatSheet.kt
@@ -85,8 +85,7 @@ fun NewChatSheet(rh: RemoteHostInfo?, close: () -> Unit) {
             ModalManager.start.showCustomModal { close -> AddGroupView(chatModel, chatModel.currentRemoteHost.value, close, closeAll) }
           },
           rh = rh,
-          close = close,
-          oneHandUI = oneHandUI
+          close = close
         )
       }
     }
@@ -127,8 +126,8 @@ private fun NewChatSheetLayout(
   scanPaste: () -> Unit,
   createGroup: () -> Unit,
   close: () -> Unit,
-  oneHandUI: SharedPreference<Boolean>,
 ) {
+  val oneHandUI = remember { chatModel.controller.appPrefs.oneHandUI }
   val listState = rememberLazyListState(lazyListState.first, lazyListState.second)
   val searchText = rememberSaveable(stateSaver = TextFieldValue.Saver) { mutableStateOf(TextFieldValue("")) }
   val searchShowingSimplexLink = remember { mutableStateOf(false) }
@@ -221,7 +220,6 @@ private fun NewChatSheetLayout(
           searchShowingSimplexLink = searchShowingSimplexLink,
           searchChatFilteredBySimplexLink = searchChatFilteredBySimplexLink,
           close = close,
-          oneHandUI = oneHandUI
         )
         Divider()
       }
@@ -237,21 +235,18 @@ private fun NewChatSheetLayout(
               text = stringResource(MR.strings.add_contact_tab),
               click = addContact,
               extraPadding = true,
-              oneHandUI = oneHandUI.state
             )
             NewChatButton(
               icon = painterResource(MR.images.ic_qr_code),
               text = if (appPlatform.isAndroid) stringResource(MR.strings.scan_paste_link) else stringResource(MR.strings.paste_link),
               click = scanPaste,
               extraPadding = true,
-              oneHandUI = oneHandUI.state
             )
             NewChatButton(
               icon = painterResource(MR.images.ic_group),
               text = stringResource(MR.strings.create_group_button),
               click = createGroup,
               extraPadding = true,
-              oneHandUI = oneHandUI.state
             )
           }
         }
@@ -333,10 +328,11 @@ private fun NewChatButton(
   iconColor: Color = MaterialTheme.colors.secondary,
   disabled: Boolean = false,
   extraPadding: Boolean = false,
-  oneHandUI: State<Boolean>
 ) {
+  val oneHandUI = remember { chatModel.controller.appPrefs.oneHandUI }
+
   SectionItemView(click, disabled = disabled) {
-    Row(modifier = if (oneHandUI.value) Modifier.scale(scaleX = 1f, scaleY = -1f) else Modifier) {
+    Row(modifier = if (oneHandUI.state.value) Modifier.scale(scaleX = 1f, scaleY = -1f) else Modifier) {
       Icon(icon, text, tint = if (disabled) MaterialTheme.colors.secondary else iconColor)
       TextIconSpaced(extraPadding)
       Text(text, color = if (disabled) MaterialTheme.colors.secondary else textColor)
@@ -351,8 +347,9 @@ private fun ContactsSearchBar(
   searchShowingSimplexLink: MutableState<Boolean>,
   searchChatFilteredBySimplexLink: MutableState<String?>,
   close: () -> Unit,
-  oneHandUI: SharedPreference<Boolean>
 ) {
+  val oneHandUI = remember { chatModel.controller.appPrefs.oneHandUI }
+
   var modifier = Modifier.fillMaxWidth();
 
   if (oneHandUI.state.value) {
@@ -612,7 +609,6 @@ private fun DeletedContactsView(rh: RemoteHostInfo?, closeDeletedChats: () -> Un
             searchShowingSimplexLink = searchShowingSimplexLink,
             searchChatFilteredBySimplexLink = searchChatFilteredBySimplexLink,
             close = close,
-            oneHandUI = oneHandUI
           )
           Divider()
 

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatSheet.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatSheet.kt
@@ -133,6 +133,7 @@ private fun NewChatSheetLayout(
   var scrollDirection by remember { mutableStateOf(ScrollDirection.Idle) }
   var previousIndex by remember { mutableStateOf(0) }
   var previousScrollOffset by remember { mutableStateOf(0) }
+  val keyboardState by getKeyboardState()
 
   LaunchedEffect(listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset) {
     val currentIndex = listState.firstVisibleItemIndex
@@ -175,7 +176,10 @@ private fun NewChatSheetLayout(
         Modifier
           .offset {
             val y = if (searchText.value.text.isEmpty()) {
-              if (oneHandUI.state.value && scrollDirection == ScrollDirection.Up) {
+              if (
+                (oneHandUI.state.value && scrollDirection == ScrollDirection.Up) ||
+                (appPlatform.isAndroid && keyboardState == KeyboardState.Opened)
+                ) {
                 0
               } else if (listState.firstVisibleItemIndex == 0) -listState.firstVisibleItemScrollOffset else -1000
             } else {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatSheet.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatSheet.kt
@@ -280,7 +280,7 @@ private fun NewChatSheetLayout(
       if (filteredContactChats.isNotEmpty() && !oneHandUI.value) {
         Text(
           stringResource(MR.strings.contact_list_header_title).uppercase(), color = MaterialTheme.colors.secondary, style = MaterialTheme.typography.body2,
-          modifier = sectionModifier.padding(start = DEFAULT_PADDING, top = DEFAULT_PADDING_HALF, bottom = 5.dp), fontSize = 12.sp
+          modifier = sectionModifier.padding(start = DEFAULT_PADDING, top = DEFAULT_PADDING_HALF, bottom = DEFAULT_PADDING_HALF), fontSize = 12.sp
         )
       }
     }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatSheet.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatSheet.kt
@@ -280,7 +280,7 @@ private fun NewChatSheetLayout(
       if (filteredContactChats.isNotEmpty() && !oneHandUI.value) {
         Text(
           stringResource(MR.strings.contact_list_header_title).uppercase(), color = MaterialTheme.colors.secondary, style = MaterialTheme.typography.body2,
-          modifier = sectionModifier.padding(start = DEFAULT_PADDING, bottom = 5.dp), fontSize = 12.sp
+          modifier = sectionModifier.padding(start = DEFAULT_PADDING, top = DEFAULT_PADDING_HALF, bottom = 5.dp), fontSize = 12.sp
         )
       }
     }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatSheet.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatSheet.kt
@@ -40,10 +40,16 @@ import java.net.URI
 @Composable
 fun NewChatSheet(rh: RemoteHostInfo?, close: () -> Unit) {
   val oneHandUI = remember { chatModel.controller.appPrefs.oneHandUI }
+  val showToolbarInOneHandUI = remember { mutableStateOf(oneHandUI.state.value) }
+  val keyboardState by getKeyboardState()
+
+  LaunchedEffect(keyboardState, oneHandUI) {
+    showToolbarInOneHandUI.value = keyboardState == KeyboardState.Closed && oneHandUI.state.value
+  }
 
   Scaffold(
     bottomBar = {
-      if (oneHandUI.state.value) {
+      if (showToolbarInOneHandUI.value) {
         CloseSheetBar(
           close = close,
           showClose = true,
@@ -121,7 +127,7 @@ private fun NewChatSheetLayout(
   scanPaste: () -> Unit,
   createGroup: () -> Unit,
   close: () -> Unit,
-  oneHandUI: SharedPreference<Boolean>
+  oneHandUI: SharedPreference<Boolean>,
 ) {
   val listState = rememberLazyListState(lazyListState.first, lazyListState.second)
   val searchText = rememberSaveable(stateSaver = TextFieldValue.Saver) { mutableStateOf(TextFieldValue("")) }
@@ -533,10 +539,16 @@ private fun contactTypesSearchTargets(baseContactTypes: List<ContactType>, searc
 @Composable
 private fun DeletedContactsView(rh: RemoteHostInfo?, closeDeletedChats: () -> Unit, close: () -> Unit) {
   val oneHandUI = remember { chatModel.controller.appPrefs.oneHandUI }
+  val showToolbarInOneHandUI = remember { mutableStateOf(oneHandUI.state.value) }
+  val keyboardState by getKeyboardState()
+
+  LaunchedEffect(keyboardState, oneHandUI) {
+    showToolbarInOneHandUI.value = keyboardState == KeyboardState.Closed && oneHandUI.state.value
+  }
 
   Scaffold(
     bottomBar = {
-      if (oneHandUI.state.value) {
+      if (showToolbarInOneHandUI.value) {
         CloseSheetBar(
           close = closeDeletedChats,
           showClose = true,

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatSheet.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatSheet.kt
@@ -190,9 +190,7 @@ private fun NewChatSheetLayout(
           }
           .background(MaterialTheme.colors.background)
       ) {
-        if (!oneHandUI.state.value) {
-          Divider()
-        }
+        Divider()
         ContactsSearchBar(
           listState = listState,
           searchText = searchText,

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatView.kt
@@ -63,7 +63,7 @@ fun ModalData.NewChatView(rh: RemoteHostInfo?, selection: NewChatOption, showQRC
        * It will be dropped automatically when connection established or when user goes away from this screen.
        * It applies only to Android because on Desktop center space will not be overlapped by [AddContactLearnMore]
        **/
-      if (chatModel.showingInvitation.value != null && (ModalManager.start.openModalCount() == 1 || appPlatform.isDesktop)) {
+      if (chatModel.showingInvitation.value != null && ModalManager.start.openModalCount() == 1) {
         val conn = contactConnection.value
         if (chatModel.showingInvitation.value?.connChatUsed == false && conn != null) {
           AlertManager.shared.showAlertDialog(
@@ -78,7 +78,7 @@ fun ModalData.NewChatView(rh: RemoteHostInfo?, selection: NewChatOption, showQRC
                 controller.deleteChat(Chat(remoteHostId = rh?.remoteHostId, chatInfo = chatInfo, chatItems = listOf()))
                 if (chatModel.chatId.value == chatInfo.id) {
                   chatModel.chatId.value = null
-                  ModalManager.end.closeModals()
+                  ModalManager.start.closeModals()
                 }
               }
             }
@@ -212,8 +212,7 @@ private fun InviteView(rhId: Long?, connReqInvitation: String, contactConnection
   Spacer(Modifier.height(10.dp))
   val incognito = remember { mutableStateOf(controller.appPrefs.incognito.get()) }
   IncognitoToggle(controller.appPrefs.incognito, incognito) {
-    if (appPlatform.isDesktop) ModalManager.end.closeModals()
-    ModalManager.end.showModal { IncognitoView() }
+    ModalManager.start.showModal { IncognitoView() }
   }
   KeyChangeEffect(incognito.value) {
     withBGApi {
@@ -233,8 +232,7 @@ private fun InviteView(rhId: Long?, connReqInvitation: String, contactConnection
 private fun AddContactLearnMoreButton() {
   IconButton(
     {
-      if (appPlatform.isDesktop) ModalManager.end.closeModals()
-      ModalManager.end.showModalCloseable { close ->
+      ModalManager.start.showModalCloseable { close ->
         AddContactLearnMore(close)
       }
     },

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatView.kt
@@ -61,7 +61,6 @@ fun ModalData.NewChatView(rh: RemoteHostInfo?, selection: NewChatOption, showQRC
       /** When [AddContactLearnMore] is open, we don't need to drop [ChatModel.showingInvitation].
        * Otherwise, it will be called here AFTER [AddContactLearnMore] is launched and will clear the value too soon.
        * It will be dropped automatically when connection established or when user goes away from this screen.
-       * It applies only to Android because on Desktop center space will not be overlapped by [AddContactLearnMore]
        **/
       if (chatModel.showingInvitation.value != null && ModalManager.start.openModalCount() == 1) {
         val conn = contactConnection.value


### PR DESCRIPTION
- [x] scroll title together with the view
- [x] paddings in new chat view
- [x] line between toolbar and search
    - [x] chat list
    - [x] chat view
- [x]  not closing search when it's focussed and keyboard is open
- [x] flip animation direction for user picker
- [x]  let's try the same size for new chat button as circle avatar (possibly, without reducing the pencil size) - it looks too big now
- [x] desktop: add contact / scan,paste -> info and incognito info page - should be in left modal
- [x] accepting contact request with sndReady contact should open chat when accepted in chat list same as on new chat sheet?
- [x] Hide toolbar on one hand UI when searching
- [x] One hand UI modal toolbar have extra padding