### PR TITLE
Add PRIVACY.md to package.yaml and cabal file

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -9,6 +9,7 @@ maintainer: chat@simplex.chat
 copyright: 2020-22 simplex.chat
 category: Web, System, Services, Cryptography
 extra-source-files:
+  - PRIVACY.md
   - README.md
   - cabal.project
 

--- a/simplex-chat.cabal
+++ b/simplex-chat.cabal
@@ -15,6 +15,7 @@ license:        AGPL-3
 license-file:   LICENSE
 build-type:     Simple
 extra-source-files:
+    PRIVACY.md
     README.md
     cabal.project
 


### PR DESCRIPTION
This PR adds PRIVACY.md to `extra-source-files` in the package.yaml and cabal file.
Listing PRIVACY.md there is correct, as this file is needed during compilation of the simplex-chat CLI client.

This change fixes building simplex-chat using Cabal 3.12 and Template Haskell 2.21.
Without this fix, Template Haskell cannot find PRIVACY.md in the project directory during compilation.
This is because build happens in a temporary directory to which PRIVACY.md is not copied unless listed
as a source file.
