### PR TITLE
Detect linux details to use the correct build during installation of the CLI

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,43 +18,46 @@ else
 fi
 
 PLATFORM=""
-if [ $PLATFORM_RAW == "Darwin" ]; then
+if [[ $PLATFORM_RAW == "Darwin" ]]; then
   PLATFORM="macos-x86-64"
-elif [ $PLATFORM_RAW == "Linux" ]; then
+elif [[ $PLATFORM_RAW == "Linux" ]]; then
   OS_FAMILY=""
   VERSION=""
   ARCHITECTURE=""
   os_release_file="/etc/os-release"
-  if [ -f "$os_release_file" ]; then
+  if [[ -f "$os_release_file" ]]; then
     os_release_file=$(cat "$os_release_file")
   else
     os_release_file=""
   fi
-  if [ grep "^ID_LIKE=" <<< $os_release_file | grep -q "ubuntu" ]
+  if grep "^ID_LIKE=" <<< $os_release_file | grep -i -q "ubuntu" ; then
     supported_ubuntus=("20_04" "22_04")
-    os_version=$(grep "^VERSION_ID=" <<< $os_release_file | sed 's/^[^=]*=//;s/^"//;s/"$//')
+    os_version=$(grep "^VERSION_ID=" <<< $os_release_file | sed 's/^[^=]*=//;s/^"//;s/"$//;s/[^a-zA-Z0-9]/_/g')
     for v in ${supported_ubuntus[@]}; do
-      if [ $v == $os_version ]; then
+      if [[ $v == $os_version ]]; then
         VERSION=$v
 	OS_FAMILY="ubuntu"
       fi
     done
   fi
-  architecture="$(uname -m)"
+  architecture="$(uname -m | sed s/[^a-zA-Z0-9]/-/g)"
   supported_architectures=("x86-64")
   for a in ${supported_architectures[@]}; do
-    if [ $a == $architecture ]; then
+    if [[ $a == $architecture ]]; then
       ARCHITECTURE=$a
     fi
   done
 
-  if [ -n $OS_FAMILY && -n $VERSION && -n $ARCHITECTURE ]; do
+  if [[ -n $OS_FAMILY && -n $VERSION && -n $ARCHITECTURE ]]; then
     PLATFORM="${OS_FAMILY}-${VERSION}-${ARCHITECTURE}"
   fi
 fi
-if [ -z $PLATFORM ]; do
+if [[ -z $PLATFORM ]]; then
   echo "Scripted installation on your platform is not supported."
   echo "See compiled binaries in the ${1:-latest} release: https://github.com/$APP_NAME/$APP_NAME/releases/$RELEASE"
+  for var in "APP_NAME" "RELEASE" "PLATFORM_RAW" "PLATFORM" "OS_FAMILY" "os_version" "VERSION" "architecture" "ARCHITECTURE"; do
+    #echo "$var = ${!var}"
+  done
   exit 1
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ set -eu
 APP_NAME="simplex-chat"
 BIN_DIR="$HOME/.local/bin"
 BIN_PATH="$BIN_DIR/$APP_NAME"
-PLATFORM="$(uname)"
+PLATFORM_RAW="$(uname)"
 
 if [ -n "${1:-}" ]; then
   RELEASE="tag/$1"
@@ -17,11 +17,42 @@ else
   echo "downloading the latest version of SimpleX Chat ..."
 fi
 
-if [ $PLATFORM == "Darwin" ]; then
+PLATFORM=""
+if [ $PLATFORM_RAW == "Darwin" ]; then
   PLATFORM="macos-x86-64"
-elif [ $PLATFORM == "Linux" ]; then
-  PLATFORM="ubuntu-20_04-x86-64"
-else
+elif [ $PLATFORM_RAW == "Linux" ]; then
+  OS_FAMILY=""
+  VERSION=""
+  ARCHITECTURE=""
+  os_release_file="/etc/os-release"
+  if [ -f "$os_release_file" ]; then
+    os_release_file=$(cat "$os_release_file")
+  else
+    os_release_file=""
+  fi
+  if [ grep "^ID_LIKE=" <<< $os_release_file | grep -q "ubuntu" ]
+    supported_ubuntus=("20_04" "22_04")
+    os_version=$(grep "^VERSION_ID=" <<< $os_release_file | sed 's/^[^=]*=//;s/^"//;s/"$//')
+    for v in ${supported_ubuntus[@]}; do
+      if [ $v == $os_version ]; then
+        VERSION=$v
+	OS_FAMILY="ubuntu"
+      fi
+    done
+  fi
+  architecture="$(uname -m)"
+  supported_architectures=("x86-64")
+  for a in ${supported_architectures[@]}; do
+    if [ $a == $architecture ]; then
+      ARCHITECTURE=$a
+    fi
+  done
+
+  if [ -n $OS_FAMILY && -n $VERSION && -n $ARCHITECTURE ]; do
+    PLATFORM="${OS_FAMILY}-${VERSION}-${ARCHITECTURE}"
+  fi
+fi
+if [ -z $PLATFORM ]; do
   echo "Scripted installation on your platform is not supported."
   echo "See compiled binaries in the ${1:-latest} release: https://github.com/$APP_NAME/$APP_NAME/releases/$RELEASE"
   exit 1


### PR DESCRIPTION
This is sibling to, and a little more involved than,  #5070. 

Also likely addresses, mitigates, or otherwise affects #4922 and #1274.