### PR TITLE
ios: fix new chat sheet closing on new message in iOS 26

### DIFF
--- a/apps/ios/Shared/Views/ChatList/ChatHelp.swift
+++ b/apps/ios/Shared/Views/ChatList/ChatHelp.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct ChatHelp: View {
     @EnvironmentObject var chatModel: ChatModel
+    @State private var showNewChatSheet = false
     let dismissSettingsSheet: DismissAction
 
     var body: some View {
@@ -38,7 +39,7 @@ struct ChatHelp: View {
 
                 HStack(spacing: 8) {
                     Text("Tap button ")
-                    NewChatMenuButton()
+                    NewChatMenuButton(showNewChatSheet: $showNewChatSheet)
                     Text("above, then choose:")
                 }
 

--- a/apps/ios/Shared/Views/ChatList/ChatListView.swift
+++ b/apps/ios/Shared/Views/ChatList/ChatListView.swift
@@ -140,6 +140,7 @@ struct ChatListView: View {
     @StateObject private var connectProgressManager = ConnectProgressManager.shared
     @EnvironmentObject var theme: AppTheme
     @Binding var activeUserPickerSheet: UserPickerSheet?
+    @State private var showNewChatSheet = false
     @State private var searchMode = false
     @FocusState private var searchFocussed
     @State private var searchText = ""
@@ -189,6 +190,10 @@ struct ChatListView: View {
             onDismiss: { chatModel.laRequest = nil },
             content: { UserPickerSheetView(sheet: $0) }
         )
+        .appSheet(isPresented: $showNewChatSheet) {
+            NewChatSheet()
+                .environment(\EnvironmentValues.refresh as! WritableKeyPath<EnvironmentValues, RefreshAction?>, nil)
+        }
         .onChange(of: activeUserPickerSheet) {
             if $0 != nil {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
@@ -331,7 +336,7 @@ struct ChatListView: View {
     
     @ViewBuilder var trailingToolbarItem: some View {
         switch chatModel.chatRunning {
-        case .some(true): NewChatMenuButton()
+        case .some(true): NewChatMenuButton(showNewChatSheet: $showNewChatSheet)
         case .some(false): chatStoppedIcon()
         case .none: EmptyView()
         }

--- a/apps/ios/Shared/Views/NewChat/NewChatMenuButton.swift
+++ b/apps/ios/Shared/Views/NewChat/NewChatMenuButton.swift
@@ -12,7 +12,7 @@ import SimpleXChat
 struct NewChatMenuButton: View {
     // do not use chatModel here because it prevents showing AddGroupMembersView after group creation and QR code after link creation on iOS 16
 //    @EnvironmentObject var chatModel: ChatModel
-    @State private var showNewChatSheet = false
+    @Binding var showNewChatSheet: Bool
     @State private var alert: SomeAlert? = nil
 
     var body: some View {
@@ -24,10 +24,6 @@ struct NewChatMenuButton: View {
                 .resizable()
                 .scaledToFit()
                 .frame(width: 24, height: 24)
-        }
-        .appSheet(isPresented: $showNewChatSheet) {
-            NewChatSheet()
-                .environment(\EnvironmentValues.refresh as! WritableKeyPath<EnvironmentValues, RefreshAction?>, nil)
         }
         .alert(item: $alert) { a in
             return a.alert
@@ -471,5 +467,5 @@ struct DeletedChats: View {
 }
 
 #Preview {
-    NewChatMenuButton()
+    NewChatMenuButton(showNewChatSheet: Binding.constant(false))
 }


### PR DESCRIPTION
It fixes new chat sheet closing subviews with navigation popping up the stack.

This only happened with bottom toolbar location, and attaching NewChatSheet outside of toolbar button prevented this recomposition.