### PR TITLE
desktop, android: user profiles move auth to change actions, show unread counts

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/UserPicker.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/UserPicker.kt
@@ -271,6 +271,7 @@ fun UserPicker(
             ModalManager.start.showCustomModal(keyboardCoversBar = false) { close ->
               val search = rememberSaveable { mutableStateOf("") }
               val profileHidden = rememberSaveable { mutableStateOf(false) }
+              val authorized = remember { stateGetOrPut("authorized") { false } }
               ModalView(
                 { close() },
                 showSearch = true,
@@ -278,7 +279,21 @@ fun UserPicker(
                 onSearchValueChanged = {
                   search.value = it
                 },
-                content = { UserProfilesView(chatModel, search, profileHidden) })
+                content = {
+                  UserProfilesView(chatModel, search, profileHidden) { block ->
+                      if (authorized.value) {
+                        block()
+                      } else {
+                        doWithAuth(
+                          generalGetString(MR.strings.auth_change_chat_profiles),
+                          generalGetString(MR.strings.auth_log_in_using_credential)
+                        ) {
+                          authorized.value = true
+                          block()
+                        }
+                      }
+                    }
+                })
             }
           },
           disabled = stopped

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/UserPicker.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/UserPicker.kt
@@ -285,7 +285,7 @@ fun UserPicker(
                         block()
                       } else {
                         doWithAuth(
-                          generalGetString(MR.strings.auth_change_chat_profiles),
+                          generalGetString(MR.strings.auth_open_chat_profiles),
                           generalGetString(MR.strings.auth_log_in_using_credential)
                         ) {
                           authorized.value = true

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/UserPicker.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/UserPicker.kt
@@ -407,26 +407,35 @@ fun UserProfilePickerItem(
     UserProfileRow(u, enabled)
     if (u.activeUser) {
       Icon(painterResource(MR.images.ic_done_filled), null, Modifier.size(20.dp), tint = MaterialTheme.colors.onBackground)
-    } else if (u.hidden) {
-      Icon(painterResource(MR.images.ic_lock), null, Modifier.size(20.dp), tint = MaterialTheme.colors.secondary)
-    } else if (unreadCount > 0) {
-      Box(
-        contentAlignment = Alignment.Center
-      ) {
-        Text(
-          unreadCountStr(unreadCount),
-          color = Color.White,
-          fontSize = 10.sp,
-          modifier = Modifier
-            .background(MaterialTheme.colors.primaryVariant, shape = CircleShape)
-            .padding(2.dp)
-            .badgeLayout()
-        )
-      }
-    } else if (!u.showNtfs) {
-      Icon(painterResource(MR.images.ic_notifications_off), null, Modifier.size(20.dp), tint = MaterialTheme.colors.secondary)
     } else {
-      Box(Modifier.size(20.dp))
+      Row(verticalAlignment = Alignment.CenterVertically) {
+        if (unreadCount > 0) {
+          Box(
+            contentAlignment = Alignment.Center,
+          ) {
+            Text(
+              unreadCountStr(unreadCount),
+              color = Color.White,
+              fontSize = 10.sp,
+              modifier = Modifier
+                .background(if (u.showNtfs) MaterialTheme.colors.primaryVariant else MaterialTheme.colors.secondary, shape = CircleShape)
+                .padding(2.dp)
+                .badgeLayout()
+            )
+          }
+        } else if (!u.showNtfs) {
+          Icon(painterResource(MR.images.ic_notifications_off), null, Modifier.size(20.dp), tint = MaterialTheme.colors.secondary)
+        } else {
+          Box(Modifier.size(20.dp))
+        }
+
+        if (u.hidden) {
+          if (unreadCount > 0) {
+            Spacer(Modifier.width(8.dp))
+          }
+          Icon(painterResource(MR.images.ic_lock), null, Modifier.size(20.dp), tint = MaterialTheme.colors.secondary)
+        }
+      }
     }
   }
 }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/UserPicker.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/UserPicker.kt
@@ -268,22 +268,17 @@ fun UserPicker(
           painterResource(MR.images.ic_manage_accounts),
           stringResource(MR.strings.your_chat_profiles),
           {
-            doWithAuth(
-              generalGetString(MR.strings.auth_open_chat_profiles),
-              generalGetString(MR.strings.auth_log_in_using_credential)
-            ) {
-              ModalManager.start.showCustomModal(keyboardCoversBar = false) { close ->
-                val search = rememberSaveable { mutableStateOf("") }
-                val profileHidden = rememberSaveable { mutableStateOf(false) }
-                ModalView(
-                  { close() },
-                  showSearch = true,
-                  searchAlwaysVisible = true,
-                  onSearchValueChanged = {
-                    search.value = it
-                  },
-                  content = { UserProfilesView(chatModel, search, profileHidden) })
-              }
+            ModalManager.start.showCustomModal(keyboardCoversBar = false) { close ->
+              val search = rememberSaveable { mutableStateOf("") }
+              val profileHidden = rememberSaveable { mutableStateOf(false) }
+              ModalView(
+                { close() },
+                showSearch = true,
+                searchAlwaysVisible = true,
+                onSearchValueChanged = {
+                  search.value = it
+                },
+                content = { UserProfilesView(chatModel, search, profileHidden) })
             }
           },
           disabled = stopped

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/UserPicker.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/UserPicker.kt
@@ -438,17 +438,17 @@ fun UserProfilePickerItem(
                 .badgeLayout()
             )
           }
+
+          if (u.hidden) {
+            Spacer(Modifier.width(8.dp))
+            Icon(painterResource(MR.images.ic_lock), null, Modifier.size(20.dp), tint = MaterialTheme.colors.secondary)
+          }
+        } else if (u.hidden) {
+          Icon(painterResource(MR.images.ic_lock), null, Modifier.size(20.dp), tint = MaterialTheme.colors.secondary)
         } else if (!u.showNtfs) {
           Icon(painterResource(MR.images.ic_notifications_off), null, Modifier.size(20.dp), tint = MaterialTheme.colors.secondary)
         } else {
           Box(Modifier.size(20.dp))
-        }
-
-        if (u.hidden) {
-          if (unreadCount > 0) {
-            Spacer(Modifier.width(8.dp))
-          }
-          Icon(painterResource(MR.images.ic_lock), null, Modifier.size(20.dp), tint = MaterialTheme.colors.secondary)
         }
       }
     }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/UserProfilesView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/UserProfilesView.kt
@@ -128,14 +128,16 @@ fun UserProfilesView(m: ChatModel, search: MutableState<String>, profileHidden: 
       }
     },
     showHiddenProfile = { user ->
-      ModalManager.start.showModalCloseable(true) { close ->
-        HiddenProfileView(m, user) {
-          profileHidden.value = true
-          withBGApi {
-            delay(10_000)
-            profileHidden.value = false
+      doWithAuthProfileChanges {
+        ModalManager.start.showModalCloseable(true) { close ->
+          HiddenProfileView(m, user) {
+            profileHidden.value = true
+            withBGApi {
+              delay(10_000)
+              profileHidden.value = false
+            }
+            close()
           }
-          close()
         }
       }
     }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/UserProfilesView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/UserProfilesView.kt
@@ -148,7 +148,7 @@ fun UserProfilesView(m: ChatModel, search: MutableState<String>, profileHidden: 
 @Composable
 private fun UserProfilesLayout(
   users: List<User>,
-  filteredUsers: List<User>,
+  filteredUsers: List<UserInfo>,
   searchTextOrPassword: MutableState<String>,
   profileHidden: MutableState<Boolean>,
   visibleUsersCount: Int,
@@ -205,7 +205,7 @@ private fun UserProfilesLayout(
 
 @Composable
 private fun UserView(
-  user: User,
+  userInfo: UserInfo,
   visibleUsersCount: Int,
   activateUser: (User) -> Unit,
   removeUser: (User) -> Unit,
@@ -215,7 +215,8 @@ private fun UserView(
   showHiddenProfile: (User) -> Unit,
 ) {
   val showMenu = remember { mutableStateOf(false) }
-  UserProfilePickerItem(user, onLongClick = { showMenu.value = true }) {
+  val user = userInfo.user
+  UserProfilePickerItem(user, onLongClick = { showMenu.value = true }, unreadCount = userInfo.unreadCount) {
     activateUser(user)
   }
   Box(Modifier.padding(horizontal = DEFAULT_PADDING)) {
@@ -300,7 +301,7 @@ private fun ProfileActionView(action: UserProfileAction, user: User, doAction: (
   }
 }
 
-fun filteredUsers(m: ChatModel, searchTextOrPassword: String): List<User> {
+fun filteredUsers(m: ChatModel, searchTextOrPassword: String): List<UserInfo> {
   val s = searchTextOrPassword.trim()
   val lower = s.lowercase()
   return m.users.filter { u ->
@@ -309,7 +310,7 @@ fun filteredUsers(m: ChatModel, searchTextOrPassword: String): List<User> {
     } else {
       correctPassword(u.user, s)
     }
-  }.map { it.user }
+  }
 }
 
 private fun visibleUsersCount(m: ChatModel): Int = m.users.filter { u -> !u.user.hidden }.size

--- a/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
@@ -268,6 +268,7 @@
   <string name="auth_stop_chat">Stop chat</string>
   <string name="auth_open_chat_console">Open chat console</string>
   <string name="auth_open_chat_profiles">Open chat profiles</string>
+  <string name="auth_change_chat_profiles">Change chat profiles</string>
   <string name="auth_open_migration_to_another_device">Open migration screen</string>
   <string name="lock_not_enabled">SimpleX Lock not enabled!</string>
   <string name="you_can_turn_on_lock">You can turn on SimpleX Lock via Settings.</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
@@ -267,8 +267,7 @@
   <string name="auth_device_authentication_is_disabled_turning_off">Device authentication is disabled. Turning off SimpleX Lock.</string>
   <string name="auth_stop_chat">Stop chat</string>
   <string name="auth_open_chat_console">Open chat console</string>
-  <string name="auth_open_chat_profiles">Open chat profiles</string>
-  <string name="auth_change_chat_profiles">Change chat profiles</string>
+  <string name="auth_open_chat_profiles">Change chat profiles</string>
   <string name="auth_open_migration_to_another_device">Open migration screen</string>
   <string name="lock_not_enabled">SimpleX Lock not enabled!</string>
   <string name="you_can_turn_on_lock">You can turn on SimpleX Lock via Settings.</string>


### PR DESCRIPTION
- [x] Stop requesting auth when visiting user profiles
- [x] Request auth only on add/delete/mute/hide profilesz
- [x] Show number of unread messages