### PR TITLE
ios: fix empty qr code reader when swapping to connect via link

### DIFF
--- a/apps/ios/Shared/Views/NewChat/NewChatView.swift
+++ b/apps/ios/Shared/Views/NewChat/NewChatView.swift
@@ -97,6 +97,11 @@ struct NewChatView: View {
             }
             .pickerStyle(.segmented)
             .padding()
+            .onChange(of: $selection.wrappedValue) { opt in
+                if opt == NewChatOption.connect {
+                    showQRCodeScanner = true
+                }
+            }
 
             VStack {
                 // it seems there's a bug in iOS 15 if several views in switch (or if-else) statement have different transitions


### PR DESCRIPTION
Tested when permission is enabled and disabled, it replicates the behaviour that happens when this view is open directly from new chat sheet