### PR TITLE
desktop: start using continuous runtime for AppImage again

### DIFF
--- a/scripts/desktop/make-appimage-linux.sh
+++ b/scripts/desktop/make-appimage-linux.sh
@@ -40,10 +40,10 @@ if [ ! -f ../appimagetool-x86_64.AppImage ]; then
     wget --secure-protocol=TLSv1_3 https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage -O ../appimagetool-x86_64.AppImage
     chmod +x ../appimagetool-x86_64.AppImage
 fi
-if [ ! -f ../runtime-fuse3-x86_64 ]; then
-    wget --secure-protocol=TLSv1_3 https://github.com/AppImage/type2-runtime/releases/download/old/runtime-fuse3-x86_64 -O ../runtime-fuse3-x86_64
-    chmod +x ../runtime-fuse3-x86_64
+if [ ! -f ../runtime-x86_64 ]; then
+    wget --secure-protocol=TLSv1_3 https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-x86_64 -O ../runtime-x86_64
+    chmod +x ../runtime-x86_64
 fi
-../appimagetool-x86_64.AppImage --runtime-file ../runtime-fuse3-x86_64 .
+../appimagetool-x86_64.AppImage --runtime-file ../runtime-x86_64 .
 
 mv *imple*.AppImage ../../


### PR DESCRIPTION
It was fixed: https://github.com/AppImage/type2-runtime/pull/82