### PR TITLE
ui: remove support for inline moderation

### DIFF
--- a/apps/ios/Shared/Views/Chat/ChatView.swift
+++ b/apps/ios/Shared/Views/Chat/ChatView.swift
@@ -1284,8 +1284,8 @@ struct ChatView: View {
 
         @ViewBuilder
         private func menu(_ ci: ChatItem, _ range: ClosedRange<Int>?, live: Bool) -> some View {
-            if let groupInfo = chat.chatInfo.groupInfo, ci.isReport, ci.meta.itemDeleted == nil {
-                if ci.chatDir != .groupSnd {
+            if case let .group(gInfo) = chat.chatInfo, ci.isReport, ci.meta.itemDeleted == nil {
+                if ci.chatDir != .groupSnd, gInfo.membership.memberRole >= .moderator {
                     archiveReportButton(ci)
                 }
                 deleteButton(ci)
@@ -1873,13 +1873,6 @@ struct ChatView: View {
             }
         }
     }
-}
-
-private func showNoMessageMessageAlert() {
-    AlertManager.shared.showAlertMsg(
-        title: LocalizedStringKey("No message"),
-        message: LocalizedStringKey("This message was deleted or not received yet.")
-    )
 }
 
 private func broadcastDeleteButtonText(_ chat: Chat) -> LocalizedStringKey {

--- a/apps/ios/Shared/Views/Chat/ChatView.swift
+++ b/apps/ios/Shared/Views/Chat/ChatView.swift
@@ -1288,7 +1288,7 @@ struct ChatView: View {
                 if ci.chatDir != .groupSnd, gInfo.membership.memberRole >= .moderator {
                     archiveReportButton(ci)
                 }
-                deleteButton(ci)
+                deleteButton(ci, label: "Delete report")
             } else if let mc = ci.content.msgContent, !ci.isReport, ci.meta.itemDeleted == nil || revealed {
                 if chat.chatInfo.featureEnabled(.reactions) && ci.allowAddReaction,
                    availableReactions.count > 0 {
@@ -1618,7 +1618,7 @@ struct ChatView: View {
             }
         }
 
-        private func deleteButton(_ ci: ChatItem) -> Button<some View> {
+        private func deleteButton(_ ci: ChatItem, label: LocalizedStringKey = "Delete") -> Button<some View> {
             Button(role: .destructive) {
                 if !revealed,
                    let currIndex = m.getChatItemIndex(ci),
@@ -1640,10 +1640,7 @@ struct ChatView: View {
                     deletingItem = ci
                 }
             } label: {
-                Label(
-                    NSLocalizedString("Delete", comment: "chat item action"),
-                    systemImage: "trash"
-                )
+                Label(label, systemImage: "trash")
             }
         }
 
@@ -1694,10 +1691,7 @@ struct ChatView: View {
                     )
                 )
             } label: {
-                Label(
-                    NSLocalizedString("Archive report", comment: "chat item action"),
-                    systemImage: "archivebox"
-                )
+                Label("Archive report", systemImage: "archivebox")
             }
         }
 

--- a/apps/ios/Shared/Views/ChatList/ChatPreviewView.swift
+++ b/apps/ios/Shared/Views/ChatList/ChatPreviewView.swift
@@ -277,7 +277,7 @@ struct ChatPreviewView: View {
         
         func prefix() -> Text {
             switch cItem.content.msgContent {
-            case let .report(text, reason): return Text(!text.isEmpty ? "\(reason.text): " : reason.text).italic().foregroundColor(Color.red)
+            case let .report(_, reason): return Text(!itemText.isEmpty ? "\(reason.text): " : reason.text).italic().foregroundColor(Color.red)
             default: return Text("")
             }
         }

--- a/apps/ios/SimpleXChat/ChatTypes.swift
+++ b/apps/ios/SimpleXChat/ChatTypes.swift
@@ -3337,17 +3337,6 @@ public struct CIQuote: Decodable, ItemContent, Hashable {
         }
         return CIQuote(chatDir: chatDir, itemId: itemId, sentAt: sentAt, content: mc)
     }
-    
-    public func memberToModerate(_ chatInfo: ChatInfo) -> GroupMember? {
-        switch (chatInfo, chatDir) {
-        case let (.group(groupInfo), .groupRcv(groupMember)):
-            let m = groupInfo.membership
-            return m.memberRole >= .admin && m.memberRole >= groupMember.memberRole
-                    ? groupMember
-                    : nil
-        default: return nil
-        }
-    }
 }
 
 public struct CIReactionCount: Decodable, Hashable {

--- a/apps/ios/SimpleXChat/ChatTypes.swift
+++ b/apps/ios/SimpleXChat/ChatTypes.swift
@@ -2078,7 +2078,7 @@ public struct GroupMember: Identifiable, Decodable, Hashable {
     public func canChangeRoleTo(groupInfo: GroupInfo) -> [GroupMemberRole]? {
         if !canBeRemoved(groupInfo: groupInfo) { return nil }
         let userRole = groupInfo.membership.memberRole
-        return GroupMemberRole.allCases.filter { $0 <= userRole && $0 != .author }
+        return GroupMemberRole.supportedRoles.filter { $0 <= userRole }
     }
 
     public func canBlockForAll(groupInfo: GroupInfo) -> Bool {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
@@ -2958,19 +2958,6 @@ class CIQuote (
     null -> null
   }
 
-  fun memberToModerate(chatInfo: ChatInfo): GroupMember? {
-    return if (chatInfo is ChatInfo.Group && chatDir is CIDirection.GroupRcv) {
-      val m = chatInfo.groupInfo.membership
-      if (m.memberRole >= GroupMemberRole.Moderator && m.memberRole >= chatDir.groupMember.memberRole) {
-        chatDir.groupMember
-      } else {
-        null
-      }
-    } else {
-      null
-    }
-  }
-
   companion object {
     fun getSample(itemId: Long?, sentAt: Instant, text: String, chatDir: CIDirection?): CIQuote =
       CIQuote(chatDir = chatDir, itemId = itemId, sentAt = sentAt, content = MsgContent.MCText(text))

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
@@ -301,41 +301,41 @@ fun ChatView(staleChatId: State<String?>, onComposed: suspend (chatId: String) -
               }
             },
             deleteMessage = { itemId, mode ->
-              val toDeleteItem = chatModel.chatItems.value.firstOrNull { it.id == itemId }
-              val toModerate = toDeleteItem?.memberToModerate(chatInfo)
-              val groupInfo = toModerate?.first
-              val groupMember = toModerate?.second
-              val deletedChatItem: ChatItem?
-              val toChatItem: ChatItem?
-              val r = if (mode == CIDeleteMode.cidmBroadcast && groupInfo != null && groupMember != null) {
-                chatModel.controller.apiDeleteMemberChatItems(
-                  chatRh,
-                  groupId = groupInfo.groupId,
-                  itemIds = listOf(itemId)
-                )
-              } else {
-                chatModel.controller.apiDeleteChatItems(
-                  chatRh,
-                  type = chatInfo.chatType,
-                  id = chatInfo.apiId,
-                  itemIds = listOf(itemId),
-                  mode = mode
-                )
-              }
-              val deleted = r?.firstOrNull()
-              if (deleted != null) {
-                deletedChatItem = deleted.deletedChatItem.chatItem
-                toChatItem = deleted.toChatItem?.chatItem
-                withChats {
-                  if (toChatItem != null) {
-                    upsertChatItem(chatRh, chatInfo, toChatItem)
-                  } else {
-                    removeChatItem(chatRh, chatInfo, deletedChatItem)
+              withBGApi {
+                val toDeleteItem = chatModel.chatItems.value.firstOrNull { it.id == itemId }
+                val toModerate = toDeleteItem?.memberToModerate(chatInfo)
+                val groupInfo = toModerate?.first
+                val groupMember = toModerate?.second
+                val deletedChatItem: ChatItem?
+                val toChatItem: ChatItem?
+                val r = if (mode == CIDeleteMode.cidmBroadcast && groupInfo != null && groupMember != null) {
+                  chatModel.controller.apiDeleteMemberChatItems(
+                    chatRh,
+                    groupId = groupInfo.groupId,
+                    itemIds = listOf(itemId)
+                  )
+                } else {
+                  chatModel.controller.apiDeleteChatItems(
+                    chatRh,
+                    type = chatInfo.chatType,
+                    id = chatInfo.apiId,
+                    itemIds = listOf(itemId),
+                    mode = mode
+                  )
+                }
+                val deleted = r?.firstOrNull()
+                if (deleted != null) {
+                  deletedChatItem = deleted.deletedChatItem.chatItem
+                  toChatItem = deleted.toChatItem?.chatItem
+                  withChats {
+                    if (toChatItem != null) {
+                      upsertChatItem(chatRh, chatInfo, toChatItem)
+                    } else {
+                      removeChatItem(chatRh, chatInfo, deletedChatItem)
+                    }
                   }
                 }
               }
-
-              deleted
             },
             deleteMessages = { itemIds -> deleteMessages(chatRh, chatInfo, itemIds, false, moderate = false) },
             receiveFile = { fileId ->
@@ -599,7 +599,7 @@ fun ChatLayout(
   info: () -> Unit,
   showMemberInfo: (GroupInfo, GroupMember) -> Unit,
   loadMessages: suspend (ChatId, ChatPagination, ActiveChatState, visibleItemIndexesNonReversed: () -> IntRange) -> Unit,
-  deleteMessage: suspend (Long, CIDeleteMode) -> ChatItemDeletion?,
+  deleteMessage: (Long, CIDeleteMode) -> Unit,
   deleteMessages: (List<Long>) -> Unit,
   receiveFile: (Long) -> Unit,
   cancelFile: (Long) -> Unit,
@@ -946,7 +946,7 @@ fun BoxScope.ChatItemsList(
   showMemberInfo: (GroupInfo, GroupMember) -> Unit,
   showChatInfo: () -> Unit,
   loadMessages: suspend (ChatId, ChatPagination, ActiveChatState, visibleItemIndexesNonReversed: () -> IntRange) -> Unit,
-  deleteMessage: suspend (Long, CIDeleteMode) -> ChatItemDeletion?,
+  deleteMessage: (Long, CIDeleteMode) -> Unit,
   deleteMessages: (List<Long>) -> Unit,
   receiveFile: (Long) -> Unit,
   cancelFile: (Long) -> Unit,
@@ -2438,7 +2438,7 @@ fun PreviewChatLayout() {
       info = {},
       showMemberInfo = { _, _ -> },
       loadMessages = { _, _, _, _ -> },
-      deleteMessage = { _, _ -> null },
+      deleteMessage = { _, _ -> },
       deleteMessages = { _ -> },
       receiveFile = { _ -> },
       cancelFile = {},
@@ -2511,7 +2511,7 @@ fun PreviewGroupChatLayout() {
       info = {},
       showMemberInfo = { _, _ -> },
       loadMessages = { _, _, _, _ -> },
-      deleteMessage = { _, _ -> null },
+      deleteMessage = { _, _ -> },
       deleteMessages = {},
       receiveFile = { _ -> },
       cancelFile = {},

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupMemberInfoView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupMemberInfoView.kt
@@ -747,13 +747,13 @@ fun updateMemberSettings(rhId: Long?, gInfo: GroupInfo, member: GroupMember, mem
   }
 }
 
-fun blockForAllAlert(rhId: Long?, gInfo: GroupInfo, mem: GroupMember, blockMember: () -> Unit = { withBGApi { blockMemberForAll(rhId, gInfo, mem, true) } }) {
+fun blockForAllAlert(rhId: Long?, gInfo: GroupInfo, mem: GroupMember) {
   AlertManager.shared.showAlertDialog(
     title = generalGetString(MR.strings.block_for_all_question),
     text = generalGetString(MR.strings.block_member_desc).format(mem.chatViewName),
     confirmText = generalGetString(MR.strings.block_for_all),
     onConfirm = {
-      blockMember()
+      blockMemberForAll(rhId, gInfo, mem, true)
     },
     destructive = true,
   )
@@ -765,15 +765,17 @@ fun unblockForAllAlert(rhId: Long?, gInfo: GroupInfo, mem: GroupMember) {
     text = generalGetString(MR.strings.unblock_member_desc).format(mem.chatViewName),
     confirmText = generalGetString(MR.strings.unblock_for_all),
     onConfirm = {
-      withBGApi { blockMemberForAll(rhId, gInfo, mem, false) }
+      blockMemberForAll(rhId, gInfo, mem, false)
     },
   )
 }
 
-suspend fun blockMemberForAll(rhId: Long?, gInfo: GroupInfo, member: GroupMember, blocked: Boolean) {
-  val updatedMember = ChatController.apiBlockMemberForAll(rhId, gInfo.groupId, member.groupMemberId, blocked)
-  withChats {
-    upsertGroupMember(rhId, gInfo, updatedMember)
+fun blockMemberForAll(rhId: Long?, gInfo: GroupInfo, member: GroupMember, blocked: Boolean) {
+  withBGApi {
+    val updatedMember = ChatController.apiBlockMemberForAll(rhId, gInfo.groupId, member.groupMemberId, blocked)
+    withChats {
+      upsertGroupMember(rhId, gInfo, updatedMember)
+    }
   }
 }
 

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/ChatItemView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/ChatItemView.kt
@@ -302,7 +302,7 @@ fun ChatItemView(
                 if (cItem.chatDir !is CIDirection.GroupSnd && cInfo.groupInfo.membership.memberRole >= GroupMemberRole.Moderator) {
                   ArchiveReportItemAction(cItem, showMenu, deleteMessage)
                 }
-                DeleteItemAction(cItem, revealed, showMenu, questionText = deleteMessageQuestionText(), deleteMessage, deleteMessages)
+                DeleteItemAction(cItem, revealed, showMenu, questionText = deleteMessageQuestionText(), deleteMessage, deleteMessages, buttonText = stringResource(MR.strings.delete_report))
                 Divider()
                 SelectItemAction(showMenu, selectChatItem)
               }
@@ -744,9 +744,10 @@ fun DeleteItemAction(
   questionText: String,
   deleteMessage: (Long, CIDeleteMode) -> Unit,
   deleteMessages: (List<Long>) -> Unit,
+  buttonText: String = stringResource(MR.strings.delete_verb),
 ) {
   ItemAction(
-    stringResource(MR.strings.delete_verb),
+    buttonText,
     painterResource(MR.images.ic_delete),
     onClick = {
       showMenu.value = false

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/ChatItemView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/ChatItemView.kt
@@ -299,7 +299,7 @@ fun ChatItemView(
             // cItem.id check is a special case for live message chat item which has negative ID while not sent yet
             cItem.isReport && cItem.meta.itemDeleted == null && cInfo is ChatInfo.Group -> {
               DefaultDropdownMenu(showMenu) {
-                if (cItem.chatDir !is CIDirection.GroupSnd) {
+                if (cItem.chatDir !is CIDirection.GroupSnd && cInfo.groupInfo.membership.memberRole >= GroupMemberRole.Moderator) {
                   ArchiveReportItemAction(cItem, showMenu, deleteMessage)
                 }
                 DeleteItemAction(cItem, revealed, showMenu, questionText = deleteMessageQuestionText(), deleteMessage, deleteMessages)

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/ChatItemView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/ChatItemView.kt
@@ -27,12 +27,9 @@ import androidx.compose.ui.unit.*
 import chat.simplex.common.model.*
 import chat.simplex.common.model.ChatModel.controller
 import chat.simplex.common.model.ChatModel.currentUser
-import chat.simplex.common.model.ChatModel.withChats
 import chat.simplex.common.platform.*
 import chat.simplex.common.ui.theme.*
 import chat.simplex.common.views.chat.*
-import chat.simplex.common.views.chat.group.blockForAllAlert
-import chat.simplex.common.views.chat.group.blockMemberForAll
 import chat.simplex.common.views.helpers.*
 import chat.simplex.res.MR
 import kotlinx.datetime.Clock
@@ -77,7 +74,7 @@ fun ChatItemView(
   selectedChatItems: MutableState<Set<Long>?>,
   fillMaxWidth: Boolean = true,
   selectChatItem: () -> Unit,
-  deleteMessage: suspend (Long, CIDeleteMode) -> ChatItemDeletion?,
+  deleteMessage: (Long, CIDeleteMode) -> Unit,
   deleteMessages: (List<Long>) -> Unit,
   receiveFile: (Long) -> Unit,
   cancelFile: (Long) -> Unit,
@@ -112,12 +109,6 @@ fun ChatItemView(
   val fullDeleteAllowed = remember(cInfo) { cInfo.featureEnabled(ChatFeature.FullDelete) }
   val onLinkLongClick = { _: String -> showMenu.value = true }
   val live = remember { derivedStateOf { composeState.value.liveMessage != null } }.value
-
-  val deleteMessageAsync: (Long, CIDeleteMode) -> Unit = { id, mode ->
-    withBGApi {
-      deleteMessage(id, mode)
-    }
-  }
 
   Box(
     modifier = if (fillMaxWidth) Modifier.fillMaxWidth() else Modifier,
@@ -293,7 +284,7 @@ fun ChatItemView(
         @Composable
         fun DeleteItemMenu() {
           DefaultDropdownMenu(showMenu) {
-            DeleteItemAction(cItem, revealed, showMenu, questionText = deleteMessageQuestionText(), deleteMessageAsync, deleteMessages)
+            DeleteItemAction(cItem, revealed, showMenu, questionText = deleteMessageQuestionText(), deleteMessage, deleteMessages)
             if (cItem.canBeDeletedForSelf) {
               Divider()
               SelectItemAction(showMenu, selectChatItem)
@@ -308,31 +299,12 @@ fun ChatItemView(
             // cItem.id check is a special case for live message chat item which has negative ID while not sent yet
             cItem.isReport && cItem.meta.itemDeleted == null && cInfo is ChatInfo.Group -> {
               DefaultDropdownMenu(showMenu) {
-                if (cItem.chatDir is CIDirection.GroupSnd) {
-                  DeleteItemAction(cItem, revealed, showMenu, questionText = deleteMessageQuestionText(), deleteMessageAsync, deleteMessages)
-                } else {
-                  ArchiveReportItemAction(cItem, showMenu, deleteMessageAsync)
-                  val qItem = cItem.quotedItem
-                  if (qItem != null) {
-                    ModerateReportItemAction(rhId, cInfo, cItem, qItem, showMenu, deleteMessage)
-                    val rMember = qItem.memberToModerate(cInfo)
-                    if (rMember != null && !rMember.blockedByAdmin && rMember.canBlockForAll(cInfo.groupInfo)) {
-                      BlockMemberAction(
-                        rhId,
-                        chatInfo = cInfo,
-                        groupInfo = cInfo.groupInfo,
-                        cItem = cItem,
-                        reportedItem = qItem,
-                        member = rMember,
-                        showMenu = showMenu,
-                        deleteMessage = deleteMessage
-                      )
-                    }
-                  }
-
-                  Divider()
-                  SelectItemAction(showMenu, selectChatItem)
+                if (cItem.chatDir !is CIDirection.GroupSnd) {
+                  ArchiveReportItemAction(cItem, showMenu, deleteMessage)
                 }
+                DeleteItemAction(cItem, revealed, showMenu, questionText = deleteMessageQuestionText(), deleteMessage, deleteMessages)
+                Divider()
+                SelectItemAction(showMenu, selectChatItem)
               }
             }
             cItem.content.msgContent != null && cItem.id >= 0 && !cItem.isReport -> {
@@ -421,13 +393,13 @@ fun ChatItemView(
                   CancelFileItemAction(cItem.file.fileId, showMenu, cancelFile = cancelFile, cancelAction = cItem.file.cancelAction)
                 }
                 if (!(live && cItem.meta.isLive) && !preview) {
-                  DeleteItemAction(cItem, revealed, showMenu, questionText = deleteMessageQuestionText(), deleteMessageAsync, deleteMessages)
+                  DeleteItemAction(cItem, revealed, showMenu, questionText = deleteMessageQuestionText(), deleteMessage, deleteMessages)
                 }
                 if (cItem.chatDir !is CIDirection.GroupSnd) {
                   val groupInfo = cItem.memberToModerate(cInfo)?.first
                   if (groupInfo != null) {
-                    ModerateItemAction(cItem, questionText = moderateMessageQuestionText(cInfo.featureEnabled(ChatFeature.FullDelete), 1), showMenu, deleteMessageAsync)
-                  } else if (cItem.meta.itemDeleted == null && cInfo is ChatInfo.Group && cInfo.groupInfo.membership.memberRole < GroupMemberRole.Moderator && !live) {
+                    ModerateItemAction(cItem, questionText = moderateMessageQuestionText(cInfo.featureEnabled(ChatFeature.FullDelete), 1), showMenu, deleteMessage)
+                  } else if (cItem.meta.itemDeleted == null && cInfo is ChatInfo.Group && cInfo.groupInfo.membership.memberRole == GroupMemberRole.Member && !live) {
                     ReportItemAction(cItem, composeState, showMenu)
                   }
                 }
@@ -447,7 +419,7 @@ fun ChatItemView(
                   ExpandItemAction(revealed, showMenu, reveal)
                 }
                 ItemInfoAction(cInfo, cItem, showItemDetails, showMenu)
-                DeleteItemAction(cItem, revealed, showMenu, questionText = deleteMessageQuestionText(), deleteMessageAsync, deleteMessages)
+                DeleteItemAction(cItem, revealed, showMenu, questionText = deleteMessageQuestionText(), deleteMessage, deleteMessages)
                 if (cItem.canBeDeletedForSelf) {
                   Divider()
                   SelectItemAction(showMenu, selectChatItem)
@@ -457,7 +429,7 @@ fun ChatItemView(
             cItem.isDeletedContent -> {
               DefaultDropdownMenu(showMenu) {
                 ItemInfoAction(cInfo, cItem, showItemDetails, showMenu)
-                DeleteItemAction(cItem, revealed, showMenu, questionText = deleteMessageQuestionText(), deleteMessageAsync, deleteMessages)
+                DeleteItemAction(cItem, revealed, showMenu, questionText = deleteMessageQuestionText(), deleteMessage, deleteMessages)
                 if (cItem.canBeDeletedForSelf) {
                   Divider()
                   SelectItemAction(showMenu, selectChatItem)
@@ -471,7 +443,7 @@ fun ChatItemView(
                 } else {
                   ExpandItemAction(revealed, showMenu, reveal)
                 }
-                DeleteItemAction(cItem, revealed, showMenu, questionText = deleteMessageQuestionText(), deleteMessageAsync, deleteMessages)
+                DeleteItemAction(cItem, revealed, showMenu, questionText = deleteMessageQuestionText(), deleteMessage, deleteMessages)
                 if (cItem.canBeDeletedForSelf) {
                   Divider()
                   SelectItemAction(showMenu, selectChatItem)
@@ -480,7 +452,7 @@ fun ChatItemView(
             }
             else -> {
               DefaultDropdownMenu(showMenu) {
-                DeleteItemAction(cItem, revealed, showMenu, questionText = deleteMessageQuestionText(), deleteMessageAsync, deleteMessages)
+                DeleteItemAction(cItem, revealed, showMenu, questionText = deleteMessageQuestionText(), deleteMessage, deleteMessages)
                 if (selectedChatItems.value == null) {
                   Divider()
                   SelectItemAction(showMenu, selectChatItem)
@@ -497,7 +469,7 @@ fun ChatItemView(
               RevealItemAction(revealed, showMenu, reveal)
             }
             ItemInfoAction(cInfo, cItem, showItemDetails, showMenu)
-            DeleteItemAction(cItem, revealed, showMenu, questionText = deleteMessageQuestionText(), deleteMessageAsync, deleteMessages)
+            DeleteItemAction(cItem, revealed, showMenu, questionText = deleteMessageQuestionText(), deleteMessage, deleteMessages)
             if (cItem.canBeDeletedForSelf) {
               Divider()
               SelectItemAction(showMenu, selectChatItem)
@@ -531,7 +503,7 @@ fun ChatItemView(
           DeletedItemView(cItem, cInfo.timedMessagesTTL, showViaProxy = showViaProxy, showTimestamp = showTimestamp)
           DefaultDropdownMenu(showMenu) {
             ItemInfoAction(cInfo, cItem, showItemDetails, showMenu)
-            DeleteItemAction(cItem, revealed, showMenu, questionText = deleteMessageQuestionText(), deleteMessageAsync, deleteMessages)
+            DeleteItemAction(cItem, revealed, showMenu, questionText = deleteMessageQuestionText(), deleteMessage, deleteMessages)
             if (cItem.canBeDeletedForSelf) {
               Divider()
               SelectItemAction(showMenu, selectChatItem)
@@ -588,7 +560,7 @@ fun ChatItemView(
           MarkedDeletedItemView(cItem, cInfo.timedMessagesTTL, revealed, showViaProxy = showViaProxy, showTimestamp = showTimestamp)
           DefaultDropdownMenu(showMenu) {
             ItemInfoAction(cInfo, cItem, showItemDetails, showMenu)
-            DeleteItemAction(cItem, revealed, showMenu, questionText = generalGetString(MR.strings.delete_message_cannot_be_undone_warning), deleteMessageAsync, deleteMessages)
+            DeleteItemAction(cItem, revealed, showMenu, questionText = generalGetString(MR.strings.delete_message_cannot_be_undone_warning), deleteMessage, deleteMessages)
             if (cItem.canBeDeletedForSelf) {
               Divider()
               SelectItemAction(showMenu, selectChatItem)
@@ -822,7 +794,7 @@ fun ModerateItemAction(
     painterResource(MR.images.ic_flag),
     onClick = {
       showMenu.value = false
-      moderateMessageAlertDialog(cItem.id, questionText, deleteMessage = deleteMessage)
+      moderateMessageAlertDialog(cItem, questionText, deleteMessage = deleteMessage)
     },
     color = Color.Red
   )
@@ -938,119 +910,9 @@ private fun ReportItemAction(
 }
 
 @Composable
-private fun ModerateReportItemAction(
-  rhId: Long?,
-  chatInfo: ChatInfo,
-  cItem: ChatItem,
-  reportedItem: CIQuote,
-  showMenu: MutableState<Boolean>,
-  deleteMessage: suspend (Long, CIDeleteMode) -> ChatItemDeletion?
-) {
-  ItemAction(
-    stringResource(MR.strings.moderate_verb),
-    painterResource(MR.images.ic_flag),
-    onClick = {
-      withBGApi {
-        val reportedMessageId = getLocalIdForReportedMessage(rhId, chatInfo, reportedItem, cItem.id)
-        if (reportedMessageId != null) {
-          moderateMessageAlertDialog(
-            reportedMessageId,
-            questionText = moderateMessageQuestionText(chatInfo.featureEnabled(ChatFeature.FullDelete), 1),
-            deleteMessage = { id, m ->
-              withApi {
-                val deleted = deleteMessage(id, m)
-                if (deleted != null) {
-                  deleteMessage(cItem.id, CIDeleteMode.cidmInternalMark)
-                }
-              }
-            },
-          )
-        }
-      }
-      showMenu.value = false
-    },
-    color = Color.Red
-  )
-}
-
-@Composable
-private fun BlockMemberAction(
-  rhId: Long?,
-  chatInfo: ChatInfo,
-  groupInfo: GroupInfo,
-  cItem: ChatItem,
-  reportedItem: CIQuote,
-  member: GroupMember,
-  showMenu: MutableState<Boolean>,
-  deleteMessage: suspend (Long, CIDeleteMode) -> ChatItemDeletion?
-) {
-  ItemAction(
-    stringResource(MR.strings.block_member_button),
-    painterResource(MR.images.ic_back_hand),
-    onClick = {
-      AlertManager.shared.showAlertDialogButtonsColumn(
-        title = generalGetString(MR.strings.report_block_and_moderate_title),
-        buttons = {
-          SectionItemView({
-            AlertManager.shared.hideAlert()
-            withBGApi {
-              val reportedMessageId = getLocalIdForReportedMessage(rhId, chatInfo, reportedItem, cItem.id)
-              if (reportedMessageId != null) {
-                blockAndModerateAlertDialog(
-                  rhId,
-                  reportedMessageId = reportedMessageId,
-                  reportId = cItem.id,
-                  gInfo = groupInfo,
-                  mem = member,
-                  deleteMessage = deleteMessage,
-                )
-              }
-            }
-          }) {
-            Text(generalGetString(MR.strings.report_block_and_moderate_block_and_moderate_action), Modifier.fillMaxWidth(), textAlign = TextAlign.Center, color = MaterialTheme.colors.error)
-          }
-          SectionItemView({
-            AlertManager.shared.hideAlert()
-            withBGApi {
-              val reportedMessageId = getLocalIdForReportedMessage(rhId, chatInfo, reportedItem, cItem.id)
-              if (reportedMessageId != null) {
-                blockForAllAlert(rhId, gInfo = groupInfo, mem = member, blockMember = {
-                  withBGApi {
-                    try {
-                      blockMemberForAll(
-                        rhId,
-                        gInfo = groupInfo,
-                        member = member,
-                        blocked = true
-                      )
-                      deleteMessage(reportedMessageId, CIDeleteMode.cidmInternalMark)
-                    } catch (ex: Exception) {
-                      Log.e(TAG, "BlockMemberAction block and moderate ${ex.message}")
-                    }
-                  }
-                })
-              }
-            }
-          }) {
-            Text(generalGetString(MR.strings.report_block_and_moderate_only_block_action), Modifier.fillMaxWidth(), textAlign = TextAlign.Center, color = MaterialTheme.colors.error)
-          }
-          SectionItemView({
-            AlertManager.shared.hideAlert()
-          }) {
-            Text(generalGetString(MR.strings.cancel_verb), Modifier.fillMaxWidth(), textAlign = TextAlign.Center, color = MaterialTheme.colors.primary)
-          }
-        }
-      )
-      showMenu.value = false
-    },
-    color = Color.Red
-  )
-}
-
-@Composable
 private fun ArchiveReportItemAction(cItem: ChatItem, showMenu: MutableState<Boolean>, deleteMessage: (Long, CIDeleteMode) -> Unit) {
   ItemAction(
-    stringResource(MR.strings.archive_verb),
+    stringResource(MR.strings.archive_report),
     painterResource(MR.images.ic_inventory_2),
     onClick = {
       AlertManager.shared.showAlertDialog(
@@ -1401,14 +1263,14 @@ fun moderateMessageQuestionText(fullDeleteAllowed: Boolean, count: Int): String 
   }
 }
 
-fun moderateMessageAlertDialog(chatItemId: Long, questionText: String, deleteMessage: (Long, CIDeleteMode) -> Unit) {
+fun moderateMessageAlertDialog(chatItem: ChatItem, questionText: String, deleteMessage: (Long, CIDeleteMode) -> Unit) {
   AlertManager.shared.showAlertDialog(
     title = generalGetString(MR.strings.delete_member_message__question),
     text = questionText,
     confirmText = generalGetString(MR.strings.delete_verb),
     destructive = true,
     onConfirm = {
-      deleteMessage(chatItemId, CIDeleteMode.cidmBroadcast)
+      deleteMessage(chatItem.id, CIDeleteMode.cidmBroadcast)
     }
   )
 }
@@ -1423,58 +1285,7 @@ fun moderateMessagesAlertDialog(itemIds: List<Long>, questionText: String, delet
   )
 }
 
-private fun blockAndModerateAlertDialog(
-  rhId: Long?,
-  reportedMessageId: Long,
-  reportId: Long,
-  gInfo: GroupInfo,
-  mem: GroupMember,
-  deleteMessage: suspend (Long, CIDeleteMode) -> ChatItemDeletion?
-) {
-  AlertManager.shared.showAlertDialog(
-    title = generalGetString(MR.strings.report_block_and_moderate_confirmation_title),
-    text = generalGetString(
-      if (gInfo.fullGroupPreferences.fullDelete.on) MR.strings.report_block_and_moderate_confirmation_desc_full_delete else MR.strings.report_block_and_moderate_confirmation_desc_full_delete).format(mem.chatViewName),
-    confirmText = generalGetString(MR.strings.report_block_and_moderate_confirmation_ok),
-    onConfirm = {
-      withBGApi {
-        try {
-          val deleted = deleteMessage(reportedMessageId, CIDeleteMode.cidmBroadcast)
-          if (deleted != null) {
-            blockMemberForAll(rhId, gInfo, mem, true)
-            deleteMessage(reportId, CIDeleteMode.cidmInternalMark)
-          }
-        } catch (ex: Exception) {
-          Log.e(TAG, "blockAndModerateAlertDialog block and moderate ${ex.message}")
-        }
-      }
-    },
-    destructive = true,
-  )
-}
-
 expect fun copyItemToClipboard(cItem: ChatItem, clipboard: ClipboardManager)
-
-private suspend fun getLocalIdForReportedMessage(
-  rhId: Long?,
-  chatInfo: ChatInfo,
-  reportedItem: CIQuote,
-  itemId: Long): Long? {
-  if (reportedItem.itemId != null) {
-    return reportedItem.itemId
-  }
-  val item = apiLoadSingleMessage(rhId, chatInfo.chatType, chatInfo.apiId, itemId)
-
-  if (item?.quotedItem?.itemId != null) {
-    withChats {
-      updateChatItem(chatInfo, item)
-    }
-    return item.quotedItem.itemId
-  } else {
-    showQuotedItemDoesNotExistAlert()
-    return null
-  }
-}
 
 @Preview
 @Composable
@@ -1493,7 +1304,7 @@ fun PreviewChatItemView(
     range = remember { mutableStateOf(0..1) },
     selectedChatItems = remember { mutableStateOf(setOf()) },
     selectChatItem = {},
-    deleteMessage = { _, _ -> null },
+    deleteMessage = { _, _ -> },
     deleteMessages = { _ -> },
     receiveFile = { _ -> },
     cancelFile = {},
@@ -1539,7 +1350,7 @@ fun PreviewChatItemViewDeletedContent() {
       range = remember { mutableStateOf(0..1) },
       selectedChatItems = remember { mutableStateOf(setOf()) },
       selectChatItem = {},
-      deleteMessage = { _, _ -> null },
+      deleteMessage = { _, _ -> },
       deleteMessages = { _ -> },
       receiveFile = { _ -> },
       cancelFile = {},

--- a/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
@@ -332,6 +332,7 @@
   <string name="search_verb">Search</string>
   <string name="archive_verb">Archive</string>
   <string name="archive_report">Archive report</string>
+  <string name="delete_report">Delete report</string>
   <string name="sent_message">Sent message</string>
   <string name="received_message">Received message</string>
   <string name="edit_history">History</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
@@ -305,13 +305,6 @@
   <string name="report_reason_alert_title">Report reason?</string>
   <string name="report_archive_alert_title">Archive report?</string>
   <string name="report_archive_alert_desc">The report will be archived for you.</string>
-  <string name="report_block_and_moderate_title">Block and moderate?</string>
-  <string name="report_block_and_moderate_block_and_moderate_action">Block and moderate</string>
-  <string name="report_block_and_moderate_only_block_action">Only block</string>
-  <string name="report_block_and_moderate_confirmation_title">Delete member message and block?</string>
-  <string name="report_block_and_moderate_confirmation_desc_full_delete">The message will be deleted for all members.\nAll new messages from %1$s will be hidden!</string>
-  <string name="report_block_and_moderate_confirmation_desc_mark_delete">The message will be marked as moderated for all members.\nAll new messages from %1$s will be hidden!</string>
-  <string name="report_block_and_moderate_confirmation_ok">Delete and block</string>
 
   <!-- CIStatus errors -->
   <string name="ci_status_other_error">Error: %1$s</string>
@@ -338,6 +331,7 @@
   <string name="info_menu">Info</string>
   <string name="search_verb">Search</string>
   <string name="archive_verb">Archive</string>
+  <string name="archive_report">Archive report</string>
   <string name="sent_message">Sent message</string>
   <string name="received_message">Received message</string>
   <string name="edit_history">History</string>


### PR DESCRIPTION
Remove inline moderation options, after this changes:

- Moderators will no longer be able to press a report and get actions of moderation (moderate, block member), in order to do that they will need to navigate to original message (full support on android, desktop, support for already loaded items in ios, with full support coming soon)
- Archive context menu action on reports renamed "Archive report"
- Only user with role "member" will be able to submit reports
- Context menu options on reports for members: (delete, select)
- Context menu options on reports for admins, moderators, owners: (archive report, delete, select)

## Progress:

- [x] Android/Desktop
- [x] ios