### PR TITLE
ios: dont show tails for moderated and blocked items unless revealed

### DIFF
--- a/apps/ios/Shared/Views/Chat/ChatView.swift
+++ b/apps/ios/Shared/Views/Chat/ChatView.swift
@@ -1187,7 +1187,7 @@ struct ChatView: View {
                     allowMenu: $allowMenu
                 )
                 .environment(\.showTimestamp, itemSeparation.timestamp)
-                .modifier(ChatItemClipped(ci, tailVisible: itemSeparation.largeGap))
+                .modifier(ChatItemClipped(ci, tailVisible: itemSeparation.largeGap, revealed: revealed))
                 .contextMenu { menu(ci, range, live: composeState.liveMessage != nil) }
                 .accessibilityLabel("")
                 if ci.content.msgContent != nil && (ci.meta.itemDeleted == nil || revealed) && ci.reactions.count > 0 {

--- a/apps/ios/Shared/Views/Chat/ChatView.swift
+++ b/apps/ios/Shared/Views/Chat/ChatView.swift
@@ -1187,7 +1187,7 @@ struct ChatView: View {
                     allowMenu: $allowMenu
                 )
                 .environment(\.showTimestamp, itemSeparation.timestamp)
-                .modifier(ChatItemClipped(ci, tailVisible: itemSeparation.largeGap, revealed: revealed))
+                .modifier(ChatItemClipped(ci, tailVisible: itemSeparation.largeGap && (ci.meta.itemDeleted == nil || revealed)))
                 .contextMenu { menu(ci, range, live: composeState.liveMessage != nil) }
                 .accessibilityLabel("")
                 if ci.content.msgContent != nil && (ci.meta.itemDeleted == nil || revealed) && ci.reactions.count > 0 {

--- a/apps/ios/Shared/Views/Helpers/ChatItemClipShape.swift
+++ b/apps/ios/Shared/Views/Helpers/ChatItemClipShape.swift
@@ -16,17 +16,20 @@ import SimpleXChat
 struct ChatItemClipped: ViewModifier {
     @AppStorage(DEFAULT_CHAT_ITEM_ROUNDNESS) private var roundness = defaultChatItemRoundness
     @AppStorage(DEFAULT_CHAT_ITEM_TAIL) private var tailEnabled = true
-    private let chatItem: (content: CIContent, chatDir: CIDirection)?
+    private let chatItem: (content: CIContent, chatDir: CIDirection, meta: CIMeta, isDeletedContent: Bool)?
     private let tailVisible: Bool
+    private let reveleaded: Bool
 
     init() {
         self.chatItem = nil
         self.tailVisible = false
+        self.reveleaded = false
     }
 
-    init(_ ci: ChatItem, tailVisible: Bool) {
-        self.chatItem = (ci.content, ci.chatDir)
+    init(_ ci: ChatItem, tailVisible: Bool, revealed: Bool) {
+        self.chatItem = (ci.content, ci.chatDir, ci.meta, ci.isDeletedContent)
         self.tailVisible = tailVisible
+        self.reveleaded = revealed
     }
     
     private func shapeStyle() -> ChatItemShape.Style {
@@ -43,6 +46,9 @@ struct ChatItemClipped: ViewModifier {
                     .rcvModerated,
                     .rcvBlocked,
                     .invalidJSON:
+                if ci.meta.itemDeleted != nil, (!reveleaded || ci.isDeletedContent) {
+                    return .roundRect(radius: msgRectMaxRadius)
+                }
                 let tail = if let mc = ci.content.msgContent, mc.isImageOrVideo && mc.text.isEmpty {
                     false
                 } else {

--- a/apps/ios/Shared/Views/Helpers/ChatItemClipShape.swift
+++ b/apps/ios/Shared/Views/Helpers/ChatItemClipShape.swift
@@ -16,20 +16,17 @@ import SimpleXChat
 struct ChatItemClipped: ViewModifier {
     @AppStorage(DEFAULT_CHAT_ITEM_ROUNDNESS) private var roundness = defaultChatItemRoundness
     @AppStorage(DEFAULT_CHAT_ITEM_TAIL) private var tailEnabled = true
-    private let chatItem: (content: CIContent, chatDir: CIDirection, meta: CIMeta, isDeletedContent: Bool)?
+    private let chatItem: (content: CIContent, chatDir: CIDirection)?
     private let tailVisible: Bool
-    private let reveleaded: Bool
 
     init() {
         self.chatItem = nil
         self.tailVisible = false
-        self.reveleaded = false
     }
 
-    init(_ ci: ChatItem, tailVisible: Bool, revealed: Bool) {
-        self.chatItem = (ci.content, ci.chatDir, ci.meta, ci.isDeletedContent)
+    init(_ ci: ChatItem, tailVisible: Bool) {
+        self.chatItem = (ci.content, ci.chatDir)
         self.tailVisible = tailVisible
-        self.reveleaded = revealed
     }
     
     private func shapeStyle() -> ChatItemShape.Style {
@@ -39,16 +36,8 @@ struct ChatItemClipped: ViewModifier {
                     .sndMsgContent,
                     .rcvMsgContent,
                     .rcvDecryptionError,
-                    .sndDeleted,
-                    .rcvDeleted,
                     .rcvIntegrityError,
-                    .sndModerated,
-                    .rcvModerated,
-                    .rcvBlocked,
                     .invalidJSON:
-                if ci.meta.itemDeleted != nil, (!reveleaded || ci.isDeletedContent) {
-                    return .roundRect(radius: msgRectMaxRadius)
-                }
                 let tail = if let mc = ci.content.msgContent, mc.isImageOrVideo && mc.text.isEmpty {
                     false
                 } else {

--- a/apps/ios/Shared/Views/UserSettings/AppearanceSettings.swift
+++ b/apps/ios/Shared/Views/UserSettings/AppearanceSettings.swift
@@ -368,13 +368,13 @@ struct ChatThemePreview: View {
                 let bob = ChatItem.getSample(2, CIDirection.directSnd, Date.now, NSLocalizedString("Good morning!", comment: "message preview"), quotedItem: CIQuote.getSample(alice.id, alice.meta.itemTs, alice.content.text, chatDir: alice.chatDir))
                 HStack {
                     ChatItemView(chat: Chat.sampleData, chatItem: alice, revealed: Binding.constant(false))
-                        .modifier(ChatItemClipped(alice, tailVisible: true, revealed: true))
+                        .modifier(ChatItemClipped(alice, tailVisible: true))
                     Spacer()
                 }
                 HStack {
                     Spacer()
                     ChatItemView(chat: Chat.sampleData, chatItem: bob, revealed: Binding.constant(false))
-                        .modifier(ChatItemClipped(bob, tailVisible: true, revealed: true))
+                        .modifier(ChatItemClipped(bob, tailVisible: true))
                         .frame(alignment: .trailing)
                 }
             } else {

--- a/apps/ios/Shared/Views/UserSettings/AppearanceSettings.swift
+++ b/apps/ios/Shared/Views/UserSettings/AppearanceSettings.swift
@@ -368,13 +368,13 @@ struct ChatThemePreview: View {
                 let bob = ChatItem.getSample(2, CIDirection.directSnd, Date.now, NSLocalizedString("Good morning!", comment: "message preview"), quotedItem: CIQuote.getSample(alice.id, alice.meta.itemTs, alice.content.text, chatDir: alice.chatDir))
                 HStack {
                     ChatItemView(chat: Chat.sampleData, chatItem: alice, revealed: Binding.constant(false))
-                        .modifier(ChatItemClipped(alice, tailVisible: true))
+                        .modifier(ChatItemClipped(alice, tailVisible: true, revealed: true))
                     Spacer()
                 }
                 HStack {
                     Spacer()
                     ChatItemView(chat: Chat.sampleData, chatItem: bob, revealed: Binding.constant(false))
-                        .modifier(ChatItemClipped(bob, tailVisible: true))
+                        .modifier(ChatItemClipped(bob, tailVisible: true, revealed: true))
                         .frame(alignment: .trailing)
                 }
             } else {


### PR DESCRIPTION
The tail looked very different from other items, and at the time we were doing it on ios we agreed this shouldn't show unless revealed, forgot to apply the same logic on ios