### PR TITLE
multiplatform: fix deleted contacts with conversations being identified as contact cards

### DIFF
--- a/apps/ios/Shared/Views/NewChat/NewChatMenuButton.swift
+++ b/apps/ios/Shared/Views/NewChat/NewChatMenuButton.swift
@@ -199,7 +199,7 @@ func chatContactType(chat: Chat) -> ContactType {
     case .contactRequest:
         return .request
     case let .direct(contact):
-        if contact.activeConn == nil && contact.profile.contactLink != nil && contact.active {
+        if contact.activeConn == nil && contact.profile.contactLink != nil {
             return .card
         } else if contact.chatDeleted {
             return .chatDeleted

--- a/apps/ios/Shared/Views/NewChat/NewChatMenuButton.swift
+++ b/apps/ios/Shared/Views/NewChat/NewChatMenuButton.swift
@@ -199,7 +199,7 @@ func chatContactType(chat: Chat) -> ContactType {
     case .contactRequest:
         return .request
     case let .direct(contact):
-        if contact.activeConn == nil && contact.profile.contactLink != nil {
+        if contact.activeConn == nil && contact.profile.contactLink != nil && contact.active {
             return .card
         } else if contact.chatDeleted {
             return .chatDeleted

--- a/apps/ios/SimpleX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apps/ios/SimpleX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kirualex/SwiftyGif",
       "state" : {
-        "branch" : "master",
-        "revision" : "7c50eb60ca4b90043c6ad719d595803488496212"
+        "revision" : "5e8619335d394901379c9add5c4c1c2f420b3800"
       }
     },
     {

--- a/apps/ios/SimpleX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apps/ios/SimpleX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,7 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kirualex/SwiftyGif",
       "state" : {
-        "revision" : "5e8619335d394901379c9add5c4c1c2f420b3800"
+        "branch" : "master",
+        "revision" : "7c50eb60ca4b90043c6ad719d595803488496212"
       }
     },
     {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListNavLinkView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListNavLinkView.kt
@@ -186,7 +186,7 @@ fun ErrorChatListItem() {
 
 suspend fun directChatAction(rhId: Long?, contact: Contact, chatModel: ChatModel) {
   when {
-    contact.activeConn == null && contact.profile.contactLink != null && contact.contactStatus == ContactStatus.Active -> askCurrentOrIncognitoProfileConnectContactViaAddress(chatModel, rhId, contact, close = null, openChat = true)
+    contact.activeConn == null && contact.profile.contactLink != null && contact.active -> askCurrentOrIncognitoProfileConnectContactViaAddress(chatModel, rhId, contact, close = null, openChat = true)
     else -> openChat(rhId, ChatInfo.Direct(contact), chatModel)
   }
 }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListNavLinkView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListNavLinkView.kt
@@ -186,7 +186,7 @@ fun ErrorChatListItem() {
 
 suspend fun directChatAction(rhId: Long?, contact: Contact, chatModel: ChatModel) {
   when {
-    contact.activeConn == null && contact.profile.contactLink != null -> askCurrentOrIncognitoProfileConnectContactViaAddress(chatModel, rhId, contact, close = null, openChat = true)
+    contact.activeConn == null && contact.profile.contactLink != null && contact.contactStatus == ContactStatus.Active -> askCurrentOrIncognitoProfileConnectContactViaAddress(chatModel, rhId, contact, close = null, openChat = true)
     else -> openChat(rhId, ChatInfo.Direct(contact), chatModel)
   }
 }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatSheet.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatSheet.kt
@@ -99,7 +99,7 @@ fun chatContactType(chat: Chat): ContactType {
       val contact = cInfo.contact
 
       when {
-        contact.activeConn == null && contact.profile.contactLink != null -> ContactType.CARD
+        contact.activeConn == null && contact.profile.contactLink != null && contact.contactStatus == ContactStatus.Active -> ContactType.CARD
         contact.chatDeleted -> ContactType.CHAT_DELETED
         contact.contactStatus == ContactStatus.Active -> ContactType.RECENT
         else -> ContactType.UNLISTED

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatSheet.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatSheet.kt
@@ -99,7 +99,7 @@ fun chatContactType(chat: Chat): ContactType {
       val contact = cInfo.contact
 
       when {
-        contact.activeConn == null && contact.profile.contactLink != null && contact.contactStatus == ContactStatus.Active -> ContactType.CARD
+        contact.activeConn == null && contact.profile.contactLink != null && contact.active -> ContactType.CARD
         contact.chatDeleted -> ContactType.CHAT_DELETED
         contact.contactStatus == ContactStatus.Active -> ContactType.RECENT
         else -> ContactType.UNLISTED


### PR DESCRIPTION
Our identification of contact cards was incorrect, because of that some deletion of conversation was missidentified as contact cards.

To reproduce the issue in `stable`

1. Create a new profile
2. Create a public address for the profile, and share the link with contacts
3. Go to your main profile and add the profile with the link from step 2.
4. Accept the invitation from the new profile
5. Delete the new profile, including server connections
6. In your main profile, delete contact and keep conversation