### PR TITLE
ios: fix ocassional error on getSubsTotal

### DIFF
--- a/apps/ios/Shared/Views/ChatList/ChatListView.swift
+++ b/apps/ios/Shared/Views/ChatList/ChatListView.swift
@@ -437,7 +437,7 @@ struct SubsStatusIndicator: View {
     private func startTask() {
         task = Task {
             while !Task.isCancelled {
-                if AppChatState.shared.value == .active {
+                if AppChatState.shared.value == .active, ChatModel.shared.chatRunning == true {
                     do {
                         let (subs, hasSess) = try await getAgentSubsTotal()
                         await MainActor.run {


### PR DESCRIPTION
in some rare cases the following can happen as a race condition:

- Stop chat and delete database
- Go to migrate to another device
- Press back
- App can crash

In some cases it does happen that the next iteration of `getSubsTotal` will run between stages where app state is active but controller is being rebuilt and chat is still stopped. It is safer that this task also checks that the chat is running as there is no guarantee that `AppChatState` being active means the chat isn't actually stopped