### PR TITLE
ios: user profiles move auth to change actions, show unread counts

### DIFF
--- a/apps/ios/Shared/Views/ChatList/UserPicker.swift
+++ b/apps/ios/Shared/Views/ChatList/UserPicker.swift
@@ -124,7 +124,7 @@ struct UserPicker: View {
             ZStack(alignment: .topTrailing) {
                 ProfileImage(imageStr: u.user.image, size: size, color: Color(uiColor: .tertiarySystemGroupedBackground))
                 if (u.unreadCount > 0) {
-                    unreadBadge(u).offset(x: 4, y: -4)
+                    UnreadBadge(userInfo: u).offset(x: 4, y: -4)
                 }
             }
             .padding(.trailing, 6)
@@ -169,15 +169,21 @@ struct UserPicker: View {
             }
         }
     }
-    
-    private func unreadBadge(_ u: UserInfo) -> some View {
+}
+
+struct UnreadBadge: View {
+    var userInfo: UserInfo
+    @EnvironmentObject var theme: AppTheme
+    @Environment(\.dynamicTypeSize) private var userFont: DynamicTypeSize
+
+    var body: some View {
         let size = dynamicSize(userFont).chatInfoSize
-        return unreadCountText(u.unreadCount)
-            .font(userFont <= .xxxLarge ? .caption  : .caption2)
+        unreadCountText(userInfo.unreadCount)
+            .font(userFont <= .xxxLarge ? .caption : .caption2)
             .foregroundColor(.white)
             .padding(.horizontal, dynamicSize(userFont).unreadPadding)
             .frame(minWidth: size, minHeight: size)
-            .background(u.user.showNtfs ? theme.colors.primary : theme.colors.secondary)
+            .background(userInfo.user.showNtfs ? theme.colors.primary : theme.colors.secondary)
             .cornerRadius(dynamicSize(userFont).unreadCorner)
     }
 }

--- a/apps/ios/Shared/Views/UserSettings/UserProfilesView.swift
+++ b/apps/ios/Shared/Views/UserSettings/UserProfilesView.swift
@@ -208,17 +208,6 @@ struct UserProfilesView: View {
         m.users.filter({ u in !u.user.hidden }).count
     }
     
-    private func unreadBadge(_ u: UserInfo) -> some View {
-        let size = dynamicSize(userFont).chatInfoSize
-        return unreadCountText(u.unreadCount)
-            .font(userFont <= .xxxLarge ? .caption  : .caption2)
-            .foregroundColor(.white)
-            .padding(.horizontal, dynamicSize(userFont).unreadPadding)
-            .frame(minWidth: size, minHeight: size)
-            .background(u.user.showNtfs ? theme.colors.primary : theme.colors.secondary)
-            .cornerRadius(dynamicSize(userFont).unreadCorner)
-    }
-    
     private func withAuth(_ action: @escaping () -> Void) {
         if authorized {
             action()
@@ -376,12 +365,16 @@ struct UserProfilesView: View {
                     Image(systemName: "checkmark").foregroundColor(theme.colors.onBackground)
                 } else {
                     if userInfo.unreadCount > 0 {
-                        unreadBadge(userInfo)
+                        UnreadBadge(userInfo: userInfo)
                     }
                     if user.hidden {
                         Image(systemName: "lock").foregroundColor(theme.colors.secondary)
                     } else if userInfo.unreadCount == 0 {
-                        Image(systemName: "checkmark").foregroundColor(.clear)
+                        if !user.showNtfs {
+                            Image(systemName: "speaker.slash").foregroundColor(theme.colors.secondary)
+                        } else {
+                            Image(systemName: "checkmark").foregroundColor(.clear)
+                        }
                     }
                 }
             }

--- a/apps/ios/Shared/Views/UserSettings/UserProfilesView.swift
+++ b/apps/ios/Shared/Views/UserSettings/UserProfilesView.swift
@@ -80,8 +80,8 @@ struct UserProfilesView: View {
                 }
                 if #available(iOS 16, *) {
                     v.onDelete { indexSet in
-                        withAuth {
-                            if let i = indexSet.first {
+                        if let i = indexSet.first {
+                            withAuth {
                                 confirmDeleteUser(users[i].user)
                             }
                         }
@@ -185,8 +185,8 @@ struct UserProfilesView: View {
             }
         }
         .onChange(of: redaction) { newRedaction in
-            if newRedaction.isEmpty {
-                self.pendingAuthAction?()
+            if newRedaction.isEmpty, let action = self.pendingAuthAction {
+                action()
                 self.pendingAuthAction = nil
             }
         }
@@ -217,7 +217,9 @@ struct UserProfilesView: View {
                 switch laResult {
                 case .success, .unavailable:
                     authorized = true
-                    pendingAuthAction = {
+                    if protectScreen && privacyLocalAuthModeDefault.get() == .system {
+                        pendingAuthAction = action
+                    } else {
                         action()
                     }
                 case .failed: authorized = false

--- a/apps/ios/Shared/Views/UserSettings/UserProfilesView.swift
+++ b/apps/ios/Shared/Views/UserSettings/UserProfilesView.swift
@@ -203,7 +203,7 @@ struct UserProfilesView: View {
                 case .success, .unavailable:
                     authorized = true
                     AppSheetState.shared.scenePhaseActive = true
-                    DispatchQueue.main.async(execute: action)
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: action)
                 case .failed: authorized = false
                 }
             }

--- a/apps/ios/Shared/Views/UserSettings/UserProfilesView.swift
+++ b/apps/ios/Shared/Views/UserSettings/UserProfilesView.swift
@@ -10,7 +10,6 @@ struct UserProfilesView: View {
     @EnvironmentObject private var m: ChatModel
     @EnvironmentObject private var theme: AppTheme
     @Environment(\.editMode) private var editMode
-    @Environment(\.dynamicTypeSize) private var userFont: DynamicTypeSize
     @AppStorage(DEFAULT_SHOW_HIDDEN_PROFILES_NOTICE) private var showHiddenProfilesNotice = true
     @AppStorage(DEFAULT_SHOW_MUTE_PROFILE_ALERT) private var showMuteProfileAlert = true
     @AppStorage(DEFAULT_PRIVACY_PROTECT_SCREEN) private var protectScreen = false

--- a/apps/ios/Shared/Views/UserSettings/UserProfilesView.swift
+++ b/apps/ios/Shared/Views/UserSettings/UserProfilesView.swift
@@ -380,8 +380,6 @@ struct UserProfilesView: View {
                     }
                     if user.hidden {
                         Image(systemName: "lock").foregroundColor(theme.colors.secondary)
-                    } else if !user.showNtfs {
-                        Image(systemName: "speaker.slash").foregroundColor(theme.colors.secondary)
                     } else if userInfo.unreadCount == 0 {
                         Image(systemName: "checkmark").foregroundColor(.clear)
                     }


### PR DESCRIPTION
- [x] Stop requesting auth when visiting user profiles
- [x] Request auth only on add/delete/mute/hide profiles
- [x] Show number of unread messages