### PR TITLE
fix(install.sh): broken linux link

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ fi
 if [ $PLATFORM == "Darwin" ]; then
   PLATFORM="macos-x86-64"
 elif [ $PLATFORM == "Linux" ]; then
-  PLATFORM="ubuntu-20_04-x86-64"
+  PLATFORM="ubuntu-24_04-x86-64"
 else
   echo "Scripted installation on your platform is not supported."
   echo "See compiled binaries in the ${1:-latest} release: https://github.com/$APP_NAME/$APP_NAME/releases/$RELEASE"

--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ fi
 if [ $PLATFORM == "Darwin" ]; then
   PLATFORM="macos-x86-64"
 elif [ $PLATFORM == "Linux" ]; then
-  PLATFORM="ubuntu-24_04-x86-64"
+  PLATFORM="ubuntu-22_04-x86-64"
 else
   echo "Scripted installation on your platform is not supported."
   echo "See compiled binaries in the ${1:-latest} release: https://github.com/$APP_NAME/$APP_NAME/releases/$RELEASE"


### PR DESCRIPTION
The Linux install got 404 cause the `platform` should be simplex-chat-ubuntu-`22_04-x86-64` or simplex-chat-ubuntu-`24_04-x86-64` and not `20_04-x86-64`.

## Reproduce
in linux 
```shell
➜  simplex-chat git:(stable) uname
Linux

➜  simplex-chat git:(stable) bash install.sh 
downloading the latest version of SimpleX Chat ...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100     9  100     9    0     0      7      0  0:00:01  0:00:01 --:--:--     0
simplex-chat installed successfully!
Type simplex-chat in your terminal to run it

➜  simplex-chat git:(stable) which simplex-chat
/home/7sunarni/.local/bin/simplex-chat

➜  simplex-chat git:(stable) cat /home/7sunarni/.local/bin/simplex-chat
Not Found%     
```