### PR TITLE
feat: Add --chat-server-host option for WebSocket server binding

### DIFF
--- a/apps/simplex-broadcast-bot/src/Broadcast/Options.hs
+++ b/apps/simplex-broadcast-bot/src/Broadcast/Options.hs
@@ -87,6 +87,7 @@ mkChatOpts BroadcastBotOpts {coreOptions, botDisplayName} =
       chatCmdDelay = 3,
       chatCmdLog = CCLNone,
       chatServerPort = Nothing,
+      chatServerHost = Nothing,
       optFilesFolder = Nothing,
       optTempDirectory = Nothing,
       showReactions = False,

--- a/apps/simplex-directory-service/src/Directory/Options.hs
+++ b/apps/simplex-directory-service/src/Directory/Options.hs
@@ -162,6 +162,7 @@ mkChatOpts DirectoryOpts {coreOptions, serviceName} =
       chatCmdDelay = 3,
       chatCmdLog = CCLNone,
       chatServerPort = Nothing,
+      chatServerHost = Nothing,
       optFilesFolder = Nothing,
       optTempDirectory = Nothing,
       showReactions = False,

--- a/src/Simplex/Chat/Mobile.hs
+++ b/src/Simplex/Chat/Mobile.hs
@@ -261,6 +261,7 @@ mobileChatOpts dbOptions =
       chatCmdDelay = 3,
       chatCmdLog = CCLNone,
       chatServerPort = Nothing,
+      chatServerHost = Nothing,
       optFilesFolder = Nothing,
       optTempDirectory = Nothing,
       showReactions = False,

--- a/src/Simplex/Chat/Options.hs
+++ b/src/Simplex/Chat/Options.hs
@@ -43,6 +43,7 @@ data ChatOpts = ChatOpts
     chatCmdDelay :: Int,
     chatCmdLog :: ChatCmdLog,
     chatServerPort :: Maybe String,
+    chatServerHost :: Maybe String,
     optFilesFolder :: Maybe FilePath,
     optTempDirectory :: Maybe FilePath,
     showReactions :: Bool,
@@ -319,6 +320,13 @@ chatOptsP appDir defaultDbName = do
           <> help "Run chat server on specified port"
           <> value Nothing
       )
+  chatServerHost <-
+    optional $
+      strOption
+        ( long "chat-server-host"
+            <> metavar "HOST"
+            <> help "Host to bind chat server to (default: 127.0.0.1, use 0.0.0.0 for all interfaces)"
+        )
   optFilesFolder <-
     optional $
       strOption
@@ -389,6 +397,7 @@ chatOptsP appDir defaultDbName = do
         chatCmdDelay,
         chatCmdLog,
         chatServerPort,
+        chatServerHost,
         optFilesFolder,
         optTempDirectory,
         showReactions,

--- a/tests/ChatClient.hs
+++ b/tests/ChatClient.hs
@@ -110,6 +110,7 @@ testOpts =
       chatCmdDelay = 3,
       chatCmdLog = CCLNone,
       chatServerPort = Nothing,
+      chatServerHost = Nothing,
       optFilesFolder = Nothing,
       optTempDirectory = Nothing,
       showReactions = True,


### PR DESCRIPTION
**Summary**
 - Adds `--chat-server-host HOST` option to specify the bind address for the WebSocket chat server
 - Defaults to `127.0.0.1` for backwards compatibility
  - Use `0.0.0.0` to bind to all interfaces (useful for Docker/container deployments)
  
**Use Case**
  
When running `simplex-chat` in a container, the WebSocket server needs to be accessible from outside localhost. Currently this requires patching the binary.

**Example**

simplex-chat -p 5225 --chat-server-host 0.0.0.0

**Test plan**

 - Verify `--chat-server-host 0.0.0.0` binds to all interfaces
 - Verify default (no flag) still binds to 127.0.0.1
 - Verify existing `-p` flag still works