### PR TITLE
desktop: fix typescript sdk ability to send / receive messages

### DIFF
--- a/packages/simplex-chat-client/typescript/examples/squaring-bot.js
+++ b/packages/simplex-chat-client/typescript/examples/squaring-bot.js
@@ -35,15 +35,16 @@ async function run() {
           )
           continue
         }
-        case "newChatItem": {
+        case "newChatItems": {
           // calculates the square of the number and sends the reply
-          const {chatInfo} = resp.chatItem
-          if (chatInfo.type !== ChatInfoType.Direct) continue
-          const msg = ciContentText(resp.chatItem.chatItem.content)
-          if (msg) {
-            const n = +msg
-            const reply = typeof n === "number" && !isNaN(n) ? `${n} * ${n} = ${n * n}` : `this is not a number`
-            await chat.apiSendTextMessage(ChatType.Direct, chatInfo.contact.contactId, reply)
+          for (const {chatInfo, chatItem} of resp.chatItems) {
+            if (chatInfo.type !== ChatInfoType.Direct) continue
+            const msg = ciContentText(chatItem.content)
+            if (msg) {
+              const n = +msg
+              const reply = typeof n === "number" && !isNaN(n) ? `${n} * ${n} = ${n * n}` : `this is not a number`
+              await chat.apiSendTextMessage(ChatType.Direct, chatInfo.contact.contactId, reply)
+            }
           }
         }
       }

--- a/packages/simplex-chat-client/typescript/package.json
+++ b/packages/simplex-chat-client/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplex-chat",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "SimpleX Chat client",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/simplex-chat-client/typescript/src/client.ts
+++ b/packages/simplex-chat-client/typescript/src/client.ts
@@ -160,14 +160,14 @@ export class ChatClient {
     throw new ChatCommandError("error loading chat", r)
   }
 
-  async apiSendMessage(chatType: ChatType, chatId: number, message: CC.ComposedMessage): Promise<CR.AChatItem> {
+  async apiSendMessage(chatType: ChatType, chatId: number, message: CC.ComposedMessage[]): Promise<CR.AChatItem[]> {
     const r = await this.sendChatCommand({type: "apiSendMessage", chatType, chatId, message})
-    if (r.type === "newChatItem") return r.chatItem
+    if (r.type === "newChatItems") return r.chatItems
     throw new ChatCommandError("unexpected response", r)
   }
 
-  apiSendTextMessage(chatType: ChatType, chatId: number, text: string): Promise<CR.AChatItem> {
-    return this.apiSendMessage(chatType, chatId, {msgContent: {type: "text", text}})
+  apiSendTextMessage(chatType: ChatType, chatId: number, text: string): Promise<CR.AChatItem[]> {
+    return this.apiSendMessage(chatType, chatId, [{msgContent: {type: "text", text}}])
   }
 
   async apiUpdateChatItem(chatType: ChatType, chatId: number, chatItemId: CC.ChatItemId, msgContent: CC.MsgContent): Promise<CR.ChatItem> {

--- a/packages/simplex-chat-client/typescript/src/client.ts
+++ b/packages/simplex-chat-client/typescript/src/client.ts
@@ -160,14 +160,14 @@ export class ChatClient {
     throw new ChatCommandError("error loading chat", r)
   }
 
-  async apiSendMessage(chatType: ChatType, chatId: number, message: CC.ComposedMessage[]): Promise<CR.AChatItem[]> {
-    const r = await this.sendChatCommand({type: "apiSendMessage", chatType, chatId, message})
+  async apiSendMessages(chatType: ChatType, chatId: number, messages: CC.ComposedMessage[]): Promise<CR.AChatItem[]> {
+    const r = await this.sendChatCommand({type: "apiSendMessage", chatType, chatId, messages})
     if (r.type === "newChatItems") return r.chatItems
     throw new ChatCommandError("unexpected response", r)
   }
 
-  apiSendTextMessage(chatType: ChatType, chatId: number, text: string): Promise<CR.AChatItem[]> {
-    return this.apiSendMessage(chatType, chatId, [{msgContent: {type: "text", text}}])
+  async apiSendTextMessage(chatType: ChatType, chatId: number, text: string): Promise<CR.AChatItem[]> {
+    return this.apiSendMessages(chatType, chatId, [{msgContent: {type: "text", text}}])
   }
 
   async apiUpdateChatItem(chatType: ChatType, chatId: number, chatItemId: CC.ChatItemId, msgContent: CC.MsgContent): Promise<CR.ChatItem> {

--- a/packages/simplex-chat-client/typescript/src/command.ts
+++ b/packages/simplex-chat-client/typescript/src/command.ts
@@ -277,7 +277,7 @@ export interface APISendMessage extends IChatCommand {
   type: "apiSendMessage"
   chatType: ChatType
   chatId: number
-  message: ComposedMessage
+  message: ComposedMessage[]
 }
 
 export interface ComposedMessage {

--- a/packages/simplex-chat-client/typescript/src/command.ts
+++ b/packages/simplex-chat-client/typescript/src/command.ts
@@ -277,7 +277,7 @@ export interface APISendMessage extends IChatCommand {
   type: "apiSendMessage"
   chatType: ChatType
   chatId: number
-  message: ComposedMessage[]
+  messages: ComposedMessage[]
 }
 
 export interface ComposedMessage {
@@ -709,7 +709,7 @@ export function cmdString(cmd: ChatCommand): string {
     case "apiGetChat":
       return `/_get chat ${cmd.chatType}${cmd.chatId}${paginationStr(cmd.pagination)}`
     case "apiSendMessage":
-      return `/_send ${cmd.chatType}${cmd.chatId} json ${JSON.stringify(cmd.message)}`
+      return `/_send ${cmd.chatType}${cmd.chatId} json ${JSON.stringify(cmd.messages)}`
     case "apiUpdateChatItem":
       return `/_update item ${cmd.chatType}${cmd.chatId} ${cmd.chatItemId} json ${JSON.stringify(cmd.msgContent)}`
     case "apiDeleteChatItem":

--- a/packages/simplex-chat-client/typescript/src/response.ts
+++ b/packages/simplex-chat-client/typescript/src/response.ts
@@ -12,7 +12,7 @@ export type ChatResponse =
   | CRUserProtoServers
   | CRContactInfo
   | CRGroupMemberInfo
-  | CRNewChatItem
+  | CRNewChatItems
   | CRChatItemStatusUpdated
   | CRChatItemUpdated
   | CRChatItemDeleted
@@ -109,7 +109,7 @@ type ChatResponseTag =
   | "userProtoServers"
   | "contactInfo"
   | "groupMemberInfo"
-  | "newChatItem"
+  | "newChatItems"
   | "chatItemStatusUpdated"
   | "chatItemUpdated"
   | "chatItemDeleted"
@@ -255,10 +255,10 @@ export interface CRGroupMemberInfo extends CR {
   connectionStats_?: ConnectionStats
 }
 
-export interface CRNewChatItem extends CR {
-  type: "newChatItem"
+export interface CRNewChatItems extends CR {
+  type: "newChatItems"
   user: User
-  chatItem: AChatItem
+  chatItems: AChatItem[]
 }
 
 export interface CRChatItemStatusUpdated extends CR {


### PR DESCRIPTION
As far I understand, recently you could send one message at once, now it changed and SDK wasn't able to handle properly message sending \ receiving (it just crushes). I fix it, so instead of sending \ receiving single message now you send \ receive array of messages at once