### PR TITLE
android, desktop: don't stop audio track on Android in calls

### DIFF
--- a/apps/multiplatform/common/src/commonMain/resources/assets/www/call.js
+++ b/apps/multiplatform/common/src/commonMain/resources/assets/www/call.js
@@ -847,6 +847,8 @@ const processCommand = (function () {
         for (const t of source == CallMediaSource.Mic ? call.localStream.getAudioTracks() : call.localStream.getVideoTracks()) {
             if (isDesktop || source != CallMediaSource.Mic || stopTrackOnAndroid)
                 t.stop();
+            else
+                t.enabled = false;
             call.localStream.removeTrack(t);
         }
         let localStream;
@@ -896,8 +898,7 @@ const processCommand = (function () {
         if (!localStream || !oldCamera || !videos)
             return;
         if (!inactiveCallMediaSources.mic) {
-            if (isDesktop || stopTrackOnAndroid)
-                localStream.getAudioTracks().forEach((elem) => elem.stop());
+            localStream.getAudioTracks().forEach((elem) => (isDesktop || stopTrackOnAndroid ? elem.stop() : (elem.enabled = false)));
             localStream.getAudioTracks().forEach((elem) => localStream.removeTrack(elem));
         }
         if (!inactiveCallMediaSources.camera || oldCamera != newCamera) {
@@ -1162,6 +1163,8 @@ const processCommand = (function () {
                     else {
                         if (isDesktop || t.kind == CallMediaType.Video || stopTrackOnAndroid)
                             t.stop();
+                        else
+                            t.enabled = false;
                         s.removeTrack(t);
                         transceiver.sender.replaceTrack(null);
                     }

--- a/packages/simplex-chat-webrtc/src/call.ts
+++ b/packages/simplex-chat-webrtc/src/call.ts
@@ -246,7 +246,7 @@ const callCrypto = callCryptoFunction()
 
 declare var RTCRtpScriptTransform: {
   prototype: RTCRtpScriptTransform
-  new (worker: Worker, options?: any): RTCRtpScriptTransform
+  new (worker: Worker, options?: any, transfer?: any[] | undefined): RTCRtpScriptTransform
 }
 
 enum TransformOperation {
@@ -315,6 +315,8 @@ const allowSendScreenAudio = false
 // When one side of a call sends candidates tot fast (until local & remote descriptions are set), that candidates
 // will be stored here and then set when the call will be ready to process them
 let afterCallInitializedCandidates: RTCIceCandidateInit[] = []
+
+const stopTrackOnAndroid = false
 
 const processCommand = (function () {
   type RTCRtpSenderWithEncryption = RTCRtpSender & {
@@ -1141,7 +1143,7 @@ const processCommand = (function () {
     // doing it vice versa gives an error like "too many cameras were open" on some Android devices or webViews
     // which means the second camera will never be opened
     for (const t of source == CallMediaSource.Mic ? call.localStream.getAudioTracks() : call.localStream.getVideoTracks()) {
-      t.stop()
+      if (isDesktop || source != CallMediaSource.Mic || stopTrackOnAndroid) t.stop()
       call.localStream.removeTrack(t)
     }
     let localStream: MediaStream
@@ -1200,7 +1202,7 @@ const processCommand = (function () {
     if (!localStream || !oldCamera || !videos) return
 
     if (!inactiveCallMediaSources.mic) {
-      localStream.getAudioTracks().forEach((elem) => elem.stop())
+      if (isDesktop || stopTrackOnAndroid) localStream.getAudioTracks().forEach((elem) => elem.stop())
       localStream.getAudioTracks().forEach((elem) => localStream.removeTrack(elem))
     }
     if (!inactiveCallMediaSources.camera || oldCamera != newCamera) {
@@ -1474,7 +1476,7 @@ const processCommand = (function () {
           if (enable) {
             transceiver.sender.replaceTrack(t)
           } else {
-            t.stop()
+            if (isDesktop || t.kind == CallMediaType.Video || stopTrackOnAndroid) t.stop()
             s.removeTrack(t)
             transceiver.sender.replaceTrack(null)
           }

--- a/packages/simplex-chat-webrtc/src/call.ts
+++ b/packages/simplex-chat-webrtc/src/call.ts
@@ -1144,6 +1144,7 @@ const processCommand = (function () {
     // which means the second camera will never be opened
     for (const t of source == CallMediaSource.Mic ? call.localStream.getAudioTracks() : call.localStream.getVideoTracks()) {
       if (isDesktop || source != CallMediaSource.Mic || stopTrackOnAndroid) t.stop()
+      else t.enabled = false
       call.localStream.removeTrack(t)
     }
     let localStream: MediaStream
@@ -1202,7 +1203,7 @@ const processCommand = (function () {
     if (!localStream || !oldCamera || !videos) return
 
     if (!inactiveCallMediaSources.mic) {
-      if (isDesktop || stopTrackOnAndroid) localStream.getAudioTracks().forEach((elem) => elem.stop())
+      localStream.getAudioTracks().forEach((elem) => (isDesktop || stopTrackOnAndroid ? elem.stop() : (elem.enabled = false)))
       localStream.getAudioTracks().forEach((elem) => localStream.removeTrack(elem))
     }
     if (!inactiveCallMediaSources.camera || oldCamera != newCamera) {
@@ -1477,6 +1478,8 @@ const processCommand = (function () {
             transceiver.sender.replaceTrack(t)
           } else {
             if (isDesktop || t.kind == CallMediaType.Video || stopTrackOnAndroid) t.stop()
+            else t.enabled = false
+
             s.removeTrack(t)
             transceiver.sender.replaceTrack(null)
           }


### PR DESCRIPTION
There is a problem related to managing selected audio output device in call. When microphone is disabled, WebView turns speaker on without need. No way to prevent it was found yet. This is temporary workaround that makes everything work except it makes microphone icon visible in status bar (microphone is not used actually in that moment)