### PR TITLE
desktop: cancel compose context with Escape key (#6612)

### DIFF
--- a/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/platform/PlatformTextField.android.kt
+++ b/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/platform/PlatformTextField.android.kt
@@ -58,6 +58,7 @@ actual fun PlatformTextField(
   showVoiceButton: Boolean,
   onMessageChange: (ComposeMessage) -> Unit,
   onUpArrow: () -> Unit,
+  onEscape: () -> Unit,
   onFilesPasted: (List<URI>) -> Unit,
   focusRequester: FocusRequester?,
   onDone: () -> Unit,

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/platform/PlatformTextField.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/platform/PlatformTextField.kt
@@ -20,6 +20,7 @@ expect fun PlatformTextField(
   showVoiceButton: Boolean,
   onMessageChange: (ComposeMessage) -> Unit,
   onUpArrow: () -> Unit,
+  onEscape: () -> Unit = {},
   onFilesPasted: (List<URI>) -> Unit,
   focusRequester: FocusRequester? = null,
   onDone: () -> Unit,

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ComposeView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ComposeView.kt
@@ -1306,6 +1306,13 @@ fun ComposeView(
         chatModel.removeLiveDummy()
       },
       editPrevMessage = ::editPrevMessage,
+      onEscape = {
+        when (composeState.value.contextItem) {
+          is ComposeContextItem.EditingItem -> clearState()
+          ComposeContextItem.NoContextItem -> {}
+          else -> composeState.value = composeState.value.copy(contextItem = ComposeContextItem.NoContextItem)
+        }
+      },
       onFilesPasted = { composeState.onFilesAttached(it) },
       onMessageChange = ::onMessageChange,
       textStyle = textStyle,

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/SendMsgView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/SendMsgView.kt
@@ -56,6 +56,7 @@ fun SendMsgView(
   updateLiveMessage: (suspend () -> Unit)? = null,
   cancelLiveMessage: (() -> Unit)? = null,
   editPrevMessage: () -> Unit,
+  onEscape: () -> Unit = {},
   onFilesPasted: (List<URI>) -> Unit,
   onMessageChange: (ComposeMessage) -> Unit,
   textStyle: MutableState<TextStyle>,
@@ -84,6 +85,7 @@ fun SendMsgView(
       showVoiceButton,
       onMessageChange,
       editPrevMessage,
+      onEscape,
       onFilesPasted,
       focusRequester
     ) {

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/PlatformTextField.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/PlatformTextField.desktop.kt
@@ -52,6 +52,7 @@ actual fun PlatformTextField(
   showVoiceButton: Boolean,
   onMessageChange: (ComposeMessage) -> Unit,
   onUpArrow: () -> Unit,
+  onEscape: () -> Unit,
   onFilesPasted: (List<URI>) -> Unit,
   focusRequester: FocusRequester?,
   onDone: () -> Unit,
@@ -178,6 +179,11 @@ actual fun PlatformTextField(
               }
             }
           }
+        else if (it.key == Key.Escape && it.type == KeyEventType.KeyDown &&
+            cs.contextItem !is ComposeContextItem.NoContextItem) {
+          onEscape()
+          true
+        }
         else false
       },
     cursorBrush = SolidColor(MaterialTheme.colors.secondary),


### PR DESCRIPTION
## Summary

- Add Escape key handling in the desktop compose text field to cancel the current compose context (editing, quoting, forwarding, reporting)
- When editing: Escape clears compose state entirely (same as clicking the X button)
- When quoting/forwarding/reporting: Escape removes the context but preserves typed text
- When no context is active: Escape is not consumed and propagates normally

Closes #6612

## Test plan

- [ ] Start editing a message, press Escape -edit cancelled, compose area cleared
- [ ] Start replying to a message (quote), press Escape - quote removed, typed text preserved
- [ ] Forward a message, press Escape -forward context removed
- [ ] Report a message, press Escape -report context removed
- [ ] Type in empty compose area (no context), press Escape - nothing happens, event propagates
- [ ] Verify Enter, Shift+Enter, Up arrow, Ctrl+V still work correctly