### PR TITLE
ios: fix some real time updates in group members

### DIFF
--- a/apps/ios/Shared/Views/Chat/ChatView.swift
+++ b/apps/ios/Shared/Views/Chat/ChatView.swift
@@ -134,12 +134,8 @@ struct ChatView: View {
             Group {
                 if case let .group(groupInfo) = chat.chatInfo {
                     GroupMemberInfoView(
-                        groupInfo: Binding(
-                            get: { groupInfo },
-                            set: { gInfo in
-                                chat.chatInfo = .group(groupInfo: gInfo)
-                            }
-                        ),
+                        groupInfo: groupInfo,
+                        chat: chat,
                         groupMember: member,
                         navigation: true
                     )

--- a/apps/ios/Shared/Views/Chat/ChatView.swift
+++ b/apps/ios/Shared/Views/Chat/ChatView.swift
@@ -133,7 +133,16 @@ struct ChatView: View {
         .appSheet(item: $selectedMember) { member in
             Group {
                 if case let .group(groupInfo) = chat.chatInfo {
-                    GroupMemberInfoView(groupInfo: groupInfo, groupMember: member, navigation: true)
+                    GroupMemberInfoView(
+                        groupInfo: Binding(
+                            get: { groupInfo },
+                            set: { gInfo in
+                                chat.chatInfo = .group(groupInfo: gInfo)
+                            }
+                        ),
+                        groupMember: member,
+                        navigation: true
+                    )
                 }
             }
         }
@@ -1122,6 +1131,7 @@ struct ChatView: View {
                                         } else {
                                             let mem = GMember.init(member)
                                             m.groupMembers.append(mem)
+                                            m.groupMembersIndexes[member.groupMemberId] = m.groupMembers.count - 1
                                             selectedMember = mem
                                         }
                                     }
@@ -1877,6 +1887,7 @@ struct ReactionContextMenu: View {
                     } else {
                         let member = GMember.init(mem)
                         m.groupMembers.append(member)
+                        m.groupMembersIndexes[member.groupMemberId] = m.groupMembers.count - 1
                         selectedMember = member
                     }
                 } label: {

--- a/apps/ios/Shared/Views/Chat/Group/GroupChatInfoView.swift
+++ b/apps/ios/Shared/Views/Chat/Group/GroupChatInfoView.swift
@@ -439,7 +439,7 @@ struct GroupChatInfoView: View {
     }
 
     private func memberInfoView(_ groupMember: GMember) -> some View {
-        GroupMemberInfoView(groupInfo: $groupInfo, groupMember: groupMember)
+        GroupMemberInfoView(groupInfo: groupInfo, chat: chat, groupMember: groupMember)
             .navigationBarHidden(false)
     }
 

--- a/apps/ios/Shared/Views/Chat/Group/GroupChatInfoView.swift
+++ b/apps/ios/Shared/Views/Chat/Group/GroupChatInfoView.swift
@@ -439,7 +439,7 @@ struct GroupChatInfoView: View {
     }
 
     private func memberInfoView(_ groupMember: GMember) -> some View {
-        GroupMemberInfoView(groupInfo: groupInfo, groupMember: groupMember)
+        GroupMemberInfoView(groupInfo: $groupInfo, groupMember: groupMember)
             .navigationBarHidden(false)
     }
 

--- a/apps/ios/Shared/Views/Chat/Group/GroupMemberInfoView.swift
+++ b/apps/ios/Shared/Views/Chat/Group/GroupMemberInfoView.swift
@@ -13,7 +13,7 @@ struct GroupMemberInfoView: View {
     @EnvironmentObject var chatModel: ChatModel
     @EnvironmentObject var theme: AppTheme
     @Environment(\.dismiss) var dismiss: DismissAction
-    @State var groupInfo: GroupInfo
+    @Binding var groupInfo: GroupInfo
     @ObservedObject var groupMember: GMember
     var navigation: Bool = false
     @State private var connectionStats: ConnectionStats? = nil
@@ -757,7 +757,7 @@ func blockMemberForAll(_ gInfo: GroupInfo, _ member: GroupMember, _ blocked: Boo
 struct GroupMemberInfoView_Previews: PreviewProvider {
     static var previews: some View {
         GroupMemberInfoView(
-            groupInfo: GroupInfo.sampleData,
+            groupInfo: Binding.constant(GroupInfo.sampleData),
             groupMember: GMember.sampleData
         )
     }

--- a/apps/ios/Shared/Views/Chat/Group/GroupMemberInfoView.swift
+++ b/apps/ios/Shared/Views/Chat/Group/GroupMemberInfoView.swift
@@ -13,7 +13,8 @@ struct GroupMemberInfoView: View {
     @EnvironmentObject var chatModel: ChatModel
     @EnvironmentObject var theme: AppTheme
     @Environment(\.dismiss) var dismiss: DismissAction
-    @Binding var groupInfo: GroupInfo
+    @State var groupInfo: GroupInfo
+    @ObservedObject var chat: Chat
     @ObservedObject var groupMember: GMember
     var navigation: Bool = false
     @State private var connectionStats: ConnectionStats? = nil
@@ -259,6 +260,11 @@ struct GroupMemberInfoView: View {
 
             if progressIndicator {
                 ProgressView().scaleEffect(2)
+            }
+        }
+        .onChange(of: chat.chatInfo) { c in
+            if case let .group(gI) = chat.chatInfo {
+                groupInfo = gI
             }
         }
         .modifier(ThemedBackground(grouped: true))
@@ -757,7 +763,8 @@ func blockMemberForAll(_ gInfo: GroupInfo, _ member: GroupMember, _ blocked: Boo
 struct GroupMemberInfoView_Previews: PreviewProvider {
     static var previews: some View {
         GroupMemberInfoView(
-            groupInfo: Binding.constant(GroupInfo.sampleData),
+            groupInfo: GroupInfo.sampleData,
+            chat: Chat.sampleData,
             groupMember: GMember.sampleData
         )
     }


### PR DESCRIPTION
**The first issue I found was minor:**
- Be in a group with at least 2 members (can start with 2 owners)
- With the user on ios to navigate to the other user profile
- With the other user downgrade the role of ios user
- Nothing is updated on ios
- With the user on ios try to delete the user (or other button that isn't allowed anymore due to role downgrade)

Result: clicking some of these buttons does generate long errors that are very hard to parse for users, as simply binding group info fixed this issue decided to fix it here, but **happy to revert.**


**Found 2 issues while testing, driven by the fact we were duplicating group members by appending to the array of group members without adding to the groupMembersIndexes Map**

**1 way to reproduce:**
- Open a group with at least 3 members (3 devices or 2 devices and 1 non ios with at least 2 profiles)
- Click one of the members on another device via chat item
- Change that member role in the leftover device (or profile)

Result: Updates in the member role (and other fields related to membership) weren't reflected

**Another way to reproduce:**
- Open a group with at least 3 members (3 devices or 2 devices and 1 non ios with at least 2 profiles)
- React to a chat item with one of the members on another device
- In ios device, view reactions for the reacted chat item and navigate to user profile
- Change that member role in the leftover device (or profile)

Result: Updates in the member role (and other fields related to membership) weren't reflected
