### PR TITLE
feat: Add Push notifications to Android (UnifiedPush/Play services)

### DIFF
--- a/apps/multiplatform/android/build.gradle.kts
+++ b/apps/multiplatform/android/build.gradle.kts
@@ -144,6 +144,11 @@ dependencies {
     //Camera Permission
     implementation("com.google.accompanist:accompanist-permissions:0.34.0")
 
+    // Push notifications
+    implementation("org.unifiedpush.android:connector:3.0.10")
+    // Allow using Play Services if available
+    implementation("org.unifiedpush.android:embedded-fcm-distributor:3.0.0")
+
     //implementation("androidx.compose.material:material-icons-extended:$compose_version")
     //implementation("androidx.compose.ui:ui-util:$compose_version")
 

--- a/apps/multiplatform/android/src/main/AndroidManifest.xml
+++ b/apps/multiplatform/android/src/main/AndroidManifest.xml
@@ -185,6 +185,13 @@
         android:foregroundServiceType="mediaPlayback|microphone|camera|remoteMessaging"
     />
 
+    <service android:name=".PushService"
+      android:exported="false">
+      <intent-filter>
+        <action android:name="org.unifiedpush.android.connector.PUSH_EVENT"/>
+      </intent-filter>
+    </service>
+
     <receiver
         android:name=".CallService$CallActionReceiver"
         android:enabled="true"

--- a/apps/multiplatform/android/src/main/java/chat/simplex/app/MessagesFetcherWorker.kt
+++ b/apps/multiplatform/android/src/main/java/chat/simplex/app/MessagesFetcherWorker.kt
@@ -15,15 +15,30 @@ import java.util.concurrent.TimeUnit
 object MessagesFetcherWorker {
   private const val UNIQUE_WORK_TAG = BuildConfig.APPLICATION_ID + ".UNIQUE_MESSAGES_FETCHER"
 
-  fun scheduleWork(intervalSec: Int = 600, durationSec: Int = 60) {
-    val initialDelaySec = intervalSec.toLong()
-    Log.d(TAG, "Worker: scheduling work to run at ${Date(System.currentTimeMillis() + initialDelaySec * 1000)} for $durationSec sec")
+  /**
+   * Schedule [MessagesFetcherWork]
+   *
+   * @param initialDelayMs Delay in milliseconds before starting the jobs, usually = [intervalMs]
+   * @param intervalMs Interval in milliseconds between the end of a jobs and the start of a new one.
+   *     If set to `0`, the job isn't restarted
+   * @param timeoutMs Timeout in milliseconds until we stop a job, if there are still new messages, a new job is started directly
+   * @param durationMs Duration in milliseconds to wait for new messages
+   */
+  fun scheduleWork(
+    initialDelayMs: Int = MessagesFetcherWork.DEFAULT_INTERVAL_MS,
+    intervalMs: Int = MessagesFetcherWork.DEFAULT_INTERVAL_MS,
+    timeoutMs: Int = MessagesFetcherWork.DEFAULT_TIMEOUT_MS,
+    durationMs: Int = MessagesFetcherWork.DEFAULT_DURATION_MS
+  ) {
+    Int.MAX_VALUE
+    Log.d(TAG, "Worker: scheduling work to run at ${Date(System.currentTimeMillis() + initialDelayMs)} for $timeoutMs ms max")
     val periodicWorkRequest = OneTimeWorkRequest.Builder(MessagesFetcherWork::class.java)
-      .setInitialDelay(initialDelaySec, TimeUnit.SECONDS)
+      .setInitialDelay(initialDelayMs.toLong(), TimeUnit.MILLISECONDS)
       .setInputData(
         Data.Builder()
-          .putInt(MessagesFetcherWork.INPUT_DATA_INTERVAL, intervalSec)
-          .putInt(MessagesFetcherWork.INPUT_DATA_DURATION, durationSec)
+          .putInt(MessagesFetcherWork.INPUT_DATA_INTERVAL, intervalMs)
+          .putInt(MessagesFetcherWork.INPUT_DATA_TIMEOUT, timeoutMs)
+          .putInt(MessagesFetcherWork.INPUT_DATA_DURATION, durationMs)
           .build()
       )
       .setConstraints(Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build())
@@ -45,25 +60,49 @@ class MessagesFetcherWork(
   workerParams: WorkerParameters
 ): CoroutineWorker(context, workerParams) {
   companion object {
+    /**
+     * Interval, in milliseconds, between the end of a job and the start of a new one
+     */
     const val INPUT_DATA_INTERVAL = "interval"
+
+    /**
+     * Timeout, in milliseconds, until we force stop the jobs, if there are new messages, a new job is started directly
+     */
+    const val INPUT_DATA_TIMEOUT = "timeout"
+
+    /**
+     * Minimum duration, in milliseconds, to wait for new messages
+     */
     const val INPUT_DATA_DURATION = "duration"
-    private const val WAIT_AFTER_LAST_MESSAGE: Long = 10_000
+    const val DEFAULT_DURATION_MS = 10_000
+    const val DEFAULT_TIMEOUT_MS = 60_000
+    const val DEFAULT_INTERVAL_MS = 600_000
   }
 
   override suspend fun doWork(): Result {
     // Skip when Simplex service is currently working
+    val durationMs = inputData.getInt(INPUT_DATA_DURATION, DEFAULT_DURATION_MS)
+    val timeoutMs = inputData.getInt(INPUT_DATA_TIMEOUT, DEFAULT_TIMEOUT_MS)
+    val intervalMs = inputData.getInt(INPUT_DATA_INTERVAL, DEFAULT_INTERVAL_MS)
+    // initialDelayMs may be = 0
+    // in this case, reschedule won't start a worker.
+    var initialDelayMs = intervalMs
     if (SimplexService.getServiceState(SimplexApp.context) == SimplexService.ServiceState.STARTED) {
-      reschedule()
+      reschedule(
+        initialDelayMs = initialDelayMs,
+        intervalMs = intervalMs,
+        timeoutMs = timeoutMs,
+        durationMs = durationMs
+      )
       return Result.success()
     }
-    val durationSeconds = inputData.getInt(INPUT_DATA_DURATION, 60)
     var shouldReschedule = true
     try {
       // In case of self-destruct is enabled the initialization process will not start in SimplexApp, Let's start it here
       if (DatabaseUtils.ksSelfDestructPassword.get() != null && chatModel.chatDbStatus.value == null) {
         initChatControllerOnStart()
       }
-      withTimeout(durationSeconds * 1000L) {
+      withTimeout(timeoutMs.toLong()) {
         val chatController = ChatController
         SimplexService.waitDbMigrationEnds(chatController)
         val chatDbStatus = chatController.chatModel.chatDbStatus.value
@@ -75,26 +114,48 @@ class MessagesFetcherWork(
         }
         Log.w(TAG, "Worker: starting work")
         // Give some time to start receiving messages
-        delay(10_000)
+        delay(durationMs + 200L)
         while (!isStopped) {
-          if (chatController.lastMsgReceivedTimestamp + WAIT_AFTER_LAST_MESSAGE < System.currentTimeMillis()) {
+          val lastMsgMs = System.currentTimeMillis() - chatController.lastMsgReceivedTimestamp
+          if (lastMsgMs > durationMs) {
             Log.d(TAG, "Worker: work is done")
             break
           }
-          delay(5000)
+          delay(durationMs - lastMsgMs + 200L)
         }
       }
     } catch (_: TimeoutCancellationException) { // When timeout happens
-      Log.d(TAG, "Worker: work is done (took $durationSeconds sec)")
+      Log.d(TAG, "Worker: Still work to do, restarting a new work (took $durationMs sec)")
+      // We reschedule a new work now (in 200 ms)
+      shouldReschedule = true
+      initialDelayMs = 200
     } catch (_: CancellationException) { // When user opens the app while the worker is still working
       Log.d(TAG, "Worker: interrupted")
     } catch (e: Exception) {
       Log.d(TAG, "Worker: unexpected exception: ${e.stackTraceToString()}")
     }
 
-    if (shouldReschedule) reschedule()
+    if (shouldReschedule) {
+      reschedule(
+        initialDelayMs = initialDelayMs,
+        intervalMs = intervalMs,
+        timeoutMs = timeoutMs,
+        durationMs = durationMs
+      )
+    }
     return Result.success()
   }
 
-  private fun reschedule() = MessagesFetcherWorker.scheduleWork()
+  /**
+   * Reschedule a work if [initialDelayMs] > 0
+   */
+  private fun reschedule(
+    initialDelayMs: Int,
+    intervalMs: Int,
+    timeoutMs: Int,
+    durationMs: Int
+  ) = {
+    if (initialDelayMs > 0)
+      MessagesFetcherWorker.scheduleWork(initialDelayMs, intervalMs, timeoutMs, durationMs)
+  }
 }

--- a/apps/multiplatform/android/src/main/java/chat/simplex/app/PushService.kt
+++ b/apps/multiplatform/android/src/main/java/chat/simplex/app/PushService.kt
@@ -1,0 +1,82 @@
+package chat.simplex.app
+
+import chat.simplex.common.model.CC
+import chat.simplex.common.platform.Log
+import chat.simplex.common.platform.chatModel
+import kotlinx.coroutines.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.unifiedpush.android.connector.FailedReason
+import org.unifiedpush.android.connector.PushService
+import org.unifiedpush.android.connector.data.PushEndpoint
+import org.unifiedpush.android.connector.data.PushMessage
+
+class PushService: PushService() {
+  private val json = Json {
+    ignoreUnknownKeys = true
+  }
+
+  @Serializable
+  data class PNMessage(
+    val verification: String? = null
+  )
+
+  private fun onVerification(code: String) {
+    CoroutineScope(Dispatchers.Default).launch {
+      chatModel.controller.sendCmd(
+        null,
+        CC.APIVerifySavedNtf(code),
+        log = true
+      )
+    }
+  }
+
+  override fun onMessage(message: PushMessage, instance: String) {
+    Log.d(TAG, "onMessage")
+    val pn: PNMessage = json.decodeFromString(String(message.content))
+    when {
+      pn.verification != null -> onVerification(pn.verification)
+    }
+    // TODO: Start same job than the periodic service ?
+    // Receiving the push notif is enough to wake the app and fetch msgs
+    // But it may not be enough when the phone is in doze, or with some
+    // vendors
+  }
+
+  override fun onNewEndpoint(endpoint: PushEndpoint, instance: String) {
+    Log.d(TAG, "onNewEndpoint")
+    endpoint.pubKeySet ?: run {
+      // Should not happen
+      Log.w(TAG, "Missing pubKeySet")
+      return
+    }
+    CoroutineScope(Dispatchers.Default).launch {
+      chatModel.controller.sendCmd(
+        null,
+        CC.APIRegisterWebPush(endpoint.url, endpoint.pubKeySet!!.auth, endpoint.pubKeySet!!.pubKey),
+        log = true
+      )
+    }
+  }
+
+  override fun onRegistrationFailed(reason: FailedReason, instance: String) {
+    Log.d(TAG, "onRegistrationFailed: $reason")
+    // TODO: notification to inform about failed registration
+  }
+
+  override fun onUnregistered(instance: String) {
+    Log.d(TAG, "onUnregistered")
+    // TODO: notification to inform about unregistration
+    CoroutineScope(Dispatchers.Default).launch {
+      chatModel.controller.sendCmd(
+        null,
+        CC.APIDeleteSavedNtf(),
+        log = true
+      )
+    }
+  }
+
+  companion object {
+    private const val TAG = "PushService"
+  }
+}

--- a/apps/multiplatform/android/src/main/java/chat/simplex/app/PushService.kt
+++ b/apps/multiplatform/android/src/main/java/chat/simplex/app/PushService.kt
@@ -37,10 +37,7 @@ class PushService: PushService() {
     when {
       pn.verification != null -> onVerification(pn.verification)
     }
-    // TODO: Start same job than the periodic service ?
-    // Receiving the push notif is enough to wake the app and fetch msgs
-    // But it may not be enough when the phone is in doze, or with some
-    // vendors
+    MessagesFetcherWorker.scheduleWork(200, 0)
   }
 
   override fun onNewEndpoint(endpoint: PushEndpoint, instance: String) {

--- a/apps/multiplatform/android/src/main/java/chat/simplex/app/PushService.kt
+++ b/apps/multiplatform/android/src/main/java/chat/simplex/app/PushService.kt
@@ -3,6 +3,9 @@ package chat.simplex.app
 import chat.simplex.common.model.CC
 import chat.simplex.common.platform.Log
 import chat.simplex.common.platform.chatModel
+import chat.simplex.common.platform.ntfManager
+import chat.simplex.common.views.helpers.generalGetString
+import chat.simplex.res.MR
 import kotlinx.coroutines.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -58,12 +61,22 @@ class PushService: PushService() {
 
   override fun onRegistrationFailed(reason: FailedReason, instance: String) {
     Log.d(TAG, "onRegistrationFailed: $reason")
-    // TODO: notification to inform about failed registration
+    val title = generalGetString(MR.strings.icon_descr_instant_notifications)
+    val text = when (reason) {
+      FailedReason.NETWORK -> generalGetString(MR.strings.unifiedpush_registration_failed_network)
+      FailedReason.VAPID_REQUIRED, // Should not happen, VAPID will be required
+      FailedReason.INTERNAL_ERROR -> generalGetString(MR.strings.unifiedpush_registration_failed_unknown)
+      FailedReason.ACTION_REQUIRED -> generalGetString(MR.strings.unifiedpush_registration_failed_action)
+
+    }
+    ntfManager.showMessage(title, text)
   }
 
   override fun onUnregistered(instance: String) {
     Log.d(TAG, "onUnregistered")
-    // TODO: notification to inform about unregistration
+    val title = generalGetString(MR.strings.icon_descr_instant_notifications)
+    val text = generalGetString(MR.strings.unifiedpush_unregistered)
+    ntfManager.showMessage(title, text)
     CoroutineScope(Dispatchers.Default).launch {
       chatModel.controller.sendCmd(
         null,

--- a/apps/multiplatform/android/src/main/java/chat/simplex/app/SimplexApp.kt
+++ b/apps/multiplatform/android/src/main/java/chat/simplex/app/SimplexApp.kt
@@ -20,6 +20,7 @@ import androidx.work.*
 import chat.simplex.app.MainActivity.Companion.OLD_ANDROID_UI_FLAGS
 import chat.simplex.app.model.NtfManager
 import chat.simplex.app.model.NtfManager.AcceptCallAction
+import chat.simplex.app.platform.PushManager
 import chat.simplex.app.views.call.CallActivity
 import chat.simplex.common.helpers.*
 import chat.simplex.common.model.*
@@ -269,6 +270,7 @@ class SimplexApp: Application(), LifecycleEventObserver {
         // Prevents from showing "Enable notifications" alert when onboarding wasn't complete yet
         if (chatModel.controller.appPrefs.onboardingStage.get() == OnboardingStage.OnboardingComplete) {
           SimplexService.showBackgroundServiceNoticeIfNeeded()
+          PushManager.initStart(context)
           if (appPrefs.notificationsMode.get() == NotificationsMode.SERVICE)
             withBGApi {
               platform.androidServiceStart()

--- a/apps/multiplatform/android/src/main/java/chat/simplex/app/SimplexApp.kt
+++ b/apps/multiplatform/android/src/main/java/chat/simplex/app/SimplexApp.kt
@@ -270,11 +270,15 @@ class SimplexApp: Application(), LifecycleEventObserver {
         // Prevents from showing "Enable notifications" alert when onboarding wasn't complete yet
         if (chatModel.controller.appPrefs.onboardingStage.get() == OnboardingStage.OnboardingComplete) {
           SimplexService.showBackgroundServiceNoticeIfNeeded()
-          PushManager.initStart(context)
-          if (appPrefs.notificationsMode.get() == NotificationsMode.SERVICE)
-            withBGApi {
+          when (appPrefs.notificationsMode.get()) {
+            NotificationsMode.SERVICE -> withBGApi {
               platform.androidServiceStart()
             }
+            NotificationsMode.INSTANT -> withBGApi {
+              PushManager.initStart(context)
+            }
+            else -> {}
+          }
         }
       }
 

--- a/apps/multiplatform/android/src/main/java/chat/simplex/app/SimplexApp.kt
+++ b/apps/multiplatform/android/src/main/java/chat/simplex/app/SimplexApp.kt
@@ -236,6 +236,16 @@ class SimplexApp: Application(), LifecycleEventObserver {
         if (mode != NotificationsMode.PERIODIC) {
           MessagesFetcherWorker.cancelAll()
         }
+        if (mode == NotificationsMode.INSTANT) {
+          CoroutineScope(Dispatchers.Default).launch {
+            SimplexService.initUnifiedPush(this) {
+              // Change notifications mode only if everything is correctly setup
+              chatModel.controller.appPrefs.notificationsMode.set(mode)
+            }
+          }
+        } else {
+          chatModel.controller.appPrefs.notificationsMode.set(mode)
+        }
         SimplexService.showBackgroundServiceNoticeIfNeeded(showOffAlert = false)
       }
 
@@ -245,6 +255,7 @@ class SimplexApp: Application(), LifecycleEventObserver {
           NotificationsMode.SERVICE -> CoroutineScope(Dispatchers.Default).launch { platform.androidServiceStart() }
           NotificationsMode.PERIODIC -> SimplexApp.context.schedulePeriodicWakeUp()
           NotificationsMode.OFF -> {}
+          NotificationsMode.INSTANT -> {}
         }
       }
 
@@ -369,6 +380,7 @@ class SimplexApp: Application(), LifecycleEventObserver {
       override fun androidCreateActiveCallState(): Closeable = ActiveCallState()
 
       override val androidApiLevel: Int get() = Build.VERSION.SDK_INT
+      override val supportsPushNotifications = true
     }
   }
 

--- a/apps/multiplatform/android/src/main/java/chat/simplex/app/SimplexService.kt
+++ b/apps/multiplatform/android/src/main/java/chat/simplex/app/SimplexService.kt
@@ -22,6 +22,7 @@ import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
 import androidx.work.*
 import chat.simplex.app.model.NtfManager
+import chat.simplex.app.platform.PushManager
 import chat.simplex.common.AppLock
 import chat.simplex.common.helpers.requiresIgnoringBattery
 import chat.simplex.common.model.ChatController
@@ -418,6 +419,10 @@ class SimplexService: Service() {
     }
 
     private fun getPreferences(context: Context): SharedPreferences = context.getSharedPreferences(SHARED_PREFS_ID, Context.MODE_PRIVATE)
+
+    suspend fun initUnifiedPush(scope: CoroutineScope, onSuccess: () -> Unit) {
+      PushManager.initUnifiedPush(androidAppContext, scope, onSuccess)
+    }
 
     fun showBackgroundServiceNoticeIfNeeded(showOffAlert: Boolean = true) {
       val appPrefs = ChatController.appPrefs

--- a/apps/multiplatform/android/src/main/java/chat/simplex/app/model/NtfManager.android.kt
+++ b/apps/multiplatform/android/src/main/java/chat/simplex/app/model/NtfManager.android.kt
@@ -231,6 +231,9 @@ object NtfManager {
     val builder = NotificationCompat.Builder(context, MessageChannel)
       .setContentTitle(title)
       .setContentText(text)
+      .setStyle(
+        NotificationCompat.BigTextStyle().bigText(text)
+      )
       .setPriority(NotificationCompat.PRIORITY_HIGH)
       .setGroup(MessageGroup)
       .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)

--- a/apps/multiplatform/android/src/main/java/chat/simplex/app/platform/PushManager.kt
+++ b/apps/multiplatform/android/src/main/java/chat/simplex/app/platform/PushManager.kt
@@ -1,0 +1,267 @@
+package chat.simplex.app.platform
+
+import SectionItemView
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.*
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import chat.simplex.common.model.*
+import chat.simplex.common.model.ChatController.getUserServers
+import chat.simplex.common.platform.Log
+import chat.simplex.common.views.helpers.*
+import chat.simplex.common.views.usersettings.networkAndServers.showAddServerDialog
+import chat.simplex.res.MR
+import dev.icerock.moko.resources.compose.painterResource
+import dev.icerock.moko.resources.compose.stringResource
+import kotlinx.coroutines.*
+import org.unifiedpush.android.connector.UnifiedPush
+
+/**
+ * Object with functions to interact with push services
+ */
+object PushManager {
+  private const val TAG = "PushManager"
+
+  /**
+   * Check if a NTF server is setup and ask user's push distributor
+   *
+   * Show an alert if NTF server isn't define,
+   * If a single distrib is available, use it
+   * If many, ask distributor to use with a dialog
+   * Else alert about missing service
+   */
+  suspend fun initUnifiedPush(context: Context, scope: CoroutineScope, onSuccess: () -> Unit) {
+    val userServers = getUserServers(null) ?: listOf()
+    if (!userServers.hasNtfServer()) {
+      Log.d(TAG, "User doesn't have any NTF server")
+      showMissingNTFDialog(scope, userServers)
+      // After coming back from the server view, users will have to click on "Instant" again
+      return
+    }
+    val distributors = UnifiedPush.getDistributors(context)
+    when (distributors.size) {
+      0 -> {
+        Log.d(TAG, "No distributor found")
+        showMissingPushServiceDialog()
+      }
+      1 -> {
+        Log.d(TAG, "Found only one distributor installed")
+        UnifiedPush.saveDistributor(context, distributors.first())
+        register(context)
+        onSuccess()
+      }
+      else -> {
+        Log.d(TAG, "Found many distributors installed")
+        showSelectPushServiceIntroDialog {
+          showSelectPushServiceDialog(context, distributors) {
+            UnifiedPush.saveDistributor(context, it)
+            register(context)
+            onSuccess
+          }
+        }
+      }
+    }
+  }
+
+  private fun register(context: Context) {
+    // TODO: add VAPID
+    UnifiedPush.register(context)
+  }
+
+  /**
+   * Check if any NTF server is recorded
+   */
+  private fun List<UserOperatorServers>.hasNtfServer(): Boolean {
+    // TODO: check if ntf server has a VAPID key
+    return this.any { it.ntfServers.any() }
+  }
+
+  /**
+   * Show a dialog to inform about missing NTF server
+   */
+  private fun showMissingNTFDialog(scope: CoroutineScope, userServers: List<UserOperatorServers>) = AlertManager.shared.showAlert {
+    AlertDialog(
+      onDismissRequest = AlertManager.shared::hideAlert,
+      title = {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+          Icon(
+            painterResource(MR.images.ic_warning),
+            contentDescription = null, // The icon doesn't add any meaning and must not be transcripted with screen readers
+          )
+          Text(
+            stringResource(MR.strings.icon_descr_instant_notifications),
+            fontWeight = FontWeight.Bold
+          )
+        }
+      },
+      text = {
+        Text(stringResource(MR.strings.warning_push_needs_ntf_server))
+      },
+      // Go to user's servers settings
+      confirmButton = {
+        TextButton(onClick = {
+          AlertManager.shared.hideAlert()
+          showAddServerDialog(scope, userServers)
+        }) { Text(stringResource(MR.strings.smp_servers_add)) }
+      },
+      // Ignore
+      dismissButton = {
+        TextButton(onClick = AlertManager.shared::hideAlert) { Text(stringResource(android.R.string.cancel)) }
+      },
+      shape = RoundedCornerShape(corner = CornerSize(25.dp))
+    )
+  }
+
+  /**
+   * Dialog to add a server, manually or with a QR code
+   */
+  private fun showAddServerDialog(scope: CoroutineScope, userServers: List<UserOperatorServers>) {
+    val userServersState = mutableStateOf(userServers)
+    val serverErrors = mutableStateOf(listOf<UserServersError>())
+    showAddServerDialog(scope, userServersState, serverErrors, null)
+  }
+
+  /**
+   * Show a dialog to inform about missing push service
+   */
+  private fun showMissingPushServiceDialog() = AlertManager.shared.showAlert {
+    AlertDialog(
+      onDismissRequest = AlertManager.shared::hideAlert,
+      title = {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+          Icon(
+            painterResource(MR.images.ic_warning),
+            contentDescription = null, // The icon doesn't add any meaning and must not be transcripted with screen readers
+          )
+          Text(
+            stringResource(MR.strings.icon_descr_instant_notifications),
+            fontWeight = FontWeight.Bold
+          )
+        }
+      },
+      text = {
+        Text(
+          buildAnnotatedString {
+            append(stringResource(MR.strings.warning_push_needs_push_service))
+            withLink(LinkAnnotation.Url(url = "https://unifiedpush.org")) {
+              withStyle(style = SpanStyle(color = MaterialTheme.colors.primary)) {
+                append("https://unifiedpush.org")
+              }
+            }
+          }
+        )
+      },
+      confirmButton = {
+        TextButton(onClick = AlertManager.shared::hideAlert) { Text(stringResource(android.R.string.ok)) }
+      },
+      shape = RoundedCornerShape(corner = CornerSize(25.dp))
+    )
+  }
+
+  /**
+   * Show an intro to explain why they need to select a push service
+   */
+  private fun showSelectPushServiceIntroDialog(onConfirm: () -> Unit) = AlertManager.shared.showAlert {
+    AlertDialog(
+      onDismissRequest = AlertManager.shared::hideAlert,
+      title = {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+          Icon(
+            painterResource(MR.images.ic_notifications),
+            contentDescription = null, // The icon doesn't add any meaning and must not be transcripted with screen readers
+          )
+          Text(
+            stringResource(MR.strings.icon_descr_instant_notifications),
+            fontWeight = FontWeight.Bold
+          )
+        }
+      },
+      text = {
+        Text(stringResource(MR.strings.select_push_service_intro))
+      },
+      confirmButton = {
+        TextButton(
+          onClick = {
+          AlertManager.shared.hideAlert()
+          onConfirm()
+          }
+        ) { Text(stringResource(MR.strings.select_push_service)) }
+      },
+      dismissButton = {
+        TextButton(onClick = AlertManager.shared::hideAlert) { Text(stringResource(android.R.string.cancel)) }
+      },
+      shape = RoundedCornerShape(corner = CornerSize(25.dp))
+    )
+  }
+
+
+  /**
+   * Show a dialog to select push service
+   *
+   * @param distributors List of installed distributors' packageName
+   * @param onSelected run when a distributor is selected, its param is the selected distrib packageName
+   */
+  private fun showSelectPushServiceDialog(context: Context, distributors: List<String>, onSelected: (String) -> Unit) = AlertManager.shared.showAlert {
+    AlertDialog(
+      onDismissRequest = AlertManager.shared::hideAlert,
+      title = {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+          Icon(
+            painterResource(MR.images.ic_notifications),
+            contentDescription = null, // The icon doesn't add any meaning and must not be transcripted with screen readers
+          )
+          Text(
+            stringResource(MR.strings.select_push_service),
+            fontWeight = FontWeight.Bold
+          )
+        }
+      },
+      text = {
+        Column {
+          distributors.map {
+            if (it == context.packageName) it to "Play Services"
+            else it to context.getApplicationName(it)
+          }.forEach {
+            SectionItemView({
+              AlertManager.shared.hideAlert()
+              onSelected(it.first)
+            }) {
+              Text(it.second)
+            }
+          }
+        }
+      },
+      confirmButton = {
+        TextButton(onClick = AlertManager.shared::hideAlert) { Text(stringResource(android.R.string.cancel)) }
+      },
+      shape = RoundedCornerShape(corner = CornerSize(25.dp))
+    )
+  }
+
+  private fun Context.getApplicationName(applicationId: String): String {
+    return try {
+      val ai = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        packageManager.getApplicationInfo(
+          applicationId,
+          PackageManager.ApplicationInfoFlags.of(
+            PackageManager.GET_META_DATA.toLong()
+          )
+        )
+      } else {
+        packageManager.getApplicationInfo(applicationId, 0)
+      }
+      packageManager.getApplicationLabel(ai)
+    } catch (e: PackageManager.NameNotFoundException) {
+      applicationId
+    } as String
+  }
+
+}

--- a/apps/multiplatform/android/src/main/java/chat/simplex/app/platform/PushManager.kt
+++ b/apps/multiplatform/android/src/main/java/chat/simplex/app/platform/PushManager.kt
@@ -73,6 +73,20 @@ object PushManager {
     }
   }
 
+  /**
+   * Register to UnifiedPush distributor if any is already used
+   *
+   * To run when the app starts; call [chat.simplex.app.PushService.onUnregistered]
+   * if the distributor is uninstalled
+   */
+  fun initStart(context: Context) {
+    Log.d(TAG, "Init UnifiedPush during app startup")
+    //TODO: limit to once a day to reduce registrations to ntf server ?
+    UnifiedPush.getAckDistributor(context)?.let {
+      register(context)
+    }
+  }
+
   private fun register(context: Context) {
     // TODO: add VAPID
     UnifiedPush.register(context)

--- a/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/helpers/Extensions.kt
+++ b/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/helpers/Extensions.kt
@@ -9,7 +9,7 @@ val NotificationsMode.requiresIgnoringBatterySinceSdk: Int get() = when(this) {
   NotificationsMode.OFF -> Int.MAX_VALUE
   NotificationsMode.PERIODIC -> Build.VERSION_CODES.M
   NotificationsMode.SERVICE -> Build.VERSION_CODES.S
-  /*INSTANT -> Int.MAX_VALUE - for Firebase notifications */
+  NotificationsMode.INSTANT -> Int.MAX_VALUE
 }
 
 val NotificationsMode.requiresIgnoringBattery

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
@@ -3464,6 +3464,9 @@ sealed class CC {
   class ResetAgentServersStats(): CC()
   class GetAgentSubsTotal(val userId: Long): CC()
   class GetAgentServersSummary(val userId: Long): CC()
+  class APIRegisterWebPush(val endpoint: String, val auth: String, val p256dh: String): CC()
+  class APIVerifySavedNtf(val code: String): CC()
+  class APIDeleteSavedNtf(): CC()
 
   val cmdString: String get() = when (this) {
     is Console -> cmd
@@ -3656,6 +3659,9 @@ sealed class CC {
     is ResetAgentServersStats -> "/reset servers stats"
     is GetAgentSubsTotal -> "/get subs total $userId"
     is GetAgentServersSummary -> "/get servers summary $userId"
+    is APIRegisterWebPush -> "/_ntf register webpush $endpoint $auth $p256dh INSTANT"
+    is APIDeleteSavedNtf -> "/_ntf delete saved"
+    is APIVerifySavedNtf -> "/_ntf verify $code"
   }
 
   val cmdType: String get() = when (this) {
@@ -3814,6 +3820,9 @@ sealed class CC {
     is ResetAgentServersStats -> "resetAgentServersStats"
     is GetAgentSubsTotal -> "getAgentSubsTotal"
     is GetAgentServersSummary -> "getAgentServersSummary"
+    is APIRegisterWebPush -> "apiRegisterWebPush"
+    is APIDeleteSavedNtf -> "apiDeleteSavedNtf"
+    is APIVerifySavedNtf -> "apiVerifySavedNtf"
   }
 
   data class ItemRange(val from: Long, val to: Long)
@@ -6952,7 +6961,7 @@ sealed class AgentErrorType {
     is CMD -> "CMD ${cmdErr.string} $errContext"
     is CONN -> "CONN ${connErr.string}"
     is SMP -> "SMP ${smpErr.string}"
-    // is NTF -> "NTF ${ntfErr.string}"
+    is NTF -> "NTF ${ntfErr.string}"
     is XFTP -> "XFTP ${xftpErr.string}"
     is PROXY -> "PROXY $proxyServer $relayServer ${proxyErr.string}"
     is RCP -> "RCP ${rcpErr.string}"
@@ -6965,7 +6974,7 @@ sealed class AgentErrorType {
   @Serializable @SerialName("CMD") class CMD(val cmdErr: CommandErrorType, val errContext: String): AgentErrorType()
   @Serializable @SerialName("CONN") class CONN(val connErr: ConnectionErrorType): AgentErrorType()
   @Serializable @SerialName("SMP") class SMP(val serverAddress: String, val smpErr: SMPErrorType): AgentErrorType()
-  // @Serializable @SerialName("NTF") class NTF(val ntfErr: SMPErrorType): AgentErrorType()
+  @Serializable @SerialName("NTF") class NTF(val ntfErr: SMPErrorType): AgentErrorType()
   @Serializable @SerialName("XFTP") class XFTP(val xftpErr: XFTPErrorType): AgentErrorType()
   @Serializable @SerialName("PROXY") class PROXY(val proxyServer: String, val relayServer: String, val proxyErr: ProxyClientError): AgentErrorType()
   @Serializable @SerialName("RCP") class RCP(val rcpErr: RCErrorType): AgentErrorType()

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
@@ -7323,7 +7323,7 @@ sealed class RemoteCtrlError {
 }
 
 enum class NotificationsMode() {
-  OFF, PERIODIC, SERVICE, /*INSTANT - for Firebase notifications */;
+  OFF, PERIODIC, SERVICE, INSTANT;
 
   companion object {
     val default: NotificationsMode = SERVICE
@@ -7550,6 +7550,7 @@ enum class AppSettingsNotificationMode {
   companion object {
     fun from(mode: NotificationsMode): AppSettingsNotificationMode =
       when (mode) {
+        NotificationsMode.INSTANT -> INSTANT
         NotificationsMode.SERVICE -> INSTANT
         NotificationsMode.PERIODIC -> PERIODIC
         NotificationsMode.OFF -> OFF

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/platform/Platform.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/platform/Platform.kt
@@ -33,6 +33,7 @@ interface PlatformInterface {
   @Composable fun androidLockPortraitOrientation() {}
   suspend fun androidAskToAllowBackgroundCalls(): Boolean = true
   @Composable fun desktopShowAppUpdateNotice() {}
+  val supportsPushNotifications: Boolean get() = false
 }
 /**
  * Multiplatform project has separate directories per platform + common directory that contains directories per platform + common for all of them.

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/NotificationsSettingsView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/NotificationsSettingsView.kt
@@ -136,6 +136,15 @@ private fun notificationModes(): List<ValueTitleDesc<NotificationsMode>> {
       AnnotatedString(generalGetString(MR.strings.notifications_mode_service_desc)),
     )
   )
+  if (platform.supportsPushNotifications) {
+    res.add(
+      ValueTitleDesc(
+        NotificationsMode.INSTANT,
+        generalGetString(MR.strings.notifications_mode_instant),
+        AnnotatedString(generalGetString(MR.strings.notifications_mode_instant_desc))
+      )
+    )
+  }
   return res
 }
 
@@ -167,6 +176,10 @@ fun notificationPreviewModes(): List<ValueTitleDesc<NotificationPreviewMode>> {
 }
 
 fun changeNotificationsMode(mode: NotificationsMode, chatModel: ChatModel) {
-  chatModel.controller.appPrefs.notificationsMode.set(mode)
-  platform.androidNotificationsModeChanged(mode)
+  // the preference is updated in androidNotificationsModeChanged for Android
+  if (appPlatform.isAndroid) {
+    platform.androidNotificationsModeChanged(mode)
+  } else {
+    chatModel.controller.appPrefs.notificationsMode.set(mode)
+  }
 }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/networkAndServers/NetworkAndServers.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/networkAndServers/NetworkAndServers.kt
@@ -932,6 +932,15 @@ fun globalXFTPServersError(serverErrors: List<UserServersError>): String? {
   return null
 }
 
+fun globalNTFServersError(serverErrors: List<UserServersError>): String? {
+  for (err in serverErrors) {
+    if (err.globalNTFError != null) {
+      return err.globalNTFError
+    }
+  }
+  return null
+}
+
 fun findDuplicateHosts(serverErrors: List<UserServersError>): Set<String> {
   val duplicateHostsList = serverErrors.mapNotNull { err ->
     if (err is UserServersError.DuplicateServer) {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/networkAndServers/NewServerView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/networkAndServers/NewServerView.kt
@@ -107,12 +107,15 @@ fun addServer(
       val operatorServers = updatedUserServers[operatorIndex]
       // Create a mutable copy of the smpServers or xftpServers and add the server
       when (serverProtocol) {
+        ServerProtocol.NTF -> {
+          // We use a single ntf server
+          updatedUserServers[operatorIndex] = operatorServers.copy(ntfServers = listOf(server))
+        }
         ServerProtocol.SMP -> {
           val updatedSMPServers = operatorServers.smpServers.toMutableList()
           updatedSMPServers.add(server)
           updatedUserServers[operatorIndex] = operatorServers.copy(smpServers = updatedSMPServers)
         }
-
         ServerProtocol.XFTP -> {
           val updatedXFTPServers = operatorServers.xftpServers.toMutableList()
           updatedXFTPServers.add(server)

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/networkAndServers/OperatorView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/networkAndServers/OperatorView.kt
@@ -387,14 +387,19 @@ fun OperatorViewLayout(
           testing = testing,
           smpServers = userServers.value[operatorIndex].smpServers,
           xftpServers = userServers.value[operatorIndex].xftpServers,
+          ntfServers = userServers.value[operatorIndex].ntfServers,
         ) { p, l ->
           when (p) {
+            ServerProtocol.NTF -> userServers.value = userServers.value.toMutableList().apply {
+              this[operatorIndex] = this[operatorIndex].copy(
+                ntfServers = l
+              )
+            }
             ServerProtocol.XFTP -> userServers.value = userServers.value.toMutableList().apply {
               this[operatorIndex] = this[operatorIndex].copy(
                 xftpServers = l
               )
             }
-
             ServerProtocol.SMP -> userServers.value = userServers.value.toMutableList().apply {
               this[operatorIndex] = this[operatorIndex].copy(
                 smpServers = l

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/networkAndServers/OperatorView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/networkAndServers/OperatorView.kt
@@ -101,27 +101,26 @@ fun navigateToProtocolView(
       userServers = userServers,
       serverErrors = serverErrors,
       onDelete = {
-        if (protocol == ServerProtocol.SMP) {
-          deleteSMPServer(userServers, operatorIndex, serverIndex)
-        } else {
-          deleteXFTPServer(userServers, operatorIndex, serverIndex)
+        when (protocol) {
+          ServerProtocol.NTF -> deleteNTFServer(userServers, operatorIndex, serverIndex)
+          ServerProtocol.SMP -> deleteSMPServer(userServers, operatorIndex, serverIndex)
+          ServerProtocol.XFTP -> deleteXFTPServer(userServers, operatorIndex, serverIndex)
         }
         close()
       },
       onUpdate = { updatedServer ->
         userServers.value = userServers.value.toMutableList().apply {
-          this[operatorIndex] = this[operatorIndex].copy(
-            smpServers = if (protocol == ServerProtocol.SMP) {
-              this[operatorIndex].smpServers.toMutableList().apply {
-                this[serverIndex] = updatedServer
-              }
-            } else this[operatorIndex].smpServers,
-            xftpServers = if (protocol == ServerProtocol.XFTP) {
-              this[operatorIndex].xftpServers.toMutableList().apply {
-                this[serverIndex] = updatedServer
-              }
-            } else this[operatorIndex].xftpServers
-          )
+          if (platform.supportsPushNotifications && protocol == ServerProtocol.NTF && updatedServer.enabled) {
+            // We keep a single ntf server, if the updatedServer is enabled, we disable all other ntf servers first
+            this.replaceAll { op ->
+              op.copy(ntfServers = op.ntfServers.map { server -> server.copy(enabled = false).also { s -> Log.d(TAG, "ntf: $s")} })
+            }
+          }
+          this[operatorIndex] = when (protocol) {
+            ServerProtocol.NTF -> this[operatorIndex].copy(ntfServers = this[operatorIndex].ntfServers.toMutableList().apply { this[serverIndex] = updatedServer })
+            ServerProtocol.SMP -> this[operatorIndex].copy(smpServers = this[operatorIndex].smpServers.toMutableList().apply { this[serverIndex] = updatedServer })
+            ServerProtocol.XFTP -> this[operatorIndex].copy(xftpServers = this[operatorIndex].xftpServers.toMutableList().apply { this[serverIndex] = updatedServer })
+          }
         }
       },
       close = close,

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/networkAndServers/ProtocolServerView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/networkAndServers/ProtocolServerView.kt
@@ -115,7 +115,11 @@ private fun ProtocolServerLayout(
   onDelete: () -> Unit,
 ) {
   ColumnWithScrollBar {
-    AppBarTitle(stringResource(if (serverProtocol == ServerProtocol.XFTP) MR.strings.xftp_server else MR.strings.smp_server))
+    AppBarTitle(stringResource(when (serverProtocol) {
+      ServerProtocol.NTF -> MR.strings.ntf_server
+      ServerProtocol.XFTP -> MR.strings.xftp_server
+      ServerProtocol.SMP -> MR.strings.smp_server
+    }))
 
     if (server.value.preset) {
       PresetServer(server, testing, testServer)

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/networkAndServers/ProtocolServersView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/networkAndServers/ProtocolServersView.kt
@@ -389,6 +389,32 @@ private suspend fun runServersTest(servers: List<UserServer>, m: ChatModel, onUp
   return fs
 }
 
+fun deleteNTFServer(
+  userServers: MutableState<List<UserOperatorServers>>,
+  operatorServersIndex: Int,
+  serverIndex: Int
+) {
+  val serverIsSaved = userServers.value[operatorServersIndex].ntfServers[serverIndex].serverId != null
+
+  if (serverIsSaved) {
+    userServers.value = userServers.value.toMutableList().apply {
+      this[operatorServersIndex] = this[operatorServersIndex].copy(
+        ntfServers = this[operatorServersIndex].ntfServers.toMutableList().apply {
+          this[serverIndex] = this[serverIndex].copy(deleted = true)
+        }
+      )
+    }
+  } else {
+    userServers.value = userServers.value.toMutableList().apply {
+      this[operatorServersIndex] = this[operatorServersIndex].copy(
+        ntfServers = this[operatorServersIndex].ntfServers.toMutableList().apply {
+          this.removeAt(serverIndex)
+        }
+      )
+    }
+  }
+}
+
 fun deleteXFTPServer(
   userServers: MutableState<List<UserOperatorServers>>,
   operatorServersIndex: Int,

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/networkAndServers/ProtocolServersView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/networkAndServers/ProtocolServersView.kt
@@ -148,37 +148,40 @@ fun YourServersViewLayout(
       }
     }
 
-    if (userServers.value[operatorIndex].ntfServers.any { !it.deleted }) {
-      SectionDividerSpaced()
-      SectionView(generalGetString(MR.strings.notif_servers).uppercase()) {
-        userServers.value[operatorIndex].ntfServers.forEachIndexed { i, server ->
-          if (server.deleted) return@forEachIndexed
-          SectionItemView({ navigateToProtocolView(i, server, ServerProtocol.NTF) }) {
-            ProtocolServerViewLink(
-              srv = server,
-              serverProtocol = ServerProtocol.NTF,
-              duplicateHosts = duplicateHosts
-            )
+    if (platform.supportsPushNotifications) {
+      if (userServers.value[operatorIndex].ntfServers.any { !it.deleted }) {
+        SectionDividerSpaced()
+        SectionView(generalGetString(MR.strings.notif_servers).uppercase()) {
+          userServers.value[operatorIndex].ntfServers.forEachIndexed { i, server ->
+            if (server.deleted) return@forEachIndexed
+            SectionItemView({ navigateToProtocolView(i, server, ServerProtocol.NTF) }) {
+              ProtocolServerViewLink(
+                srv = server,
+                serverProtocol = ServerProtocol.NTF,
+                duplicateHosts = duplicateHosts
+              )
+            }
           }
         }
-      }
-      val ntfErr = globalNTFServersError(serverErrors.value)
-      if (ntfErr != null) {
-        SectionCustomFooter {
-          ServersErrorFooter(ntfErr)
+        val ntfErr = globalNTFServersError(serverErrors.value)
+        if (ntfErr != null) {
+          SectionCustomFooter {
+            ServersErrorFooter(ntfErr)
+          }
+        } else {
+          SectionTextFooter(generalGetString(MR.strings.ntf_servers_per_user))
         }
-      } else {
-        SectionTextFooter(generalGetString(MR.strings.ntf_servers_per_user))
       }
     }
 
     if (
-      userServers.value[operatorIndex].ntfServers.any { !it.deleted } ||
+      userServers.value[operatorIndex].ntfServers.any { !it.deleted } && platform.supportsPushNotifications ||
       userServers.value[operatorIndex].smpServers.any { !it.deleted } ||
       userServers.value[operatorIndex].xftpServers.any { !it.deleted }
       ) {
       SectionDividerSpaced(maxTopPadding = false, maxBottomPadding = false)
     }
+
 
     SectionView {
       SettingsActionItem(

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/networkAndServers/ProtocolServersView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/networkAndServers/ProtocolServersView.kt
@@ -148,7 +148,32 @@ fun YourServersViewLayout(
       }
     }
 
+    if (userServers.value[operatorIndex].ntfServers.any { !it.deleted }) {
+      SectionDividerSpaced()
+      SectionView(generalGetString(MR.strings.notif_servers).uppercase()) {
+        userServers.value[operatorIndex].ntfServers.forEachIndexed { i, server ->
+          if (server.deleted) return@forEachIndexed
+          SectionItemView({ navigateToProtocolView(i, server, ServerProtocol.NTF) }) {
+            ProtocolServerViewLink(
+              srv = server,
+              serverProtocol = ServerProtocol.NTF,
+              duplicateHosts = duplicateHosts
+            )
+          }
+        }
+      }
+      val ntfErr = globalNTFServersError(serverErrors.value)
+      if (ntfErr != null) {
+        SectionCustomFooter {
+          ServersErrorFooter(ntfErr)
+        }
+      } else {
+        SectionTextFooter(generalGetString(MR.strings.ntf_servers_per_user))
+      }
+    }
+
     if (
+      userServers.value[operatorIndex].ntfServers.any { !it.deleted } ||
       userServers.value[operatorIndex].smpServers.any { !it.deleted } ||
       userServers.value[operatorIndex].xftpServers.any { !it.deleted }
       ) {
@@ -178,14 +203,19 @@ fun YourServersViewLayout(
         testing = testing,
         smpServers = userServers.value[operatorIndex].smpServers,
         xftpServers = userServers.value[operatorIndex].xftpServers,
+        ntfServers = userServers.value[operatorIndex].ntfServers,
       ) { p, l ->
         when (p) {
+          ServerProtocol.NTF -> userServers.value = userServers.value.toMutableList().apply {
+            this[operatorIndex] = this[operatorIndex].copy(
+              ntfServers = l
+            )
+          }
           ServerProtocol.XFTP -> userServers.value = userServers.value.toMutableList().apply {
             this[operatorIndex] = this[operatorIndex].copy(
               xftpServers = l
             )
           }
-
           ServerProtocol.SMP -> userServers.value = userServers.value.toMutableList().apply {
             this[operatorIndex] = this[operatorIndex].copy(
               smpServers = l
@@ -204,16 +234,17 @@ fun YourServersViewLayout(
 fun TestServersButton(
   smpServers: List<UserServer>,
   xftpServers: List<UserServer>,
+  ntfServers: List<UserServer>,
   testing: MutableState<Boolean>,
   onUpdate: (ServerProtocol, List<UserServer>) -> Unit
 ) {
   val scope = rememberCoroutineScope()
-  val disabled = derivedStateOf { (smpServers.none { it.enabled } && xftpServers.none { it.enabled }) || testing.value }
+  val disabled = derivedStateOf { (smpServers.none { it.enabled } && xftpServers.none { it.enabled } && ntfServers.none { it.enabled }) || testing.value }
 
   SectionItemView(
     {
       scope.launch {
-        testServers(testing, smpServers, xftpServers, chatModel, onUpdate)
+        testServers(testing, smpServers, xftpServers, ntfServers, chatModel, onUpdate)
       }
     },
     disabled = disabled.value
@@ -303,6 +334,7 @@ private suspend fun testServers(
   testing: MutableState<Boolean>,
   smpServers: List<UserServer>,
   xftpServers: List<UserServer>,
+  ntfServers: List<UserServer>,
   m: ChatModel,
   onUpdate: (ServerProtocol, List<UserServer>) -> Unit
 ) {
@@ -310,11 +342,14 @@ private suspend fun testServers(
   onUpdate(ServerProtocol.SMP, smpResetStatus)
   val xftpResetStatus = resetTestStatus(xftpServers)
   onUpdate(ServerProtocol.XFTP, xftpResetStatus)
+  val ntfResetStatus = resetTestStatus(ntfServers)
+  onUpdate(ServerProtocol.NTF, ntfResetStatus)
   testing.value = true
   val smpFailures = runServersTest(smpResetStatus, m) { onUpdate(ServerProtocol.SMP, it) }
   val xftpFailures = runServersTest(xftpResetStatus, m) { onUpdate(ServerProtocol.XFTP, it) }
+  val ntfFailures = runServersTest(ntfResetStatus, m) { onUpdate(ServerProtocol.NTF, it) }
   testing.value = false
-  val fs = smpFailures + xftpFailures
+  val fs = smpFailures + xftpFailures + ntfFailures
   if (fs.isNotEmpty()) {
     val msg = fs.map { it.key + ": " + it.value.localizedDescription }.joinToString("\n")
     AlertManager.shared.showAlertMsg(

--- a/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
@@ -280,6 +280,10 @@
   <string name="warning_push_needs_push_service">You don\'t have any push service installed on your device.\n\nPlease installed one and try again.\n\nFor more information, visit\ </string>
   <string name="select_push_service">Select Push Service</string>
   <string name="select_push_service_intro">Multiple push services are installed on your system, please select the service you wish to use.</string>
+  <string name="unifiedpush_unregistered">SimpleX is no longer registered with your UnifiedPush distributor. The distributor may have been uninstalled or been logged out. You should reset your notifications settings.</string>
+  <string name="unifiedpush_registration_failed_network">Registration with your UnifiedPush distributor failed due to a network issue. Please try again when your network is back.</string>
+  <string name="unifiedpush_registration_failed_action">Registration with your UnifiedPush distributor failed due to a missing requirement from your distributor.</string>
+  <string name="unifiedpush_registration_failed_unknown">Registration with your UnifiedPush distributor failed due to an unknown issue. This could be a missing requirement from your distributor.</string>
 
   <!-- local authentication notice - SimpleXAPI.kt -->
   <string name="la_notice_title_simplex_lock">SimpleX Lock</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
@@ -277,7 +277,9 @@
   <string name="notification_contact_connected">Connected</string>
   <string name="error_showing_desktop_notification">Error showing notification, contact developers.</string>
   <string name="warning_push_needs_ntf_server">You first need to set a NTF server to get push notifications.\n\nIt will send the notifications to your push provider.</string>
+  <string name="warning_push_needs_ntf_server_with_vapid">Your NTF server doesn\'t support VAPID, which is required to get push notifications.</string>
   <string name="warning_push_needs_push_service">You don\'t have any push service installed on your device.\n\nPlease installed one and try again.\n\nFor more information, visit\ </string>
+  <string name="warning_ntf_server_changed">Your NTF server has been removed or has changed and doesn\'t support VAPID, which is required to get push notifications.</string>
   <string name="select_push_service">Select Push Service</string>
   <string name="select_push_service_intro">Multiple push services are installed on your system, please select the service you wish to use.</string>
   <string name="unifiedpush_unregistered">SimpleX is no longer registered with your UnifiedPush distributor. The distributor may have been uninstalled or been logged out. You should reset your notifications settings.</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
@@ -131,6 +131,8 @@
   <string name="no_media_servers_configured">No media &amp; file servers.</string>
   <string name="no_media_servers_configured_for_sending">No servers to send files.</string>
   <string name="no_media_servers_configured_for_private_routing">No servers to receive files.</string>
+  <string name="no_notif_servers_configured">No notification servers.</string>
+  <string name="no_notif_servers_configured_for_receiving">No servers to notify.</string>
   <string name="for_chat_profile">For chat profile %s:</string>
   <string name="errors_in_servers_configuration">Errors in servers configuration.</string>
   <string name="error_accepting_operator_conditions">Error accepting conditions</string>
@@ -898,6 +900,7 @@
   <string name="smp_servers_per_user">The servers for new connections of your current chat profile</string>
   <string name="smp_save_servers_question">Save servers?</string>
   <string name="media_and_file_servers">Media &amp; file servers</string>
+  <string name="notif_servers">Notifications servers</string>
   <string name="xftp_servers">XFTP servers</string>
   <string name="xftp_servers_configured">Configured XFTP servers</string>
   <string name="xftp_servers_other">Other XFTP servers</string>
@@ -1921,6 +1924,7 @@
   <string name="operator_use_for_files">Use for files</string>
   <string name="operator_use_for_sending">To send</string>
   <string name="xftp_servers_per_user">The servers for new files of your current chat profile</string>
+  <string name="ntf_servers_per_user">The servers for your notifications.</string>
   <string name="operator_added_xftp_servers">Added media &amp; file servers</string>
   <string name="operator_open_conditions">Open conditions</string>
   <string name="operator_open_changes">Open changes</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
@@ -2642,6 +2642,7 @@
   <string name="servers_info_starting_from">Starting from %s.</string>
   <string name="smp_server">SMP server</string>
   <string name="xftp_server">XFTP server</string>
+  <string name="ntf_server">NTF server</string>
   <string name="reconnect">Reconnect</string>
   <string name="attempts_label">attempts</string>
   <string name="sent_directly">Sent directly</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
@@ -260,9 +260,11 @@
   <string name="notifications_mode_off">Runs when app is open</string>
   <string name="notifications_mode_periodic">Starts periodically</string>
   <string name="notifications_mode_service">Always on</string>
+  <string name="notifications_mode_instant">Instant</string>
   <string name="notifications_mode_off_desc">App can receive notifications only when it\'s running, no background service will be started</string>
   <string name="notifications_mode_periodic_desc">Checks new messages every 10 minutes for up to 1 minute</string>
   <string name="notifications_mode_service_desc">Background service is always running – notifications will be shown as soon as the messages are available.</string>
+  <string name="notifications_mode_instant_desc">Receive notifications instantly using an external push service.</string>
   <string name="notification_preview_mode_message">Message text</string>
   <string name="notification_preview_mode_contact">Contact name</string>
   <string name="notification_preview_mode_hidden">Hidden</string>
@@ -274,6 +276,10 @@
   <string name="notification_new_contact_request">New contact request</string>
   <string name="notification_contact_connected">Connected</string>
   <string name="error_showing_desktop_notification">Error showing notification, contact developers.</string>
+  <string name="warning_push_needs_ntf_server">You first need to set a NTF server to get push notifications.\n\nIt will send the notifications to your push provider.</string>
+  <string name="warning_push_needs_push_service">You don\'t have any push service installed on your device.\n\nPlease installed one and try again.\n\nFor more information, visit\ </string>
+  <string name="select_push_service">Select Push Service</string>
+  <string name="select_push_service_intro">Multiple push services are installed on your system, please select the service you wish to use.</string>
 
   <!-- local authentication notice - SimpleXAPI.kt -->
   <string name="la_notice_title_simplex_lock">SimpleX Lock</string>

--- a/cabal.project
+++ b/cabal.project
@@ -11,8 +11,13 @@ constraints: zip +disable-bzip2 +disable-zstd
 
 source-repository-package
     type: git
-    location: https://github.com/simplex-chat/simplexmq.git
-    tag: d352d518c2b3a42bc7a298954dde799422e1457f
+    location: https://codeberg.org/s1m/sxmq.git
+    tag: f5720a254104d70b33ac1479ffa9d24ba9988b59
+
+-- source-repository-package
+--     type: git
+--     location: https://github.com/simplex-chat/simplexmq.git
+--     tag: d352d518c2b3a42bc7a298954dde799422e1457f
 
 source-repository-package
     type: git

--- a/cabal.project
+++ b/cabal.project
@@ -12,7 +12,7 @@ constraints: zip +disable-bzip2 +disable-zstd
 source-repository-package
     type: git
     location: https://codeberg.org/s1m/sxmq.git
-    tag: a9ef465c0af3829c58fb5e45627d9673aa5b1ee7
+    tag: f28a2052ae88c59653993ca0e409231b5ed00b11
 
 -- source-repository-package
 --     type: git

--- a/cabal.project
+++ b/cabal.project
@@ -12,7 +12,7 @@ constraints: zip +disable-bzip2 +disable-zstd
 source-repository-package
     type: git
     location: https://codeberg.org/s1m/sxmq.git
-    tag: f5720a254104d70b33ac1479ffa9d24ba9988b59
+    tag: a9ef465c0af3829c58fb5e45627d9673aa5b1ee7
 
 -- source-repository-package
 --     type: git

--- a/scripts/nix/sha256map.nix
+++ b/scripts/nix/sha256map.nix
@@ -1,5 +1,5 @@
 {
-  "https://codeberg.org/s1m/sxmq.git"."a9ef465c0af3829c58fb5e45627d9673aa5b1ee7" = "5921e554cd08372335a415d7c6edcb8d83893f77fffcf5370edaaff7fe47bea6";
+  "https://codeberg.org/s1m/sxmq.git"."f28a2052ae88c59653993ca0e409231b5ed00b11" = "86128d5cdb952e28460b4450042622807e0b683de5598817cac80e85ecee8c3f";
   "https://github.com/simplex-chat/simplexmq.git"."d352d518c2b3a42bc7a298954dde799422e1457f" = "1rha84pfpaqx3mf218szkfra334vhijqf17hanxqmp1sicfbf1x3";
   "https://github.com/simplex-chat/hs-socks.git"."a30cc7a79a08d8108316094f8f2f82a0c5e1ac51" = "0yasvnr7g91k76mjkamvzab2kvlb1g5pspjyjn2fr6v83swjhj38";
   "https://github.com/simplex-chat/direct-sqlcipher.git"."f814ee68b16a9447fbb467ccc8f29bdd3546bfd9" = "1ql13f4kfwkbaq7nygkxgw84213i0zm7c1a8hwvramayxl38dq5d";

--- a/scripts/nix/sha256map.nix
+++ b/scripts/nix/sha256map.nix
@@ -1,4 +1,5 @@
 {
+  "https://codeberg.org/s1m/sxmq.git"."f5720a254104d70b33ac1479ffa9d24ba9988b59" = "cf9a74de0d05afa60a74aa8aa54205c718286b9c16c5f0f398a24d7fa7f7b1ff";
   "https://github.com/simplex-chat/simplexmq.git"."d352d518c2b3a42bc7a298954dde799422e1457f" = "1rha84pfpaqx3mf218szkfra334vhijqf17hanxqmp1sicfbf1x3";
   "https://github.com/simplex-chat/hs-socks.git"."a30cc7a79a08d8108316094f8f2f82a0c5e1ac51" = "0yasvnr7g91k76mjkamvzab2kvlb1g5pspjyjn2fr6v83swjhj38";
   "https://github.com/simplex-chat/direct-sqlcipher.git"."f814ee68b16a9447fbb467ccc8f29bdd3546bfd9" = "1ql13f4kfwkbaq7nygkxgw84213i0zm7c1a8hwvramayxl38dq5d";

--- a/scripts/nix/sha256map.nix
+++ b/scripts/nix/sha256map.nix
@@ -1,5 +1,5 @@
 {
-  "https://codeberg.org/s1m/sxmq.git"."f5720a254104d70b33ac1479ffa9d24ba9988b59" = "cf9a74de0d05afa60a74aa8aa54205c718286b9c16c5f0f398a24d7fa7f7b1ff";
+  "https://codeberg.org/s1m/sxmq.git"."a9ef465c0af3829c58fb5e45627d9673aa5b1ee7" = "5921e554cd08372335a415d7c6edcb8d83893f77fffcf5370edaaff7fe47bea6";
   "https://github.com/simplex-chat/simplexmq.git"."d352d518c2b3a42bc7a298954dde799422e1457f" = "1rha84pfpaqx3mf218szkfra334vhijqf17hanxqmp1sicfbf1x3";
   "https://github.com/simplex-chat/hs-socks.git"."a30cc7a79a08d8108316094f8f2f82a0c5e1ac51" = "0yasvnr7g91k76mjkamvzab2kvlb1g5pspjyjn2fr6v83swjhj38";
   "https://github.com/simplex-chat/direct-sqlcipher.git"."f814ee68b16a9447fbb467ccc8f29bdd3546bfd9" = "1ql13f4kfwkbaq7nygkxgw84213i0zm7c1a8hwvramayxl38dq5d";

--- a/simplex-chat.cabal
+++ b/simplex-chat.cabal
@@ -238,6 +238,7 @@ library
           Simplex.Chat.Store.SQLite.Migrations.M20250402_short_links
           Simplex.Chat.Store.SQLite.Migrations.M20250512_member_admission
           Simplex.Chat.Store.SQLite.Migrations.M20250513_group_scope
+          Simplex.Chat.Store.SQLite.Migrations.M20250815_extras
   other-modules:
       Paths_simplex_chat
   hs-source-dirs:

--- a/src/Simplex/Chat/Controller.hs
+++ b/src/Simplex/Chat/Controller.hs
@@ -353,8 +353,10 @@ data ChatCommand
   | APIGetNtfToken
   | APIRegisterToken DeviceToken NotificationsMode
   | APIVerifyToken DeviceToken C.CbNonce ByteString
+  | APIVerifySavedToken ByteString
   | APICheckToken DeviceToken
   | APIDeleteToken DeviceToken
+  | APIDeleteSavedToken
   | APIGetNtfConns {nonce :: C.CbNonce, encNtfInfo :: ByteString}
   | APIGetConnNtfMessages (NonEmpty ConnMsgReq)
   | APIAddMember GroupId ContactId GroupMemberRole

--- a/src/Simplex/Chat/Controller.hs
+++ b/src/Simplex/Chat/Controller.hs
@@ -350,6 +350,8 @@ data ChatCommand
   | APISetConnectionAlias Int64 LocalAlias
   | APISetUserUIThemes UserId (Maybe UIThemeEntityOverrides)
   | APISetChatUIThemes ChatRef (Maybe UIThemeEntityOverrides)
+  | APIGetNtfServers
+  | APISetNtfServers [NtfServer]
   | APIGetNtfToken
   | APIRegisterToken DeviceToken NotificationsMode
   | APIVerifyToken DeviceToken C.CbNonce ByteString
@@ -717,6 +719,7 @@ data ChatResponse
   | CRNewMemberContact {user :: User, contact :: Contact, groupInfo :: GroupInfo, member :: GroupMember}
   | CRNewMemberContactSentInv {user :: User, contact :: Contact, groupInfo :: GroupInfo, member :: GroupMember}
   | CRCallInvitations {callInvitations :: [RcvCallInvitation]}
+  | CRNtfServers {ntfServers :: [NtfServer]}
   | CRNtfTokenStatus {status :: NtfTknStatus}
   | CRNtfToken {token :: DeviceToken, status :: NtfTknStatus, ntfMode :: NotificationsMode, ntfServer :: NtfServer}
   | CRNtfConns {ntfConns :: [NtfConn]}

--- a/src/Simplex/Chat/Controller.hs
+++ b/src/Simplex/Chat/Controller.hs
@@ -163,7 +163,8 @@ data ChatConfig = ChatConfig
 
 data RandomAgentServers = RandomAgentServers
   { smpServers :: NonEmpty (ServerCfg 'PSMP),
-    xftpServers :: NonEmpty (ServerCfg 'PXFTP)
+    xftpServers :: NonEmpty (ServerCfg 'PXFTP),
+    ntfServers :: NonEmpty (ServerCfg 'PNTF)
   }
   deriving (Show)
 
@@ -185,7 +186,6 @@ defaultChatHooks = ChatHooks Nothing Nothing Nothing
 
 data PresetServers = PresetServers
   { operators :: NonEmpty PresetOperator,
-    ntf :: [NtfServer],
     netCfg :: NetworkConfig
   }
   deriving (Show)
@@ -350,8 +350,6 @@ data ChatCommand
   | APISetConnectionAlias Int64 LocalAlias
   | APISetUserUIThemes UserId (Maybe UIThemeEntityOverrides)
   | APISetChatUIThemes ChatRef (Maybe UIThemeEntityOverrides)
-  | APIGetNtfServers
-  | APISetNtfServers [NtfServer]
   | APIGetNtfToken
   | APIRegisterToken DeviceToken NotificationsMode
   | APIVerifyToken DeviceToken C.CbNonce ByteString
@@ -719,7 +717,6 @@ data ChatResponse
   | CRNewMemberContact {user :: User, contact :: Contact, groupInfo :: GroupInfo, member :: GroupMember}
   | CRNewMemberContactSentInv {user :: User, contact :: Contact, groupInfo :: GroupInfo, member :: GroupMember}
   | CRCallInvitations {callInvitations :: [RcvCallInvitation]}
-  | CRNtfServers {ntfServers :: [NtfServer]}
   | CRNtfTokenStatus {status :: NtfTknStatus}
   | CRNtfToken {token :: DeviceToken, status :: NtfTknStatus, ntfMode :: NotificationsMode, ntfServer :: NtfServer}
   | CRNtfConns {ntfConns :: [NtfConn]}

--- a/src/Simplex/Chat/Library/Commands.hs
+++ b/src/Simplex/Chat/Library/Commands.hs
@@ -1304,6 +1304,8 @@ processChatCommand' vr = \case
         liftIO $ setGroupUIThemes db user g uiThemes
       ok user
     _ -> throwCmdError "not supported"
+  APIGetNtfServers -> withUser $ \_ -> CRNtfServers <$> lift (withAgent' getNtfServers)
+  APISetNtfServers servers -> withUser $ \_ -> lift (withAgent' (`setNtfServers` servers)) >> ok_
   APIGetNtfToken -> withUser' $ \_ -> crNtfToken <$> withAgent getNtfToken
   APIRegisterToken token mode -> withUser $ \_ ->
     CRNtfTokenStatus <$> withAgent (\a -> registerNtfToken a token mode)
@@ -4098,6 +4100,8 @@ chatCommandP =
       "/_set prefs @" *> (APISetContactPrefs <$> A.decimal <* A.space <*> jsonP),
       "/_set theme user " *> (APISetUserUIThemes <$> A.decimal <*> optional (A.space *> jsonP)),
       "/_set theme " *> (APISetChatUIThemes <$> chatRefP <*> optional (A.space *> jsonP)),
+      "/_ntf servers" $> APIGetNtfServers,
+      "/_ntf servers " *> (APISetNtfServers . map SMP.protoServer <$> protocolServersP),
       "/_ntf get" $> APIGetNtfToken,
       "/_ntf register " *> (APIRegisterToken <$> strP_ <*> strP),
       "/_ntf verify " *> (APIVerifyToken <$> strP <* A.space <*> strP <* A.space <*> strP),

--- a/src/Simplex/Chat/Library/Internal.hs
+++ b/src/Simplex/Chat/Library/Internal.hs
@@ -146,13 +146,14 @@ withFileLock name = withEntityLock name . CLFile
 {-# INLINE withFileLock #-}
 
 useServerCfgs :: forall p. UserProtocol p => SProtocolType p -> RandomAgentServers -> [(Text, ServerOperator)] -> [UserServer p] -> NonEmpty (ServerCfg p)
-useServerCfgs p RandomAgentServers {smpServers, xftpServers} opDomains =
+useServerCfgs p RandomAgentServers {smpServers, xftpServers, ntfServers} opDomains =
   fromMaybe (rndAgentServers p) . L.nonEmpty . agentServerCfgs p opDomains
   where
     rndAgentServers :: SProtocolType p -> NonEmpty (ServerCfg p)
     rndAgentServers = \case
       SPSMP -> smpServers
       SPXFTP -> xftpServers
+      SPNTF -> ntfServers
 
 contactCITimed :: Contact -> CM (Maybe CITimed)
 contactCITimed ct = sndContactCITimed False ct Nothing

--- a/src/Simplex/Chat/Mobile.hs
+++ b/src/Simplex/Chat/Mobile.hs
@@ -208,6 +208,7 @@ mobileChatOpts dbOptions =
           { dbOptions,
             smpServers = [],
             xftpServers = [],
+            ntfServers = [],
             simpleNetCfg = defaultSimpleNetCfg,
             logLevel = CLLImportant,
             logConnections = False,

--- a/src/Simplex/Chat/Operators/Presets.hs
+++ b/src/Simplex/Chat/Operators/Presets.hs
@@ -115,3 +115,6 @@ fluxXFTPServers =
       "xftp://Rh19D5e4Eez37DEE9hAlXDB3gZa1BdFYJTPgJWPO9OI=@xftp5.simplexonflux.com,q7itltdn32hjmgcqwhow4tay5ijetng3ur32bolssw32fvc5jrwvozad.onion",
       "xftp://0AznwoyfX8Od9T_acp1QeeKtxUi676IBIiQjXVwbdyU=@xftp6.simplexonflux.com,upvzf23ou6nrmaf3qgnhd6cn3d74tvivlmz3p7wdfwq6fhthjrjiiqid.onion"
     ]
+
+fluxNTFServers :: [NewUserServer 'PNTF]
+fluxNTFServers = []

--- a/src/Simplex/Chat/Options.hs
+++ b/src/Simplex/Chat/Options.hs
@@ -32,7 +32,7 @@ import Simplex.FileTransfer.Description (mb)
 import Simplex.Messaging.Client (HostMode (..), SMPWebPortServers (..), SocksMode (..), textToHostMode)
 import Simplex.Messaging.Encoding.String
 import Simplex.Messaging.Parsers (parseAll)
-import Simplex.Messaging.Protocol (ProtoServerWithAuth, ProtocolTypeI, SMPServerWithAuth, XFTPServerWithAuth)
+import Simplex.Messaging.Protocol (ProtoServerWithAuth, ProtocolTypeI, SMPServerWithAuth, XFTPServerWithAuth, NtfServerWithAuth)
 import Simplex.Messaging.Transport.Client (SocksProxyWithAuth (..), SocksAuth (..), defaultSocksProxyWithAuth)
 import Simplex.Chat.Options.DB
 
@@ -56,6 +56,7 @@ data CoreChatOpts = CoreChatOpts
   { dbOptions :: ChatDbOpts,
     smpServers :: [SMPServerWithAuth],
     xftpServers :: [XFTPServerWithAuth],
+    ntfServers :: [NtfServerWithAuth],
     simpleNetCfg :: SimpleNetCfg,
     logLevel :: ChatLogLevel,
     logConnections :: Bool,
@@ -104,6 +105,18 @@ coreChatOptsP appDir defaultDbName = do
             ( ("Space-separated list of XFTP server(s) to use (each server can have more than one hostname)." <> "\n")
                 <> ("If you pass multiple servers, surround the entire list in quotes." <> "\n")
                 <> "Examples: xftp1.example.com, \"xftp1.example.com xftp2.example.com xftp3.example.com\""
+            )
+          <> value []
+      )
+  ntfServers <-
+    option
+      parseProtocolServers
+      ( long "ntf-server"
+          <> metavar "SERVER"
+          <> help
+            ( ("Space-separated list of NTF server(s) to use (each server can have more than one hostname)." <> "\n")
+                <> ("If you pass multiple servers, surround the entire list in quotes." <> "\n")
+                <> "Examples: ntf1.example.com, \"ntf1.example.com ntf2.example.com ntf3.example.com\""
             )
           <> value []
       )
@@ -241,6 +254,7 @@ coreChatOptsP appDir defaultDbName = do
       { dbOptions,
         smpServers,
         xftpServers,
+        ntfServers,
         simpleNetCfg =
           SimpleNetCfg
             { socksProxy,

--- a/src/Simplex/Chat/Store/SQLite/Migrations.hs
+++ b/src/Simplex/Chat/Store/SQLite/Migrations.hs
@@ -131,6 +131,7 @@ import Simplex.Chat.Store.SQLite.Migrations.M20250130_indexes
 import Simplex.Chat.Store.SQLite.Migrations.M20250402_short_links
 import Simplex.Chat.Store.SQLite.Migrations.M20250512_member_admission
 import Simplex.Chat.Store.SQLite.Migrations.M20250513_group_scope
+import Simplex.Chat.Store.SQLite.Migrations.M20250815_extras
 import Simplex.Messaging.Agent.Store.Shared (Migration (..))
 
 schemaMigrations :: [(String, Query, Maybe Query)]
@@ -261,7 +262,8 @@ schemaMigrations =
     ("20250130_indexes", m20250130_indexes, Just down_m20250130_indexes),
     ("20250402_short_links", m20250402_short_links, Just down_m20250402_short_links),
     ("20250512_member_admission", m20250512_member_admission, Just down_m20250512_member_admission),
-    ("20250513_group_scope", m20250513_group_scope, Just down_m20250513_group_scope)
+    ("20250513_group_scope", m20250513_group_scope, Just down_m20250513_group_scope),
+    ("20250815_extras", m20250815_extras, Just down_m20250815_extras)
   ]
 
 -- | The list of migrations in ascending order by date

--- a/src/Simplex/Chat/Store/SQLite/Migrations/M20250815_extras.hs
+++ b/src/Simplex/Chat/Store/SQLite/Migrations/M20250815_extras.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Simplex.Chat.Store.SQLite.Migrations.M20250815_extras where
+
+import Database.SQLite.Simple (Query)
+import Database.SQLite.Simple.QQ (sql)
+
+m20250815_extras :: Query
+m20250815_extras =
+  [sql|
+ALTER TABLE protocol_servers ADD COLUMN extras TEXT;
+|]
+
+down_m20250815_extras :: Query
+down_m20250815_extras =
+  [sql|
+ALTER TABLE protocol_servers DROP COLUMN extras;
+|]

--- a/src/Simplex/Chat/Store/SQLite/Migrations/chat_schema.sql
+++ b/src/Simplex/Chat/Store/SQLite/Migrations/chat_schema.sql
@@ -464,6 +464,7 @@ CREATE TABLE IF NOT EXISTS "protocol_servers"(
   host TEXT NOT NULL,
   port TEXT NOT NULL,
   key_hash BLOB NOT NULL,
+  extras TEXT,
   basic_auth TEXT,
   preset INTEGER NOT NULL DEFAULT 0,
   tested INTEGER,

--- a/src/Simplex/Chat/Terminal.hs
+++ b/src/Simplex/Chat/Terminal.hs
@@ -50,10 +50,11 @@ terminalChatConfig =
                         ],
                     useSMP = 3,
                     xftp = map (presetServer True) $ L.toList defaultXFTPServers,
-                    useXFTP = 3
+                    useXFTP = 3,
+                    ntf = map (presetServer True) $ L.toList _defaultNtfServers,
+                    useNTF = 3
                   }
               ],
-            ntf = _defaultNtfServers,
             netCfg =
               defaultNetworkConfig
                 { smpProxyMode = SPMUnknown,

--- a/src/Simplex/Chat/View.hs
+++ b/src/Simplex/Chat/View.hs
@@ -235,6 +235,7 @@ chatResponseToView hu cfg@ChatConfig {logLevel, showReactions, testView} liveIte
   CRNewMemberContactSentInv u _ct g m -> ttyUser u ["sent invitation to connect directly to member " <> ttyGroup' g <> " " <> ttyMember m]
   CRCallInvitations _ -> []
   CRContactConnectionDeleted u PendingContactConnection {pccConnId} -> ttyUser u ["connection :" <> sShow pccConnId <> " deleted"]
+  CRNtfServers ntfServers -> viewNtfServers ntfServers
   CRNtfTokenStatus status -> ["device token status: " <> plain (smpEncode status)]
   CRNtfToken _ status mode srv -> ["device token status: " <> plain (smpEncode status) <> ", notifications mode: " <> plain (strEncode mode) <> ", server: " <> sShow srv]
   CRNtfConns {ntfConns} -> map (\NtfConn {agentConnId, expectedMsg_} -> plain $ show agentConnId <> " " <> show expectedMsg_) ntfConns
@@ -2200,6 +2201,14 @@ viewVersionInfo logLevel CoreVersionInfo {version, simplexmqVersion, simplexmqCo
 
 parens :: (IsString a, Semigroup a) => a -> a
 parens s = " (" <> s <> ")"
+
+viewNtfServers :: [SMP.NtfServer] -> [StyledString]
+viewNtfServers = \case
+  [] -> ["No remote NTF server"]
+  s -> map viewNtfServer s
+  where
+    viewNtfServer s =
+      plain $ SMP.legacyStrEncodeServer s
 
 viewRemoteHosts :: [RemoteHostInfo] -> [StyledString]
 viewRemoteHosts = \case

--- a/src/Simplex/Chat/View.hs
+++ b/src/Simplex/Chat/View.hs
@@ -235,7 +235,6 @@ chatResponseToView hu cfg@ChatConfig {logLevel, showReactions, testView} liveIte
   CRNewMemberContactSentInv u _ct g m -> ttyUser u ["sent invitation to connect directly to member " <> ttyGroup' g <> " " <> ttyMember m]
   CRCallInvitations _ -> []
   CRContactConnectionDeleted u PendingContactConnection {pccConnId} -> ttyUser u ["connection :" <> sShow pccConnId <> " deleted"]
-  CRNtfServers ntfServers -> viewNtfServers ntfServers
   CRNtfTokenStatus status -> ["device token status: " <> plain (smpEncode status)]
   CRNtfToken _ status mode srv -> ["device token status: " <> plain (smpEncode status) <> ", notifications mode: " <> plain (strEncode mode) <> ", server: " <> sShow srv]
   CRNtfConns {ntfConns} -> map (\NtfConn {agentConnId, expectedMsg_} -> plain $ show agentConnId <> " " <> show expectedMsg_) ntfConns
@@ -1390,11 +1389,12 @@ viewUserPrivacy User {userId} User {userId = userId', localDisplayName = n', sho
   ]
 
 viewUserServers :: UserOperatorServers -> [StyledString]
-viewUserServers (UserOperatorServers _ [] []) = []
-viewUserServers UserOperatorServers {operator, smpServers, xftpServers} =
+viewUserServers (UserOperatorServers _ [] [] []) = []
+viewUserServers UserOperatorServers {operator, smpServers, xftpServers, ntfServers} =
   [plain $ maybe "Your servers" shortViewOperator operator]
     <> viewServers SPSMP smpServers
     <> viewServers SPXFTP xftpServers
+    <> viewServers SPNTF ntfServers
   where
     viewServers :: (ProtocolTypeI p, UserProtocol p) => SProtocolType p -> [UserServer p] -> [StyledString]
     viewServers _ [] = []
@@ -2201,14 +2201,6 @@ viewVersionInfo logLevel CoreVersionInfo {version, simplexmqVersion, simplexmqCo
 
 parens :: (IsString a, Semigroup a) => a -> a
 parens s = " (" <> s <> ")"
-
-viewNtfServers :: [SMP.NtfServer] -> [StyledString]
-viewNtfServers = \case
-  [] -> ["No remote NTF server"]
-  s -> map viewNtfServer s
-  where
-    viewNtfServer s =
-      plain $ SMP.legacyStrEncodeServer s
 
 viewRemoteHosts :: [RemoteHostInfo] -> [StyledString]
 viewRemoteHosts = \case


### PR DESCRIPTION
This pull request adds push notifications to Android (Mode=INSTANT). It works with the Play Services or UnifiedPush. (https://github.com/simplex-chat/simplex-chat/issues/1081 which seems to be the most upvoted issue)

The user can use the Play Services or UnifiedPush to get push notifications. When a push message arrives, the MessagesFetcherWorker is started.

CLI commands are added to allow the user to define their own ntf server. And at this moment, the implementation requires the user to self-host the ntf server; this can easily be change, and the db should be updated to add to SimpleX NTF servers their own VAPID key fingerprints (which is requires by the implementation).

I've improved MessagesFetcherWorker in the same time, cf https://github.com/simplex-chat/simplex-chat/commit/4683d47259153c795780e5b5cbfdb213660b1e12 and its message for the details.

Because we start the worker on push message, when and if a new PING NtfMode will be introduced, it will be possible to use it, with a minimal modification here

This PR doesn't include any proprietary library (which is often the case when we support FCM)

**UX**

To activate, the user go to the Settings > Notifications > Notification Service and Select "Instant"
If the user doesn't have any ntf server, a dialog will ask them to add one,
else, either their only push service available will be selected, or a dialog will ask them which one to use

Then, the user will be able to get new notifications for SimpleX even if the app is killed

**Security**

I expect a question about security, at least from some readers (*please use the issue to discuss it instead of the PR*), most of the points are answered here: https://unifiedpush.org/news/20250513_push_security_privacy/

For the current implementation, **if the user self-host their own ntf server** (which doesn't have to be exposed on the Internet) **and their own push service**, as soon as their servers are trusted, **it doesn't add any additional security/privacy risk**: from SimpleX network, there is just a constant connection from their home, like another device would do.

Else, a compromised push service may be used to link a simplex profile with the push service profile (by sending a message on SimpleX, and see who gets a push message). Of course, it requires the user server to be compromised, which may require being able to compromise many push servers. cf. the blog post.

Nevertheless, push notifications allows having an instant messaging experience, without heavily relying on the battery. Even a few % a day may be a no go when using an application for rare occasions (this is an important point to accept installing an application when you only have a few contacts)