### PR TITLE
desktop: cleanup current invitation when closing new chat sheet by pressing on center modal

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatView.kt
@@ -68,7 +68,7 @@ fun ModalData.NewChatView(rh: RemoteHostInfo?, selection: NewChatOption, showQRC
        * Otherwise, it will be called here AFTER [AddContactLearnMore] is launched and will clear the value too soon.
        * It will be dropped automatically when connection established or when user goes away from this screen.
        **/
-      if (chatModel.showingInvitation.value != null && ModalManager.start.openModalCount() == 1) {
+      if (chatModel.showingInvitation.value != null && ModalManager.start.openModalCount() <= 1) {
         val conn = contactConnection.value
         if (chatModel.showingInvitation.value?.connChatUsed == false && conn != null) {
           AlertManager.shared.showAlertDialog(


### PR DESCRIPTION
Fixes such issue:
- on desktop open new chat sheet -> create new link
- close by pressing on center (in master it doesn't pass check on modal number and cleanup is not done)
- open new chat sheet and go to link creation again - same link is shown