### PR TITLE
ios: asynchronous api calls when entering foreground

### DIFF
--- a/apps/ios/Shared/Model/SimpleXAPI.swift
+++ b/apps/ios/Shared/Model/SimpleXAPI.swift
@@ -2166,7 +2166,7 @@ func refreshCallInvitations() async throws {
     let callInvitations = try await justRefreshCallInvitations()
     if let (chatId, ntfAction) = m.ntfCallInvitationAction,
        let invitation = m.callInvitations.removeValue(forKey: chatId) {
-        m.ntfCallInvitationAction = nil
+        await MainActor.run { m.ntfCallInvitationAction = nil }
         CallController.shared.callAction(invitation: invitation, action: ntfAction)
     } else if let invitation = callInvitations.last(where: { $0.user.showNotifications }) {
         activateCall(invitation)

--- a/apps/ios/Shared/SimpleXApp.swift
+++ b/apps/ios/Shared/SimpleXApp.swift
@@ -150,10 +150,12 @@ struct SimpleXApp: App {
     }
 
     private func updateCallInvitations() {
-        do {
-            try refreshCallInvitations()
-        } catch let error {
-            logger.error("apiGetCallInvitations: cannot update call invitations \(responseError(error))")
+        Task {
+            do {
+                try await refreshCallInvitations()
+            } catch let error {
+                logger.error("apiGetCallInvitations: cannot update call invitations \(responseError(error))")
+            }
         }
     }
 }

--- a/apps/ios/Shared/Views/Call/CallController.swift
+++ b/apps/ios/Shared/Views/Call/CallController.swift
@@ -198,8 +198,11 @@ class CallController: NSObject, CXProviderDelegate, PKPushRegistryDelegate, Obse
                 if let uuid = invitation.callkitUUID {
                     logger.debug("CallController: report pushkit call via CallKit")
                     let update = self.cxCallUpdate(invitation: invitation)
-                    do { try await self.provider.reportNewIncomingCall(with: uuid, update: update) }
-                    catch { m.callInvitations.removeValue(forKey: contactId) }
+                    do {
+                        try await self.provider.reportNewIncomingCall(with: uuid, update: update)
+                    } catch {
+                        _ = await MainActor.run { m.callInvitations.removeValue(forKey: contactId) }
+                    }
                     completion()
                 } else {
                     self.reportExpiredCall(update: update, completion)

--- a/apps/ios/Shared/Views/ChatList/UserPicker.swift
+++ b/apps/ios/Shared/Views/ChatList/UserPicker.swift
@@ -89,8 +89,8 @@ struct UserPicker: View {
             if case .active = scenePhase {
                 Task {
                     do {
-                        let u = try await listUsersAsync()
-                        await MainActor.run { m.users = u }
+                        let users = try await listUsersAsync()
+                        await MainActor.run { m.users = users }
                     } catch {
                         logger.error("Error loading users \(responseError(error))")
                     }

--- a/apps/ios/Shared/Views/ChatList/UserPicker.swift
+++ b/apps/ios/Shared/Views/ChatList/UserPicker.swift
@@ -85,13 +85,16 @@ struct UserPicker: View {
         .padding(8)
         .opacity(userPickerVisible ? 1.0 : 0.0)
         .onAppear {
-            do {
-                // This check prevents the call of listUsers after the app is suspended, and the database is closed.
-                if case .active = scenePhase {
-                    m.users = try listUsers()
+            // This check prevents the call of listUsers after the app is suspended, and the database is closed.
+            if case .active = scenePhase {
+                Task {
+                    do {
+                        let u = try await listUsersAsync()
+                        await MainActor.run { m.users = u }
+                    } catch {
+                        logger.error("Error loading users \(responseError(error))")
+                    }
                 }
-            } catch let error {
-                logger.error("Error loading users \(responseError(error))")
             }
         }
     }


### PR DESCRIPTION
Moves all of the api calls (excpt `apiActivate`), which occur on main thread during entering foreground:
- `apiGetCallInvitations`
- `apiGetChats`
- `apiListUsers`

Further improvements:
- `apiActivate` chat remains sync due to it occurring in `suspendLockQueue.sync` block.
- `ChatModel.updateChats(with newChats: [ChatData])` does processing in nested loops, potentially degrading performance when many chats are added.