### PR TITLE
bots: add missing ttl argument to apiSendMessages

### DIFF
--- a/apps/ios/SimpleX SE/ShareAPI.swift
+++ b/apps/ios/SimpleX SE/ShareAPI.swift
@@ -48,7 +48,7 @@ func apiSetEncryptLocalFiles(_ enable: Bool) throws {
     throw r.unexpected
 }
 
-func apiGetChats(userId: User.ID) throws -> Array<ChatData> {
+func apiGetChats(userId: User.ID) throws -> Array<SEChatData> {
     let r: APIResult<SEChatResponse> = sendSimpleXCmd(SEChatCommand.apiGetChats(userId: userId))
     if case let .result(.apiChats(user: _, chats: chats)) = r { return chats }
     throw r.unexpected
@@ -170,7 +170,7 @@ enum SEChatResponse: Decodable, ChatAPIResult {
     case activeUser(user: User)
     case chatStarted
     case chatRunning
-    case apiChats(user: UserRef, chats: [ChatData])
+    case apiChats(user: UserRef, chats: [SEChatData])
     case newChatItems(user: UserRef, chatItems: [AChatItem])
     case cmdOk(user_: UserRef?)
     
@@ -199,7 +199,7 @@ enum SEChatResponse: Decodable, ChatAPIResult {
     }
 
     static func fallbackResult(_ type: String, _ json: NSDictionary) -> SEChatResponse? {
-        if type == "apiChats", let r = parseApiChats(json) {
+        if type == "apiChats", let r = seParseApiChats(json) {
             .apiChats(user: r.user, chats: r.chats)
         } else {
             nil
@@ -238,4 +238,36 @@ enum SEChatEvent: Decodable, ChatAPIResult {
         case let .sndFileWarning(u, chatItem, _, err): return withUser(u, "error: \(String(describing: err))\nchatItem: \(String(describing: chatItem))")
         }
     }    
+}
+
+public struct SEChatData: Decodable, Identifiable, Hashable, ChatLike {
+    public var chatInfo: ChatInfo
+
+    public var id: ChatId { get { chatInfo.id } }
+
+    public init(chatInfo: ChatInfo) {
+        self.chatInfo = chatInfo
+    }
+
+    public static func invalidJSON(_ json: Data?) -> SEChatData {
+        SEChatData(chatInfo: .invalidJSON(json: json))
+    }
+}
+
+public func seParseApiChats(_ jResp: NSDictionary) -> (user: UserRef, chats: [SEChatData])? {
+    if let jApiChats = jResp["apiChats"] as? NSDictionary,
+       let user: UserRef = try? decodeObject(jApiChats["user"] as Any),
+       let jChats = jApiChats["chats"] as? NSArray {
+        let chats: [SEChatData] = jChats.map { jChat in
+            if let jChatDict = jChat as? NSDictionary,
+               let jChatInfo = jChatDict["chatInfo"],
+               let chatInfo: ChatInfo = try? decodeObject(jChatInfo) {
+                return SEChatData(chatInfo: chatInfo)
+            }
+            return SEChatData.invalidJSON(serializeJSON(jChat, options: .prettyPrinted))
+        }
+        return (user, chats)
+    } else {
+        return nil
+    }
 }

--- a/apps/ios/SimpleX SE/ShareModel.swift
+++ b/apps/ios/SimpleX SE/ShareModel.swift
@@ -19,11 +19,11 @@ private let MAX_DOWNSAMPLE_SIZE: Int64 = 2000
 
 class ShareModel: ObservableObject {
     @Published var sharedContent: SharedContent?
-    @Published var chats: [ChatData] = []
+    @Published var chats: [SEChatData] = []
     @Published var profileImages: [ChatInfo.ID: UIImage] = [:]
     @Published var search = ""
     @Published var comment = ""
-    @Published var selected: ChatData?
+    @Published var selected: SEChatData?
     @Published var isLoaded = false
     @Published var bottomBar: BottomBar = .loadingSpinner
     @Published var errorAlert: ErrorAlert?
@@ -60,13 +60,13 @@ class ShareModel: ObservableObject {
         }
     }
 
-    func isProhibited(_ chat: ChatData?) -> Bool {
+    func isProhibited(_ chat: SEChatData?) -> Bool {
         if let chat, let sharedContent {
             sharedContent.prohibited(in: chat, hasSimplexLink: hasSimplexLink)
         } else { false }
     }
 
-    var filteredChats: [ChatData] {
+    var filteredChats: [SEChatData] {
         search.isEmpty
         ? filterChatsToForwardTo(chats: chats)
         : filterChatsToForwardTo(chats: chats)
@@ -253,7 +253,7 @@ class ShareModel: ObservableObject {
         }
     }
     
-    private func fetchChats() -> Result<Array<ChatData>, ErrorAlert> {
+    private func fetchChats() -> Result<Array<SEChatData>, ErrorAlert> {
         do {
             guard let user = try apiGetActiveUser() else {
                 return .failure(
@@ -396,7 +396,7 @@ enum SharedContent {
         }
     }
 
-    func prohibited(in chatData: ChatData, hasSimplexLink: Bool) -> Bool {
+    func prohibited(in chatData: SEChatData, hasSimplexLink: Bool) -> Bool {
         chatData.prohibitedByPref(
             hasSimplexLink: hasSimplexLink,
             isMediaOrFileAttachment: cryptoFile != nil,

--- a/apps/ios/SimpleXChat/ChatUtils.swift
+++ b/apps/ios/SimpleXChat/ChatUtils.swift
@@ -9,9 +9,7 @@
 import Foundation
 
 public protocol ChatLike {
-    var chatInfo: ChatInfo { get}
-    var chatItems: [ChatItem] { get }
-    var chatStats: ChatStats { get }
+    var chatInfo: ChatInfo { get }
 }
 
 extension ChatLike {

--- a/packages/simplex-chat-client/typescript/src/client.ts
+++ b/packages/simplex-chat-client/typescript/src/client.ts
@@ -119,9 +119,9 @@ export class ChatClient {
     }
   }
 
-  async apiSendMessages(chatType: T.ChatType, chatId: number, messages: T.ComposedMessage[]): Promise<T.AChatItem[]> {
+  async apiSendMessages(chatType: T.ChatType, chatId: number, messages: T.ComposedMessage[], ttl?: number): Promise<T.AChatItem[]> {
     const r = await this.sendChatCmd(
-      CC.APISendMessages.cmdString({sendRef: {chatType, chatId}, composedMessages: messages, liveMessage: false})
+      CC.APISendMessages.cmdString({sendRef: {chatType, chatId}, composedMessages: messages, ttl, liveMessage: false})
     )
     if (r.type === "newChatItems") return r.chatItems
     throw new ChatCommandError("unexpected response", r)

--- a/tests/ChatTests/Utils.hs
+++ b/tests/ChatTests/Utils.hs
@@ -93,6 +93,9 @@ xit' = if os == "linux" then xit else it
 xit'' :: (HasCallStack, Example a) => String -> a -> SpecWith (Arg a)
 xit'' = ifCI xit Hspec.it
 
+xitMacCI :: HasCallStack => String -> (TestParams -> Expectation) -> SpecWith (Arg (TestParams -> Expectation))
+xitMacCI = ifCI (if os == "darwin" then xit else it) it
+
 xdescribe'' :: HasCallStack => String -> SpecWith a -> SpecWith a
 xdescribe'' = ifCI xdescribe describe
 

--- a/tests/RemoteTests.hs
+++ b/tests/RemoteTests.hs
@@ -33,7 +33,7 @@ remoteTests = describe "Remote" $ do
     it "connects with new pairing (stops mobile)" $ remoteHandshakeTest False
     it "connects with new pairing (stops desktop)" $ remoteHandshakeTest True
     it "connects with stored pairing" remoteHandshakeStoredTest
-    it "connects with multicast discovery" remoteHandshakeDiscoverTest
+    xitMacCI "connects with multicast discovery" remoteHandshakeDiscoverTest
     it "refuses invalid client cert" remoteHandshakeRejectTest
     it "connects with stored server bindings" storedBindingsTest
   it "sends messages" remoteMessageTest


### PR DESCRIPTION
while interface APISendMessages already supports a attribute _ttl_, the ttl argument was missing from apiSendMessages() in client.ts