### PR TITLE
fix: fix AndroidManifest.xml so that the dynamic icon is actually applied

### DIFF
--- a/apps/multiplatform/android/src/main/AndroidManifest.xml
+++ b/apps/multiplatform/android/src/main/AndroidManifest.xml
@@ -39,7 +39,7 @@
       android:name="SimplexApp"
       android:allowBackup="false"
       android:fullBackupOnly="false"
-      android:icon="@mipmap/icon"
+      android:icon="@mipmap/ic_launcher"
       android:label="${app_name}"
       android:extractNativeLibs="${extract_native_libs}"
       android:supportsRtl="true"


### PR DESCRIPTION
it seems the code is already implemented [here](https://github.com/simplex-chat/simplex-chat/blob/stable/apps/multiplatform/android/src/main/res/mipmap-anydpi-v26/icon.xml), but it isn't used [here](https://github.com/simplex-chat/simplex-chat/blob/stable/apps/multiplatform/android/src/main/AndroidManifest.xml). Line 42 should be `android:icon="@mipmap/ic_launcher"` instead of `android:icon="@mipmap/icon"` now the MDY icon should be applied properly. This closes #1301 