### PR TITLE
core: fix (Invalid cross-device link) error during file transfers

### DIFF
--- a/src/Simplex/Chat/Archive.hs
+++ b/src/Simplex/Chat/Archive.hs
@@ -25,7 +25,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Database.SQLite3 as SQL
 import Simplex.Chat.Controller
-import Simplex.Chat.Util ()
+import Simplex.Chat.Util (crossDeviceRenameFile)
 import Simplex.Messaging.Agent.Client (agentClientStore)
 import Simplex.Messaging.Agent.Store.SQLite (closeDBStore, keyString, sqlString, storeKey)
 import Simplex.Messaging.Agent.Store.SQLite.Common (DBStore (..))
@@ -170,7 +170,7 @@ sqlCipherExport DBEncryptionConfig {currentKey = DBEncryptionKey key, newKey = D
     exported = (<> ".exported")
     removeExported f = whenM (doesFileExist $ exported f) $ removeFile (exported f)
     moveExported DBStore {dbFilePath = f, dbKey} = do
-      renameFile (exported f) f
+      crossDeviceRenameFile (exported f) f
       atomically $ writeTVar dbKey $ storeKey key' (fromMaybe False keepKey)
     export f = do
       withDB f (`SQL.exec` exportSQL) DBErrorExport

--- a/src/Simplex/Chat/Library/Internal.hs
+++ b/src/Simplex/Chat/Library/Internal.hs
@@ -78,7 +78,7 @@ import Simplex.Chat.Types
 import Simplex.Chat.Types.MemberRelations
 import Simplex.Chat.Types.Preferences
 import Simplex.Chat.Types.Shared
-import Simplex.Chat.Util (encryptFile, shuffle)
+import Simplex.Chat.Util (encryptFile, shuffle, crossDeviceRenameFile)
 import Simplex.FileTransfer.Description (FileDescriptionURI (..), ValidFileDescription)
 import qualified Simplex.FileTransfer.Description as FD
 import qualified Simplex.Messaging.Crypto.Lazy as LC
@@ -1918,7 +1918,7 @@ appendFileChunk ft@RcvFileTransfer {fileId, fileStatus, cryptoArgs, fileInvitati
           tryAllErrors (liftError encryptErr $ encryptFile fsFilePath tmpFile cfArgs) >>= \case
             Right () -> do
               removeFile fsFilePath `catchAllErrors` \_ -> pure ()
-              renameFile tmpFile fsFilePath
+              crossDeviceRenameFile tmpFile fsFilePath
             Left e -> do
               eToView e
               removeFile tmpFile `catchAllErrors` \_ -> pure ()

--- a/src/Simplex/Chat/Library/Subscriber.hs
+++ b/src/Simplex/Chat/Library/Subscriber.hs
@@ -73,6 +73,7 @@ import Simplex.Chat.Types
 import Simplex.Chat.Types.MemberRelations
 import Simplex.Chat.Types.Preferences
 import Simplex.Chat.Types.Shared
+import Simplex.Chat.Util (crossDeviceRenameFile)
 import Simplex.FileTransfer.Description (ValidFileDescription)
 import qualified Simplex.FileTransfer.Description as FD
 import Simplex.FileTransfer.Protocol (FilePartyI)
@@ -105,7 +106,6 @@ import qualified System.FilePath as FP
 import System.Mem.Weak (Weak)
 import Text.Read (readMaybe)
 import UnliftIO.Concurrent (ThreadId, forkIO, mkWeakThreadId)
-import UnliftIO.Directory
 import UnliftIO.STM
 import qualified Data.Aeson as J
 
@@ -351,7 +351,7 @@ processAgentMsgRcvFile _corrId aFileId msg = do
             Nothing -> throwChatError $ CEInternalError "no target path for received XFTP file"
             Just targetPath -> do
               fsTargetPath <- lift $ toFSFilePath targetPath
-              renameFile xftpPath fsTargetPath
+              crossDeviceRenameFile xftpPath fsTargetPath
               badDigest <- case ft of
                 RcvFileTransfer {fileInvitation = FileInvitation {fileDigest = Just d}, cryptoArgs} ->
                   (/= d) <$> cryptoFileDigest (CryptoFile fsTargetPath cryptoArgs)

--- a/src/Simplex/Chat/Remote.hs
+++ b/src/Simplex/Chat/Remote.hs
@@ -49,7 +49,7 @@ import Simplex.Chat.Store.Files
 import Simplex.Chat.Store.Remote
 import Simplex.Chat.Store.Shared
 import Simplex.Chat.Types
-import Simplex.Chat.Util (encryptFile, liftIOEither)
+import Simplex.Chat.Util (encryptFile, liftIOEither, crossDeviceRenameFile)
 import Simplex.FileTransfer.Description (FileDigest (..))
 import Simplex.Messaging.Agent
 import Simplex.Messaging.Agent.Protocol (AgentErrorType (RCP))
@@ -68,7 +68,7 @@ import Simplex.RemoteControl.Types
 import System.FilePath (takeFileName, (</>))
 import UnliftIO
 import UnliftIO.Concurrent (forkIO)
-import UnliftIO.Directory (copyFile, createDirectoryIfMissing, doesDirectoryExist, removeDirectoryRecursive, renameFile)
+import UnliftIO.Directory (copyFile, createDirectoryIfMissing, doesDirectoryExist, removeDirectoryRecursive)
 
 remoteFilesFolder :: String
 remoteFilesFolder = "simplex_v1_files"
@@ -354,7 +354,7 @@ storeRemoteFile rhId encrypted_ localPath = do
     let rhf = hf </> storePath </> remoteFilesFolder
         hPath = rhf </> takeFileName filePath'
     createDirectoryIfMissing True rhf
-    (if encrypt then renameFile else copyFile) filePath hPath
+    (if encrypt then crossDeviceRenameFile else copyFile) filePath hPath
   pure (cf :: CryptoFile) {filePath = filePath'}
   where
     encryptLocalFile :: CM CryptoFile

--- a/src/Simplex/Chat/Util.hs
+++ b/src/Simplex/Chat/Util.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE TupleSections #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Simplex.Chat.Util (week, encryptFile, chunkSize, liftIOEither, shuffle, zipWith3') where
+module Simplex.Chat.Util (week, encryptFile, chunkSize, liftIOEither, shuffle, zipWith3', crossDeviceRenameFile) where
 
 import Control.Exception (Exception)
 import Control.Monad
@@ -19,9 +19,13 @@ import Data.List.NonEmpty (NonEmpty (..))
 import Data.Ord (comparing)
 import Data.Time (NominalDiffTime)
 import Data.Word (Word16)
+import Foreign.C.Error (Errno (..), eXDEV)
+import GHC.IO.Exception (ioe_errno)
 import Simplex.Messaging.Crypto.File (CryptoFile (..), CryptoFileArgs (..))
 import qualified Simplex.Messaging.Crypto.File as CF
+import System.IO.Error (catchIOError)
 import System.Random (randomRIO)
+import UnliftIO.Directory (copyFile, removeFile, renameFile)
 import qualified UnliftIO.Exception as E
 import UnliftIO.IO (IOMode (..), withFile)
 
@@ -80,3 +84,18 @@ instance Exception e => MonadUnliftIO (ExceptT e (ReaderT r IO)) where
     withExceptT unInternalException . ExceptT . E.try $
       withRunInIO $ \run ->
         inner $ run . (either (E.throwIO . InternalException) pure <=< runExceptT)
+
+-- | Rename a file, falling back to copy + delete when source and destination
+-- are on different filesystems (rename(2) fails with EXDEV).
+crossDeviceRenameFile :: MonadIO m => FilePath -> FilePath -> m ()
+crossDeviceRenameFile src dst =
+  liftIO $ catchIOError (renameFile src dst) $ \e ->
+    if isCrossDeviceError e
+      then do
+        copyFile src dst
+        removeFile src
+      else E.throwIO e
+  where
+    isCrossDeviceError e = case ioe_errno e of
+      Just errno -> Errno errno == eXDEV
+      Nothing -> False


### PR DESCRIPTION
Fixes #2660.

`rename(2)` fails with `EXDEV` when source and destination are on different
filesystems. For CLI file transfers this is the common case — the XFTP temp
directory is under `/tmp`, the destination is the user's Downloads folder:

```
exception: renameFile:renamePath:rename '/tmp/…/xftp.decrypted' to
'/home/…/Downloads/photo.jpg': unsupported operation (Invalid cross-device link)
```

Adds `crossDeviceRenameFile` to `Simplex.Chat.Util`: falls back to copy + delete
when `rename` fails with `EXDEV`, rethrows anything else unchanged. Applied at the
file-move call sites in `Subscriber.hs`, `Internal.hs`, `Archive.hs` and `Remote.hs`.

The `EXDEV` check reads `ioe_errno` from the caught `IOError` rather than calling
`getErrno` in the handler, so the value can't drift during exception unwinding.