### PR TITLE
ios: fix last message being hidden on load

### DIFF
--- a/apps/ios/Shared/Views/Chat/ReverseList.swift
+++ b/apps/ios/Shared/Views/Chat/ReverseList.swift
@@ -180,6 +180,13 @@ struct ReverseList<Item: Identifiable & Hashable & Sendable, Content: View>: UIV
                 snapshot,
                 animatingDifferences: itemCount != 0 && abs(items.count - itemCount) == 1
             )
+            // Sets content offset on initial load
+            if itemCount == 0 {
+                tableView.setContentOffset(
+                    CGPoint(x: 0, y: -InvertedTableView.inset),
+                    animated: false
+                )
+            }
             itemCount = items.count
         }
     }


### PR DESCRIPTION
Manually sets the right offset, when items are loaded into an empty list