### PR TITLE
ios: fix open from notification and connected directly chat item chat loading

### DIFF
--- a/apps/ios/Shared/Model/NtfManager.swift
+++ b/apps/ios/Shared/Model/NtfManager.swift
@@ -26,6 +26,7 @@ enum NtfCallAction {
 class NtfManager: NSObject, UNUserNotificationCenterDelegate, ObservableObject {
     static let shared = NtfManager()
 
+    public var navigatingToChat = false
     private var granted = false
     private var prevNtfTime: Dictionary<ChatId, Date> = [:]
 
@@ -74,7 +75,10 @@ class NtfManager: NSObject, UNUserNotificationCenterDelegate, ObservableObject {
             }
         } else {
             if let chatId = content.targetContentIdentifier {
-                ItemsModel.shared.loadOpenChat(chatId)
+                self.navigatingToChat = true
+                ItemsModel.shared.loadOpenChat(chatId) {
+                    self.navigatingToChat = false
+                }
             }
         }
     }

--- a/apps/ios/Shared/SimpleXApp.swift
+++ b/apps/ios/Shared/SimpleXApp.swift
@@ -143,7 +143,8 @@ struct SimpleXApp: App {
             let chats = try await apiGetChatsAsync()
             await MainActor.run { chatModel.updateChats(chats) }
             if let id = chatModel.chatId,
-               let chat = chatModel.getChat(id) {
+               let chat = chatModel.getChat(id),
+               !ItemsModel.shared.isLoading {
                 Task { await loadChat(chat: chat, clearItems: false) }
             }
             if let ncr = chatModel.ntfContactRequest {

--- a/apps/ios/Shared/SimpleXApp.swift
+++ b/apps/ios/Shared/SimpleXApp.swift
@@ -144,7 +144,7 @@ struct SimpleXApp: App {
             await MainActor.run { chatModel.updateChats(chats) }
             if let id = chatModel.chatId,
                let chat = chatModel.getChat(id),
-               !ItemsModel.shared.isLoading {
+               !NtfManager.shared.navigatingToChat {
                 Task { await loadChat(chat: chat, clearItems: false) }
             }
             if let ncr = chatModel.ntfContactRequest {

--- a/apps/ios/Shared/Views/Chat/ChatItem/CIMemberCreatedContactView.swift
+++ b/apps/ios/Shared/Views/Chat/ChatItem/CIMemberCreatedContactView.swift
@@ -23,7 +23,7 @@ struct CIMemberCreatedContactView: View {
                         .onTapGesture {
                             dismissAllSheets(animated: true)
                             DispatchQueue.main.async {
-                                m.chatId = "@\(contactId)"
+                                ItemsModel.shared.loadOpenChat("@\(contactId)")
                             }
                         }
                 } else {


### PR DESCRIPTION
Steps:

- In ios, go to any chat in your profile
- Leave the app and lock the phone, wait for a minute or 2
- Send a message from another device and wait for notification to arrive
- Open from notification

Result:

- Chat header changes to contact/group associated with notification
- Chat message are from the chat you had open before locking the phone

open contact via "connected directly" chat item also replicates this issue