### PR TITLE
ios: fix theme import file picker

### DIFF
--- a/apps/ios/Shared/Views/Helpers/ThemeModeEditor.swift
+++ b/apps/ios/Shared/Views/Helpers/ThemeModeEditor.swift
@@ -16,6 +16,7 @@ struct UserWallpaperEditor: View {
     @State var themeModeOverride: ThemeModeOverride
     @State var applyToMode: DefaultThemeMode?
     @State var showMore: Bool = false
+    @State var showFileImporter: Bool = false
     @Binding var globalThemeUsed: Bool
     var save: (DefaultThemeMode?, ThemeModeOverride?) async -> Void
 
@@ -125,24 +126,27 @@ struct UserWallpaperEditor: View {
 
                 CustomizeThemeColorsSection(editColor: { name in editColor(name, theme) })
 
-                ImportExportThemeSection(perChat: nil, perUser: ChatModel.shared.currentUser?.uiThemes) { imported in
-                    let importedFromString = imported.wallpaper?.importFromString()
-                    let importedType = importedFromString?.toAppWallpaper().type
-                    let currentTheme = ThemeManager.currentColors(nil, nil, nil, themeOverridesDefault.get())
-                    let type: WallpaperType? = if importedType?.sameType(currentTheme.wallpaper.type) == true { nil } else { importedType }
-                    let colors = ThemeManager.currentThemeOverridesForExport(type, nil, nil).colors
-                    let res = ThemeModeOverride(mode: imported.base.mode, colors: imported.colors, wallpaper: importedFromString).removeSameColors(imported.base, colorsToCompare: colors)
-                    Task {
-                        await MainActor.run {
-                            themeModeOverride = res
-                        }
-                        await save(applyToMode, res)
-                    }
-                }
+                ImportExportThemeSection(showFileImporter: $showFileImporter, perChat: nil, perUser: ChatModel.shared.currentUser?.uiThemes)
             } else {
                 AdvancedSettingsButton(theme.colors.primary) { showMore = true }
             }
         }
+        .modifier(
+            ThemeImporter(isPresented: $showMore) { imported in
+                let importedFromString = imported.wallpaper?.importFromString()
+                let importedType = importedFromString?.toAppWallpaper().type
+                let currentTheme = ThemeManager.currentColors(nil, nil, nil, themeOverridesDefault.get())
+                let type: WallpaperType? = if importedType?.sameType(currentTheme.wallpaper.type) == true { nil } else { importedType }
+                let colors = ThemeManager.currentThemeOverridesForExport(type, nil, nil).colors
+                let res = ThemeModeOverride(mode: imported.base.mode, colors: imported.colors, wallpaper: importedFromString).removeSameColors(imported.base, colorsToCompare: colors)
+                Task {
+                    await MainActor.run {
+                        themeModeOverride = res
+                    }
+                    await save(applyToMode, res)
+                }
+            }
+        )
     }
 
     private func onTypeCopyFromSameTheme(_ type: WallpaperType?) -> Bool {
@@ -216,6 +220,7 @@ struct ChatWallpaperEditor: View {
     @State var themeModeOverride: ThemeModeOverride
     @State var applyToMode: DefaultThemeMode?
     @State var showMore: Bool = false
+    @State var showFileImporter: Bool = false
     @Binding var globalThemeUsed: Bool
     var save: (DefaultThemeMode?, ThemeModeOverride?) async -> Void
 
@@ -328,24 +333,27 @@ struct ChatWallpaperEditor: View {
 
                 CustomizeThemeColorsSection(editColor: editColor)
 
-                ImportExportThemeSection(perChat: themeModeOverride, perUser: ChatModel.shared.currentUser?.uiThemes) { imported in
-                    let importedFromString = imported.wallpaper?.importFromString()
-                    let importedType = importedFromString?.toAppWallpaper().type
-                    let currentTheme = ThemeManager.currentColors(nil, nil, ChatModel.shared.currentUser?.uiThemes, themeOverridesDefault.get())
-                    let type: WallpaperType? = if importedType?.sameType(currentTheme.wallpaper.type) == true { nil } else { importedType }
-                    let colors = ThemeManager.currentThemeOverridesForExport(type, nil, ChatModel.shared.currentUser?.uiThemes).colors
-                    let res = ThemeModeOverride(mode: imported.base.mode, colors: imported.colors, wallpaper: importedFromString).removeSameColors(imported.base, colorsToCompare: colors)
-                    Task {
-                        await MainActor.run {
-                            themeModeOverride = res
-                        }
-                        await save(applyToMode, res)
-                    }
-                }
+                ImportExportThemeSection(showFileImporter: $showFileImporter, perChat: themeModeOverride, perUser: ChatModel.shared.currentUser?.uiThemes)
             } else {
                 AdvancedSettingsButton(theme.colors.primary) { showMore = true }
             }
         }
+        .modifier(
+            ThemeImporter(isPresented: $showFileImporter) { imported in
+                let importedFromString = imported.wallpaper?.importFromString()
+                let importedType = importedFromString?.toAppWallpaper().type
+                let currentTheme = ThemeManager.currentColors(nil, nil, ChatModel.shared.currentUser?.uiThemes, themeOverridesDefault.get())
+                let type: WallpaperType? = if importedType?.sameType(currentTheme.wallpaper.type) == true { nil } else { importedType }
+                let colors = ThemeManager.currentThemeOverridesForExport(type, nil, ChatModel.shared.currentUser?.uiThemes).colors
+                let res = ThemeModeOverride(mode: imported.base.mode, colors: imported.colors, wallpaper: importedFromString).removeSameColors(imported.base, colorsToCompare: colors)
+                Task {
+                    await MainActor.run {
+                        themeModeOverride = res
+                    }
+                    await save(applyToMode, res)
+                }
+            }
+        )
     }
 
     private func onTypeCopyFromSameTheme(_ type: WallpaperType?) -> Bool {

--- a/apps/ios/Shared/Views/Helpers/ThemeModeEditor.swift
+++ b/apps/ios/Shared/Views/Helpers/ThemeModeEditor.swift
@@ -132,7 +132,7 @@ struct UserWallpaperEditor: View {
             }
         }
         .modifier(
-            ThemeImporter(isPresented: $showMore) { imported in
+            ThemeImporter(isPresented: $showFileImporter) { imported in
                 let importedFromString = imported.wallpaper?.importFromString()
                 let importedType = importedFromString?.toAppWallpaper().type
                 let currentTheme = ThemeManager.currentColors(nil, nil, nil, themeOverridesDefault.get())


### PR DESCRIPTION
Fix `.fileImporter` modifier not working in iOS15.* by attaching it higher in the view hierarchy - outside of the containing `List`.