### PR TITLE
opt-in to MTE async mode

### DIFF
--- a/apps/multiplatform/android/src/main/AndroidManifest.xml
+++ b/apps/multiplatform/android/src/main/AndroidManifest.xml
@@ -33,6 +33,7 @@
       android:fullBackupOnly="false"
       android:icon="@mipmap/icon"
       android:label="${app_name}"
+      android:memtagMode="async"
       android:extractNativeLibs="${extract_native_libs}"
       android:supportsRtl="true"
       android:theme="@style/Theme.SimpleX">


### PR DESCRIPTION
currently only benefits GrapheneOS users on Pixel 8 and 9 who don't turn on MTE for all apps or SimpleX manually. hopefully will be extended to all Pixel users and then more devices