### PR TITLE
ios: fix pending connection sheet styling when opened via icon; fix tappable area of pending connections and contact requests

### DIFF
--- a/apps/ios/Shared/Views/ChatList/ChatListNavLink.swift
+++ b/apps/ios/Shared/Views/ChatList/ChatListNavLink.swift
@@ -355,6 +355,7 @@ struct ChatListNavLink: View {
             .tint(.red)
         }
         .frame(height: dynamicRowHeight)
+        .contentShape(Rectangle())
         .onTapGesture { showContactRequestDialog = true }
         .confirmationDialog("Accept connection request?", isPresented: $showContactRequestDialog, titleVisibility: .visible) {
             Button("Accept") { Task { await acceptContactRequest(incognito: false, contactRequest: contactRequest) } }

--- a/apps/ios/Shared/Views/ChatList/ChatListNavLink.swift
+++ b/apps/ios/Shared/Views/ChatList/ChatListNavLink.swift
@@ -392,6 +392,7 @@ struct ChatListNavLink: View {
                 }
             }
         }
+        .contentShape(Rectangle())
         .onTapGesture {
             showContactConnectionInfo = true
         }

--- a/apps/ios/Shared/Views/ChatList/ContactConnectionView.swift
+++ b/apps/ios/Shared/Views/ChatList/ContactConnectionView.swift
@@ -16,7 +16,6 @@ struct ContactConnectionView: View {
     @Environment(\.dynamicTypeSize) private var userFont: DynamicTypeSize
     @State private var localAlias = ""
     @FocusState private var aliasTextFieldFocused: Bool
-    @State private var showContactConnectionInfo = false
 
     var body: some View {
         if case let .contactConnection(conn) = chat.chatInfo {
@@ -32,7 +31,6 @@ struct ContactConnectionView: View {
                     .scaledToFill()
                     .frame(width: 48, height: 48)
                     .foregroundColor(Color(uiColor: .tertiarySystemGroupedBackground).asAnotherColorFromSecondaryVariant(theme))
-                    .onTapGesture { showContactConnectionInfo = true }
             }
             .frame(width: 63, height: 63)
             .padding(.leading, 4)
@@ -72,9 +70,6 @@ struct ContactConnectionView: View {
                 Spacer()
             }
             .frame(maxHeight: .infinity)
-            .appSheet(isPresented: $showContactConnectionInfo) {
-                ContactConnectionInfo(contactConnection: contactConnection)
-            }
         }
     }
 }


### PR DESCRIPTION
## Issue

Fixes "You invited a contact" sheet having incorrect styling, when invoked from the "link" icon.

## Approach

Extends the tap gesture to the whole navigation link using `.contentShape(Rectangle())`, so that the second sheet is no longer required.

## Before > After

<img width=320 src="https://github.com/user-attachments/assets/189e3245-50d2-42e4-a31f-197f10a8b5e9">
<img width=320 src="https://github.com/user-attachments/assets/3f9c95d2-8dd9-40ca-9d0f-9c2201f20bb3">
