### PR TITLE
ui: improve french translation

### DIFF
--- a/apps/ios/SimpleX Localizations/fr.xcloc/Localized Contents/fr.xliff
+++ b/apps/ios/SimpleX Localizations/fr.xcloc/Localized Contents/fr.xliff
@@ -7842,7 +7842,7 @@ Les serveurs SimpleX ne peuvent pas voir votre profil.</target>
       </trans-unit>
       <trans-unit id="blocked" xml:space="preserve">
         <source>blocked</source>
-        <target>blocké</target>
+        <target>bloqué</target>
         <note>marked deleted chat item preview text</note>
       </trans-unit>
       <trans-unit id="blocked %@" xml:space="preserve">

--- a/apps/ios/fr.lproj/Localizable.strings
+++ b/apps/ios/fr.lproj/Localizable.strings
@@ -689,7 +689,7 @@
 "Block member?" = "Bloquer ce membre ?";
 
 /* marked deleted chat item preview text */
-"blocked" = "blocké";
+"blocked" = "bloqué";
 
 /* rcv group event chat item */
 "blocked %@" = "%@ bloqué";

--- a/apps/multiplatform/common/src/commonMain/resources/MR/fr/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/fr/strings.xml
@@ -1444,7 +1444,7 @@
     <string name="connect_plan_you_have_already_requested_connection_via_this_address">Vous avez déjà demandé une connexion via cette adresse !</string>
     <string name="terminal_always_visible">Afficher la console dans une nouvelle fenêtre</string>
     <string name="block_member_desc">Tous les nouveaux messages provenant de %s seront cachés !</string>
-    <string name="blocked_item_description">blocké</string>
+    <string name="blocked_item_description">bloqué</string>
     <string name="encryption_renegotiation_error">Erreur lors de la renégociation du chiffrement</string>
     <string name="alert_text_encryption_renegotiation_failed">La renégociation du chiffrement a échoué.</string>
     <string name="v5_4_block_group_members">Bloquer des membres d\'un groupe</string>


### PR DESCRIPTION
Updated the French translation by fixing the term "blocké" to "bloqué" for accuracy and consistency. This change ensures proper spelling and better alignment with standard French usage.