### PR TITLE
android, desktop: fix previous years display on chat view

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
@@ -2540,7 +2540,7 @@ fun getTimestampDateText(t: Instant): String {
   val time = t.toLocalDateTime(tz).toJavaLocalDateTime()
   val weekday = time.format(DateTimeFormatter.ofPattern("EEE"))
   val dayMonthYear = time.format(DateTimeFormatter.ofPattern(
-    if (Clock.System.now().toLocalDateTime(tz).year == time.year) "d MMM" else "d MMM YYYY")
+    if (Clock.System.now().toLocalDateTime(tz).year == time.year) "d MMM" else "d MMM yyyy")
   )
 
   return "$weekday, $dayMonthYear"


### PR DESCRIPTION
30 and 31 of December messages were incorrectly showing as "31 December 2025", this was due to the year pattern used when formatting dates.

- `YYYY` (week-based year) can cause issues at the end of December or start of January.
- `yyyy` (calendar year) ensures you get the actual year of the LocalDateTime.