### PR TITLE
ios: fix alignment on operators review later button and notice

### DIFF
--- a/apps/ios/Shared/Views/Onboarding/ChooseServerOperators.swift
+++ b/apps/ios/Shared/Views/Onboarding/ChooseServerOperators.swift
@@ -140,6 +140,7 @@ struct ChooseServerOperators: View {
                             .font(.footnote)
                             .padding(.horizontal, 32)
                         }
+                        .frame(maxWidth: .infinity)
                         .disabled(!canReviewLater)
                         .padding(.bottom)
                     }


### PR DESCRIPTION
Noticed the following while opening this view from what's new.

<img width="441" alt="Screenshot 2024-11-29 at 15 58 23" src="https://github.com/user-attachments/assets/515d15c2-558a-41de-8d6e-6ec3b0ec7e44">
