### PR TITLE
ios: replace LPMetadataProvider with direct HTTP fetch for link previews

### DIFF
--- a/apps/ios/Shared/Views/Chat/ComposeMessage/ComposeLinkView.swift
+++ b/apps/ios/Shared/Views/Chat/ComposeMessage/ComposeLinkView.swift
@@ -7,7 +7,6 @@
 //
 
 import SwiftUI
-import LinkPresentation
 import SimpleXChat
 
 struct ComposeLinkView: View {


### PR DESCRIPTION
LPMetadataProvider silently fails on many URLs, making link previews unreliable on iOS. Replace with direct HTTP fetch and HTML parsing (regex-based extraction of og:tags, title, and favicon), mirroring the approach used on Android with JSoup.