### PR TITLE
ci: free up disk space before executing reproducible script

### DIFF
--- a/.github/workflows/reproduce-schedule.yml
+++ b/.github/workflows/reproduce-schedule.yml
@@ -23,10 +23,10 @@ jobs:
           grep -i "tag_name" | \
           awk -F \" '{print "TAG="$4}' >> $GITHUB_ENV
 
-      - name: Free up disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache /opt/microsoft /opt/pipx /usr/local/julia* /usr/lib/jvm /usr/lib/google-cloud-sdk /usr/lib/llvm* /usr/lib/firefox /usr/share/swift /usr/share/miniconda /usr/share/az* /usr/share/gradle* /usr/lib/python* /usr/local/share/powershell /usr/local/share/chromium /usr/local/share/vcpkg
-
+      # Otherwise we run out of disk space with Docker build
+      - name: Free disk space
+        shell: bash
+        run: ./scripts/ci/linux_util_free_space.sh
       - name: Execute reproduce script
         run: |
           ${GITHUB_WORKSPACE}/scripts/simplex-chat-reproduce-builds.sh "$TAG" || :


### PR DESCRIPTION
As you may have noticed, all your reproducible Actions have been failing for the past month: https://github.com/simplex-chat/simplex-chat/actions/workflows/reproduce-schedule.yml

It always fails with the same exception:
```java
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':desktop:packageDeb'.
> External tool execution failed:
  * Command: [/usr/lib/jvm/java-17-amazon-corretto/bin/jpackage, @/project/apps/multiplatform/desktop/build/compose/tmp/packageDeb.args.txt]
  * Working dir: []
  * Exit code: 1
  * Standard output log: /project/apps/multiplatform/desktop/build/compose/logs/packageDeb/jpackage-2025-11-13-03-58-59-out.txt
  * Error log: /project/apps/multiplatform/desktop/build/compose/logs/packageDeb/jpackage-2025-11-13-03-58-59-err.txt
```

This error file contains the following error:
```java
java.nio.file.FileSystemException: /project/apps/multiplatform/desktop/build/compose/tmp/packageDeb/libs/resources/vlc/vlc/plugins/codec/liba52_plugin.so -> /tmp/jdk.jpackage3625266857269235061/images/src/simplex/lib/app/resources/vlc/vlc/plugins/codec/liba52_plugin.so: No space left on device
```

`No space left on device`

Indeed, Github Actions jobs are limited to 14-22GB of free disk space, as you can see in this `df -h` output:
```bash
Filesystem      Size  Used Avail Use% Mounted on

/dev/root        72G   50G   22G  70% /
tmpfs           7.9G   84K  7.9G   1% /dev/shm
tmpfs           3.2G  1.1M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb16      881M   62M  758M   8% /boot
/dev/sdb15      105M  6.2M   99M   6% /boot/efi
/dev/sda1        74G  4.1G   66G   6% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
```

Each job VM actually has 72 GB of total disk space, but only 22 GB free. GitHub Actions VMs come with many pre-installed binaries and resources (Android SDK, Java, .NET, Swift, vcpkg, etc.).

Since we do not need any of these for the reproducible script (we only need `docker`), we can simply remove them.

This cleanup frees up 23 GB of disk space, resulting in 55 GB of free space on the job VM, which is more than enough.