### PR TITLE
android, desktop: reset incognito on profile picker

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatView.kt
@@ -308,6 +308,7 @@ fun ActiveProfilePicker(
         switchingProfile.value = true
         withApi {
           try {
+            appPreferences.incognito.set(false)
             var updatedConn: PendingContactConnection? = null;
 
             if (contactConnection != null) {
@@ -361,6 +362,7 @@ fun ActiveProfilePicker(
         switchingProfile.value = true
         withApi {
           try {
+            appPreferences.incognito.set(true)
             val conn = controller.apiSetConnectionIncognito(rhId, contactConnection.pccConnId, true)
             if (conn != null) {
               withChats {


### PR DESCRIPTION
To match ios behaviour.

There was also an issue where if someone did have the pref for incognito turned on (by for example toogle on group creation) it would be impossible to stop having incognito as the default on profile picker