### PR TITLE
android: one hand UI fixes and improvements

### DIFF
--- a/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/views/chatlist/ChatListNavLinkView.android.kt
+++ b/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/views/chatlist/ChatListNavLinkView.android.kt
@@ -6,7 +6,6 @@ import androidx.compose.material.Divider
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.scale
 import androidx.compose.ui.unit.dp
 import chat.simplex.common.platform.onRightClick
 import chat.simplex.common.views.helpers.*
@@ -20,13 +19,8 @@ actual fun ChatListNavLinkLayout(
   disabled: Boolean,
   selectedChat: State<Boolean>,
   nextChatSelected: State<Boolean>,
-  oneHandUI: State<Boolean>
 ) {
   var modifier = Modifier.fillMaxWidth()
-
-  if (oneHandUI != null && oneHandUI.value) {
-    modifier = modifier.scale(scaleX = 1f, scaleY = -1f)
-  }
 
   if (!disabled) modifier = modifier
     .combinedClickable(onClick = click, onLongClick = { showMenu.value = true })

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
@@ -225,7 +225,7 @@ class AppPreferences {
   val iosCallKitEnabled = mkBoolPreference(SHARED_PREFS_IOS_CALL_KIT_ENABLED, true)
   val iosCallKitCallsInRecents = mkBoolPreference(SHARED_PREFS_IOS_CALL_KIT_CALLS_IN_RECENTS, false)
 
-  val oneHandUI = mkBoolPreference(SHARED_PREFS_ONE_HAND_UI, false)
+  val oneHandUI = mkBoolPreference(SHARED_PREFS_ONE_HAND_UI, if (appPlatform.isAndroid) true else false)
 
   private fun mkIntPreference(prefName: String, default: Int) =
     SharedPreference(

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
@@ -225,7 +225,7 @@ class AppPreferences {
   val iosCallKitEnabled = mkBoolPreference(SHARED_PREFS_IOS_CALL_KIT_ENABLED, true)
   val iosCallKitCallsInRecents = mkBoolPreference(SHARED_PREFS_IOS_CALL_KIT_CALLS_IN_RECENTS, false)
 
-  val oneHandUI = mkBoolPreference(SHARED_PREFS_ONE_HAND_UI, if (appPlatform.isAndroid) true else false)
+  val oneHandUI = mkBoolPreference(SHARED_PREFS_ONE_HAND_UI, appPlatform.isAndroid)
 
   private fun mkIntPreference(prefName: String, default: Int) =
     SharedPreference(

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
@@ -6295,7 +6295,7 @@ data class AppSettings(
           uiDarkColorScheme = def.systemDarkTheme.get() ?: DefaultTheme.SIMPLEX.themeName,
           uiCurrentThemeIds = def.currentThemeIds.get(),
           uiThemes = def.themeOverrides.get(),
-          oneHandUI = if (appPlatform.isAndroid) def.oneHandUI.get() else false
+          oneHandUI = def.oneHandUI.get()
         )
     }
   }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
@@ -6230,7 +6230,7 @@ data class AppSettings(
     uiDarkColorScheme?.let { def.systemDarkTheme.set(it) }
     uiCurrentThemeIds?.let { def.currentThemeIds.set(it) }
     uiThemes?.let { def.themeOverrides.set(it.skipDuplicates()) }
-    oneHandUI?.let { def.oneHandUI.set(it) }
+    oneHandUI?.let { def.oneHandUI.set(if (appPlatform.isAndroid) it else false) }
   }
 
   companion object {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
@@ -6262,7 +6262,7 @@ data class AppSettings(
         uiDarkColorScheme = DefaultTheme.SIMPLEX.themeName,
         uiCurrentThemeIds = null,
         uiThemes = null,
-        oneHandUI = false
+        oneHandUI = appPlatform.isAndroid
       )
 
     val current: AppSettings
@@ -6295,7 +6295,7 @@ data class AppSettings(
           uiDarkColorScheme = def.systemDarkTheme.get() ?: DefaultTheme.SIMPLEX.themeName,
           uiCurrentThemeIds = def.currentThemeIds.get(),
           uiThemes = def.themeOverrides.get(),
-          oneHandUI = def.oneHandUI.get()
+          oneHandUI = if (appPlatform.isAndroid) def.oneHandUI.get() else false
         )
     }
   }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
@@ -6262,7 +6262,7 @@ data class AppSettings(
         uiDarkColorScheme = DefaultTheme.SIMPLEX.themeName,
         uiCurrentThemeIds = null,
         uiThemes = null,
-        oneHandUI = appPlatform.isAndroid
+        oneHandUI = true
       )
 
     val current: AppSettings

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListNavLinkView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListNavLinkView.kt
@@ -35,7 +35,7 @@ import kotlinx.coroutines.*
 import kotlinx.datetime.Clock
 
 @Composable
-fun ChatListNavLinkView(chat: Chat, nextChatSelected: State<Boolean>, oneHandUI: State<Boolean>) {
+fun ChatListNavLinkView(chat: Chat, nextChatSelected: State<Boolean>) {
   val showMenu = remember { mutableStateOf(false) }
   val showMarkRead = remember(chat.chatStats.unreadCount, chat.chatStats.unreadChat) {
     chat.chatStats.unreadCount > 0 || chat.chatStats.unreadChat
@@ -81,7 +81,6 @@ fun ChatListNavLinkView(chat: Chat, nextChatSelected: State<Boolean>, oneHandUI:
         disabled,
         selectedChat,
         nextChatSelected,
-        oneHandUI
       )
     }
     is ChatInfo.Group ->
@@ -101,7 +100,6 @@ fun ChatListNavLinkView(chat: Chat, nextChatSelected: State<Boolean>, oneHandUI:
         disabled,
         selectedChat,
         nextChatSelected,
-        oneHandUI
       )
     is ChatInfo.Local -> {
       ChatListNavLinkLayout(
@@ -120,7 +118,6 @@ fun ChatListNavLinkView(chat: Chat, nextChatSelected: State<Boolean>, oneHandUI:
         disabled,
         selectedChat,
         nextChatSelected,
-        oneHandUI
       )
     }
     is ChatInfo.ContactRequest ->
@@ -140,7 +137,6 @@ fun ChatListNavLinkView(chat: Chat, nextChatSelected: State<Boolean>, oneHandUI:
         disabled,
         selectedChat,
         nextChatSelected,
-        oneHandUI
       )
     is ChatInfo.ContactConnection ->
       ChatListNavLinkLayout(
@@ -161,7 +157,6 @@ fun ChatListNavLinkView(chat: Chat, nextChatSelected: State<Boolean>, oneHandUI:
         disabled,
         selectedChat,
         nextChatSelected,
-        oneHandUI
       )
     is ChatInfo.InvalidJSON ->
       ChatListNavLinkLayout(
@@ -178,7 +173,6 @@ fun ChatListNavLinkView(chat: Chat, nextChatSelected: State<Boolean>, oneHandUI:
         disabled,
         selectedChat,
         nextChatSelected,
-        oneHandUI
       )
   }
 }
@@ -879,7 +873,6 @@ expect fun ChatListNavLinkLayout(
   disabled: Boolean,
   selectedChat: State<Boolean>,
   nextChatSelected: State<Boolean>,
-  oneHandUI: State<Boolean>
 )
 
 @Preview/*(
@@ -923,7 +916,6 @@ fun PreviewChatListNavLinkDirect() {
       disabled = false,
       selectedChat = remember { mutableStateOf(false) },
       nextChatSelected = remember { mutableStateOf(false) },
-      oneHandUI = remember { mutableStateOf(false) }
     )
   }
 }
@@ -969,7 +961,6 @@ fun PreviewChatListNavLinkGroup() {
       disabled = false,
       selectedChat = remember { mutableStateOf(false) },
       nextChatSelected = remember { mutableStateOf(false) },
-      oneHandUI = remember { mutableStateOf(false) }
     )
   }
 }
@@ -992,7 +983,6 @@ fun PreviewChatListNavLinkContactRequest() {
       disabled = false,
       selectedChat = remember { mutableStateOf(false) },
       nextChatSelected = remember { mutableStateOf(false) },
-      oneHandUI = remember { mutableStateOf(false) }
     )
   }
 }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
@@ -585,7 +585,7 @@ private fun ChatList(chatModel: ChatModel, searchText: MutableState<TextFieldVal
                 (appPlatform.isAndroid && keyboardState == KeyboardState.Opened)
               ) {
                 0
-              } else if (listState.firstVisibleItemIndex == 0) offsetMultiplier*listState.firstVisibleItemScrollOffset else offsetMultiplier*1000
+              } else if (listState.firstVisibleItemIndex == 0) offsetMultiplier * listState.firstVisibleItemScrollOffset else offsetMultiplier * 1000
             } else {
               0
             }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ShareListNavLinkView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ShareListNavLinkView.kt
@@ -6,7 +6,6 @@ import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -22,8 +21,7 @@ fun ShareListNavLinkView(
   chatModel: ChatModel,
   isMediaOrFileAttachment: Boolean,
   isVoice: Boolean,
-  hasSimplexLink: Boolean,
-  oneHandUI: State<Boolean>
+  hasSimplexLink: Boolean
 ) {
   val stopped = chatModel.chatRunning.value == false
   val scope = rememberCoroutineScope()
@@ -31,7 +29,7 @@ fun ShareListNavLinkView(
     is ChatInfo.Direct -> {
       val voiceProhibited = isVoice && !chat.chatInfo.featureEnabled(ChatFeature.Voice)
       ShareListNavLinkLayout(
-        chatLinkPreview = { SharePreviewView(chat, disabled = voiceProhibited, oneHandUI = oneHandUI) },
+        chatLinkPreview = { SharePreviewView(chat, disabled = voiceProhibited) },
         click = {
           if (voiceProhibited) {
             showForwardProhibitedByPrefAlert()
@@ -48,7 +46,7 @@ fun ShareListNavLinkView(
       val voiceProhibited = isVoice && !chat.chatInfo.featureEnabled(ChatFeature.Voice)
       val prohibitedByPref = simplexLinkProhibited || fileProhibited || voiceProhibited
       ShareListNavLinkLayout(
-        chatLinkPreview = { SharePreviewView(chat, disabled = prohibitedByPref, oneHandUI = oneHandUI) },
+        chatLinkPreview = { SharePreviewView(chat, disabled = prohibitedByPref) },
         click = {
           if (prohibitedByPref) {
             showForwardProhibitedByPrefAlert()
@@ -61,7 +59,7 @@ fun ShareListNavLinkView(
     }
     is ChatInfo.Local ->
       ShareListNavLinkLayout(
-        chatLinkPreview = { SharePreviewView(chat, disabled = false, oneHandUI = oneHandUI) },
+        chatLinkPreview = { SharePreviewView(chat, disabled = false) },
         click = { scope.launch { noteFolderChatAction(chat.remoteHostId, chat.chatInfo.noteFolder) } },
         stopped
       )
@@ -89,15 +87,9 @@ private fun ShareListNavLinkLayout(
 }
 
 @Composable
-private fun SharePreviewView(chat: Chat, disabled: Boolean, oneHandUI: State<Boolean>) {
-  var modifier = Modifier.fillMaxSize()
-
-  if (oneHandUI.value) {
-    modifier = modifier.scale(scaleX = 1f, scaleY = -1f)
-  }
-
+private fun SharePreviewView(chat: Chat, disabled: Boolean) {
   Row(
-    modifier,
+    Modifier.fillMaxSize(),
     horizontalArrangement = Arrangement.SpaceBetween,
     verticalAlignment = Alignment.CenterVertically
   ) {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ShareListView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ShareListView.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import dev.icerock.moko.resources.compose.painterResource
 import dev.icerock.moko.resources.compose.stringResource
@@ -15,6 +14,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import chat.simplex.common.SettingsViewState
 import chat.simplex.common.model.*
+import chat.simplex.common.model.ChatController.appPrefs
 import chat.simplex.common.views.helpers.*
 import chat.simplex.common.platform.*
 import chat.simplex.res.MR
@@ -25,7 +25,7 @@ fun ShareListView(chatModel: ChatModel, settingsState: SettingsViewState, stoppe
   var searchInList by rememberSaveable { mutableStateOf("") }
   val (userPickerState, scaffoldState) = settingsState
   val endPadding = if (appPlatform.isDesktop) 56.dp else 0.dp
-  val oneHandUI = remember { chatModel.controller.appPrefs.oneHandUI }
+  val oneHandUI = remember { appPrefs.oneHandUI.state }
 
   Scaffold(
     Modifier.padding(end = endPadding),
@@ -33,7 +33,7 @@ fun ShareListView(chatModel: ChatModel, settingsState: SettingsViewState, stoppe
     drawerContentColor = LocalContentColor.current,
     scaffoldState = scaffoldState,
     topBar = {
-      if (!oneHandUI.state.value) {
+      if (!oneHandUI.value) {
         Column {
           ShareListToolbar(chatModel, userPickerState, stopped) { searchInList = it.trim() }
           Divider()
@@ -41,7 +41,7 @@ fun ShareListView(chatModel: ChatModel, settingsState: SettingsViewState, stoppe
       }
     },
     bottomBar = {
-      if (oneHandUI.state.value) {
+      if (oneHandUI.value) {
         Column {
           Divider()
           ShareListToolbar(chatModel, userPickerState, stopped) { searchInList = it.trim() }
@@ -74,15 +74,9 @@ fun ShareListView(chatModel: ChatModel, settingsState: SettingsViewState, stoppe
       }
       null -> {}
     }
-    var modifier = Modifier.fillMaxSize()
-
-    if (oneHandUI.state.value) {
-      modifier = modifier.scale(scaleX = 1f, scaleY = -1f)
-    }
-
     Box(Modifier.padding(it)) {
       Column(
-        modifier = modifier
+        modifier = Modifier.fillMaxSize()
       ) {
         if (chatModel.chats.value.isNotEmpty()) {
           ShareList(
@@ -91,10 +85,9 @@ fun ShareListView(chatModel: ChatModel, settingsState: SettingsViewState, stoppe
             isMediaOrFileAttachment = isMediaOrFileAttachment,
             isVoice = isVoice,
             hasSimplexLink = hasSimplexLink,
-            oneHandUI = oneHandUI.state
           )
         } else {
-          EmptyList(oneHandUI = oneHandUI.state)
+          EmptyList()
         }
       }
     }
@@ -115,14 +108,8 @@ private fun hasSimplexLink(msg: String): Boolean {
 }
 
 @Composable
-private fun EmptyList(oneHandUI: State<Boolean>) {
-  var modifier = Modifier.fillMaxSize()
-
-  if (oneHandUI.value) {
-    modifier = modifier.scale(scaleX = 1f, scaleY = -1f)
-  }
-
-  Box(modifier, contentAlignment = Alignment.Center) {
+private fun EmptyList() {
+  Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
     Text(stringResource(MR.strings.you_have_no_chats), color = MaterialTheme.colors.secondary)
   }
 }
@@ -212,8 +199,8 @@ private fun ShareList(
   isMediaOrFileAttachment: Boolean,
   isVoice: Boolean,
   hasSimplexLink: Boolean,
-  oneHandUI: State<Boolean>
 ) {
+  val oneHandUI = remember { appPrefs.oneHandUI.state }
   val chats by remember(search) {
     derivedStateOf {
       val sorted = chatModel.chats.value.toList().sortedByDescending { it.chatInfo is ChatInfo.Local }
@@ -225,7 +212,8 @@ private fun ShareList(
     }
   }
   LazyColumnWithScrollBar(
-    modifier = Modifier.fillMaxWidth()
+    modifier = Modifier.fillMaxSize(),
+    reverseLayout = oneHandUI.value
   ) {
     items(chats) { chat ->
       ShareListNavLinkView(
@@ -234,7 +222,6 @@ private fun ShareList(
         isMediaOrFileAttachment = isMediaOrFileAttachment,
         isVoice = isVoice,
         hasSimplexLink = hasSimplexLink,
-        oneHandUI = oneHandUI
       )
     }
   }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ShareListView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ShareListView.kt
@@ -32,9 +32,23 @@ fun ShareListView(chatModel: ChatModel, settingsState: SettingsViewState, stoppe
     contentColor = LocalContentColor.current,
     drawerContentColor = LocalContentColor.current,
     scaffoldState = scaffoldState,
-    topBar = { if (!oneHandUI.state.value) Column { ShareListToolbar(chatModel, userPickerState, stopped) { searchInList = it.trim() } } },
-    bottomBar = { if (oneHandUI.state.value) Column { ShareListToolbar(chatModel, userPickerState, stopped) { searchInList = it.trim() } } },
-    ) {
+    topBar = {
+      if (!oneHandUI.state.value) {
+        Column {
+          ShareListToolbar(chatModel, userPickerState, stopped) { searchInList = it.trim() }
+          Divider()
+        }
+      }
+    },
+    bottomBar = {
+      if (oneHandUI.state.value) {
+        Column {
+          Divider()
+          ShareListToolbar(chatModel, userPickerState, stopped) { searchInList = it.trim() }
+        }
+      }
+    }
+  ) {
     val sharedContent = chatModel.sharedContent.value
     var isMediaOrFileAttachment = false
     var isVoice = false
@@ -189,7 +203,6 @@ private fun ShareListToolbar(chatModel: ChatModel, userPickerState: MutableState
     onSearchValueChanged = onSearchValueChanged,
     buttons = barButtons
   )
-  Divider()
 }
 
 @Composable

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/contacts/ContactListNavView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/contacts/ContactListNavView.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.graphics.Color
 import dev.icerock.moko.resources.compose.painterResource
 import dev.icerock.moko.resources.compose.stringResource
 import chat.simplex.common.model.*
-import chat.simplex.common.model.ChatController.appPrefs
 import chat.simplex.common.model.ChatModel.withChats
 import chat.simplex.common.platform.*
 import chat.simplex.common.views.chat.*
@@ -29,7 +28,6 @@ fun onRequestAccepted(chat: Chat) {
 
 @Composable
 fun ContactListNavLinkView(chat: Chat, nextChatSelected: State<Boolean>, showDeletedChatIcon: Boolean) {
-    val oneHandUI = remember { appPrefs.oneHandUI.state }
     val showMenu = remember { mutableStateOf(false) }
     val rhId = chat.remoteHostId
     val disabled = chatModel.chatRunning.value == false || chatModel.deletedChats.value.contains(rhId to chat.chatInfo.id)

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/contacts/ContactListNavView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/contacts/ContactListNavView.kt
@@ -90,7 +90,6 @@ fun ContactListNavLinkView(chat: Chat, nextChatSelected: State<Boolean>, showDel
                 disabled,
                 selectedChat,
                 nextChatSelected,
-                oneHandUI
             )
         }
         is ChatInfo.ContactRequest -> {
@@ -123,9 +122,7 @@ fun ContactListNavLinkView(chat: Chat, nextChatSelected: State<Boolean>, showDel
                 showMenu,
                 disabled,
                 selectedChat,
-                nextChatSelected,
-                oneHandUI
-            )
+                nextChatSelected)
         }
         else -> {}
     }

--- a/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
@@ -1288,7 +1288,7 @@
   <string name="database_downgrade">Database downgrade</string>
   <string name="incompatible_database_version">Incompatible database version</string>
   <string name="confirm_database_upgrades">Confirm database upgrades</string>
-  <string name="one_hand_ui">One-hand UI</string>
+  <string name="one_hand_ui">Reachable chat toolbar</string>
   <string name="terminal_always_visible">Show console in new window</string>
   <string name="chat_list_always_visible">Show chat list in new window</string>
   <string name="invalid_migration_confirmation">Invalid migration confirmation</string>

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/views/chatlist/ChatListNavLinkView.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/views/chatlist/ChatListNavLinkView.desktop.kt
@@ -35,7 +35,6 @@ actual fun ChatListNavLinkLayout(
   disabled: Boolean,
   selectedChat: State<Boolean>,
   nextChatSelected: State<Boolean>,
-  oneHandUI: State<Boolean>,
 ) {
   var modifier = Modifier.fillMaxWidth()
   if (!disabled) modifier = modifier


### PR DESCRIPTION
- [x] Fix share bottom bar
- [x] Renamed one hand UI label to "Reachable chat toolbar"
- [x] One hand UI should be android default
- [x] Use reserve as opposed to mirror
- [x] Make sure one hand ui is always false on desktop 