### PR TITLE
desktop Webrtc screensharing audio FEATURE (WIP Testing needed) 

### DIFF
--- a/packages/simplex-chat-webrtc/src/call.ts
+++ b/packages/simplex-chat-webrtc/src/call.ts
@@ -1379,7 +1379,7 @@ const processCommand = (function () {
   async function getLocalMediaStream(mic: boolean, camera: boolean, facingMode: VideoCamera): Promise<MediaStream> {
     if (!mic && !camera) return new MediaStream()
     const constraints = callMediaConstraints(mic, camera, facingMode)
-    return await navigator.mediaDevices.getUserMedia(constraints)
+    return await navigator.mediaDevices.getDisplayMedia(constraints)
   }
 
   function getLocalScreenCaptureStream(): Promise<MediaStream> {

--- a/packages/simplex-chat-webrtc/src/call.ts
+++ b/packages/simplex-chat-webrtc/src/call.ts
@@ -1379,11 +1379,11 @@ const processCommand = (function () {
   async function getLocalMediaStream(mic: boolean, camera: boolean, facingMode: VideoCamera): Promise<MediaStream> {
     if (!mic && !camera) return new MediaStream()
     const constraints = callMediaConstraints(mic, camera, facingMode)
-    return await navigator.mediaDevices.getDisplayMedia(constraints)
+    return await navigator.mediaDevices.getDisplayMedia(DisplayMediaStreamConstraints)
   }
 
   function getLocalScreenCaptureStream(): Promise<MediaStream> {
-    const constraints: any /* DisplayMediaStreamConstraints */ = {
+    const DisplayMediaStreamConstraints = {
       video: {
         frameRate: 24,
         //width: {
@@ -1394,10 +1394,10 @@ const processCommand = (function () {
         //aspectRatio: 1.33,
       },
       audio: allowSendScreenAudio,
-      // This works with Chrome, Edge, Opera, but not with Firefox and Safari
-      // systemAudio: "include"
+      // This works with Chrome, Edge, Opera, but not with Firefox and Safari (https://developer.mozilla.org/en-US/docs/Web/API/Screen_Capture_API/Using_Screen_Capture#browser_compatibility)
+      systemAudio: "include"
     }
-    return navigator.mediaDevices.getDisplayMedia(constraints)
+    return navigator.mediaDevices.getDisplayMedia(DisplayMediaStreamConstraints)
   }
 
   async function browserHasCamera(): Promise<boolean> {


### PR DESCRIPTION
### This pull request should allow users to screenshare audio 
[Audio capture support works with Chrome, Edge, Opera, but not with Firefox and Safari](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Capture_API/Using_Screen_Capture#browser_compatibility)

### Changes
Updates the webrtc code to [Use getDisplayMedia instead of getUserMedia](https://github.com/simplex-chat/simplex-chat/commit/27896f18b7ee28e015f9d33749e1fdfb0acf988a)

As well as [Update the Constraints definitons to include system audio](https://github.com/simplex-chat/simplex-chat/commit/d3ce48afa4a568ce820aa64ecad3431b92c88e77)

### Refrences:
https://stackoverflow.com/questions/19382444/is-it-possible-broadcast-audio-with-screensharing-with-webrtc
https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia

### Testing help request
However I am unsure how to proceed with the proper testing of this feature. Could someone let me know how/test this feature for me?