### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/BUSINESS.md
+++ b/docs/BUSINESS.md
@@ -9,7 +9,7 @@ SimpleX Chat (aka SimpleX) is a decentralized communication network that provide
 
 This document aims to help you make the best use of SimpleX Chat if you choose to engage with its users.
 
-## Communcate with customers via business address
+## Communicate with customers via business address
 
 In the same way you can connect to our "SimpleX Chat team" profile via the app, you can provide the address for your existing and prospective customers:
 - to buy your product and services via chat,
@@ -85,7 +85,7 @@ To install SimpleX Chat CLI in the cloud, follow this:
    simplex-chat
    ```
 
-To deattach from running CLI simply press `Ctrl+B` and then `D`.
+To detach from running CLI simply press `Ctrl+B` and then `D`.
 
 To reattach back to CLI, run: `tmux attach -t simplex-cli`.
 

--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -59,7 +59,7 @@ To create SMP server as a systemd service, you'll need:
 - Your server domain, with A and AAAA records specifying server IPv4 and IPv6 addresses (`smp1.example.com`)
 - A basic Linux knowledge.
 
-*Please note*: while you can run an SMP server without a domain name, in the near future client applications will start using server domain name in the invitation links (instead of `simplex.chat` domain they use now). In case a server does not have domain name and server pages (see below), the clients will be generaing the links with `simplex:` scheme that cannot be opened in the browsers.
+*Please note*: while you can run an SMP server without a domain name, in the near future client applications will start using server domain name in the invitation links (instead of `simplex.chat` domain they use now). In case a server does not have domain name and server pages (see below), the clients will be generating the links with `simplex:` scheme that cannot be opened in the browsers.
 
 1. Install server with [Installation script](https://github.com/simplex-chat/simplexmq#using-installation-script).
 
@@ -114,7 +114,7 @@ To create SMP server as a systemd service, you'll need:
    ```sh
    # Enable log (otherwise, tor doesn't seem to deploy onion address)
    Log notice file /var/log/tor/notices.log
-   # Enable single hop routing (2 options below are dependencies of the third) - It will reduce the latency at the cost of lower anonimity of the server - as SMP-server onion address is used in the clients together with public address, this is ok. If you deploy SMP-server with onion-only address, keep standard configuration.
+   # Enable single hop routing (2 options below are dependencies of the third) - It will reduce the latency at the cost of lower anonymity of the server - as SMP-server onion address is used in the clients together with public address, this is ok. If you deploy SMP-server with onion-only address, keep standard configuration.
    SOCKSPort 0
    HiddenServiceNonAnonymousMode 1
    HiddenServiceSingleHopMode 1
@@ -634,7 +634,7 @@ to initialize your `smp-server` configuration with:
 
 ---
 
-After that, your installation is complete and you should see in your teminal output something like this:
+After that, your installation is complete and you should see in your terminal output something like this:
 
 ```sh
 Certificate request self-signature ok
@@ -742,7 +742,7 @@ websockets: off
 [PROXY]
 # Network configuration for SMP proxy client.
 # `host_mode` can be 'public' (default) or 'onion'.
-# It defines prefferred hostname for destination servers with multiple hostnames.
+# It defines preferred hostname for destination servers with multiple hostnames.
 # host_mode: public
 # required_host_mode: off
 
@@ -757,7 +757,7 @@ websockets: off
 # or 'always' to be used for all destination hosts (can be used if it is an .onion server).
 # socks_mode: onion
 
-# Limit number of threads a client can spawn to process proxy commands in parrallel.
+# Limit number of threads a client can spawn to process proxy commands in parallel.
 # client_concurrency: 32
 
 [INACTIVE_CLIENTS]
@@ -913,9 +913,9 @@ SMP-server can also be deployed to be available via [Tor](https://www.torproject
 
 1. Install tor:
 
-   We're assuming you're using Ubuntu/Debian based distributions. If not, please refer to [offical tor documentation](https://community.torproject.org/onion-services/setup/install/) or your distribution guide.
+   We're assuming you're using Ubuntu/Debian based distributions. If not, please refer to [official tor documentation](https://community.torproject.org/onion-services/setup/install/) or your distribution guide.
 
-   - Configure offical Tor PPA repository:
+   - Configure official Tor PPA repository:
 
      ```sh
      CODENAME="$(lsb_release -c | awk '{print $2}')"
@@ -956,7 +956,7 @@ SMP-server can also be deployed to be available via [Tor](https://www.torproject
      ```sh
      # Enable log (otherwise, tor doesn't seem to deploy onion address)
      Log notice file /var/log/tor/notices.log
-     # Enable single hop routing (2 options below are dependencies of the third) - It will reduce the latency at the cost of lower anonimity of the server - as SMP-server onion address is used in the clients together with public address, this is ok. If you deploy SMP-server with onion-only address, you may want to keep standard configuration instead.
+     # Enable single hop routing (2 options below are dependencies of the third) - It will reduce the latency at the cost of lower anonymity of the server - as SMP-server onion address is used in the clients together with public address, this is ok. If you deploy SMP-server with onion-only address, you may want to keep standard configuration instead.
      SOCKSPort 0
      HiddenServiceNonAnonymousMode 1
      HiddenServiceSingleHopMode 1
@@ -974,7 +974,7 @@ SMP-server can also be deployed to be available via [Tor](https://www.torproject
 
 3. Start tor:
 
-   Enable `systemd` service and start tor. Offical `tor` is a bit flaky on the first start and may not create onion host address, so we're restarting it just in case.
+   Enable `systemd` service and start tor. Official `tor` is a bit flaky on the first start and may not create onion host address, so we're restarting it just in case.
 
    ```sh
    systemctl enable --now tor && systemctl restart tor
@@ -1101,7 +1101,7 @@ _Please note:_ this configuration is supported since `v6.1.0-beta.2`.
    hosting_country: <HOSTING_PROVIDER_LOCATION> 
    ```
 
-2. Install the webserver. For easy deployment we'll describe the installtion process of [Caddy](https://caddyserver.com) webserver on Ubuntu server:
+2. Install the webserver. For easy deployment we'll describe the installation process of [Caddy](https://caddyserver.com) webserver on Ubuntu server:
 
    1. Install the packages:
 
@@ -1127,7 +1127,7 @@ _Please note:_ this configuration is supported since `v6.1.0-beta.2`.
       sudo apt update && sudo apt install caddy
       ```
 
-   [Full Caddy instllation instructions](https://caddyserver.com/docs/install)
+   [Full Caddy installation instructions](https://caddyserver.com/docs/install)
 
 3. Replace Caddy configuration with the following:
 
@@ -1237,7 +1237,7 @@ smp://<fingerprint>[:<password>]@<public_hostname>[,<onion_hostname>]
 
 - **optional** `<password>`
 
-  Your configured password of `smp-server`. You can check your configured pasword in `/etc/opt/simplex/smp-server.ini`, under `[AUTH]` section in `create_password:` field.
+  Your configured password of `smp-server`. You can check your configured password in `/etc/opt/simplex/smp-server.ini`, under `[AUTH]` section in `create_password:` field.
 
 - `<public_hostname>`, **optional** `<onion_hostname>`
 
@@ -1368,9 +1368,9 @@ Here's the full list of commands, their descriptions and who can access them.
 | `stats-rts`      | GHC/Haskell statistics. Can be enabled with `+RTS -T -RTS` option               | -                          |
 | `clients`        | Clients information. Useful for debugging.                                      | yes                        |
 | `sockets`        | General sockets information.                                                    | -                          |
-| `socket-threads` | Thread infomation per socket. Useful for debugging.                             | yes                        |
+| `socket-threads` | Thread information per socket. Useful for debugging.                             | yes                        |
 | `threads`        | Threads information. Useful for debugging.                                      | yes                        |
-| `server-info`    | Aggregated server infomation.                                                   | -                          |
+| `server-info`    | Aggregated server information.                                                   | -                          |
 | `delete`         | Delete known queue. Useful for content moderation.                              | -                          |
 | `save`           | Save queues/messages from memory.                                               | yes                        |
 | `help`           | Help menu.                                                                      | -                          |
@@ -1417,31 +1417,31 @@ fromTime,qCreated,qSecured,qDeleted,msgSent,msgRecv,dayMsgQueues,weekMsgQueues,m
 | 20            | `pRelays_pRequests`          | - requests                 |
 | 21            | `pRelays_pSuccesses`         | - successes                |
 | 22            | `pRelays_pErrorsConnect`     | - connection errors        |
-| 23            | `pRelays_pErrorsCompat`      | - compatability errors     |
+| 23            | `pRelays_pErrorsCompat`      | - compatibility errors     |
 | 24            | `pRelays_pErrorsOther`       | - other errors             |
 | Requested sessions with own relays:                                       |
 | 25            | `pRelaysOwn_pRequests`       | - requests                 |
 | 26            | `pRelaysOwn_pSuccesses`      | - successes                |
 | 27            | `pRelaysOwn_pErrorsConnect`  | - connection errors        |
-| 28            | `pRelaysOwn_pErrorsCompat`   | - compatability errors     |
+| 28            | `pRelaysOwn_pErrorsCompat`   | - compatibility errors     |
 | 29            | `pRelaysOwn_pErrorsOther`    | - other errors             |
 | Message forwards to all relays:                                           |
 | 30            | `pMsgFwds_pRequests`         | - requests                 |
 | 31            | `pMsgFwds_pSuccesses`        | - successes                |
 | 32            | `pMsgFwds_pErrorsConnect`    | - connection errors        |
-| 33            | `pMsgFwds_pErrorsCompat`     | - compatability errors     |
+| 33            | `pMsgFwds_pErrorsCompat`     | - compatibility errors     |
 | 34            | `pMsgFwds_pErrorsOther`      | - other errors             |
 | Message forward to own relays:                                            |
 | 35            | `pMsgFwdsOwn_pRequests`      | - requests                 |
 | 36            | `pMsgFwdsOwn_pSuccesses`     | - successes                |
 | 37            | `pMsgFwdsOwn_pErrorsConnect` | - connection errors        |
-| 38            | `pMsgFwdsOwn_pErrorsCompat`  | - compatability errors     |
+| 38            | `pMsgFwdsOwn_pErrorsCompat`  | - compatibility errors     |
 | 39            | `pMsgFwdsOwn_pErrorsOther`   | - other errors             |
 | Received message forwards:                                                |
 | 40            | `pMsgFwdsRecv`               |                            |
-| Message queue subscribtion errors:                                        |
+| Message queue subscription errors:                                        |
 | 41            | `qSub`                       | All                        |
-| 42            | `qSubAuth`                   | Authentication erorrs      |
+| 42            | `qSubAuth`                   | Authentication errors      |
 | 43            | `qSubDuplicate`              | Duplicate SUB errors       |
 | 44            | `qSubProhibited`             | Prohibited SUB errors      |
 | Message errors:                                                           |
@@ -1526,9 +1526,9 @@ To update your smp-server to latest version, choose your installation method and
         sudo systemctl start smp-server
         ```
 
-   - [Offical installation script](https://github.com/simplex-chat/simplexmq#using-installation-script)
+   - [Official installation script](https://github.com/simplex-chat/simplexmq#using-installation-script)
 
-     1. Execute the followin command:
+     1. Execute the following command:
 
         ```sh
         sudo simplex-servers-update

--- a/docs/XFTP-SERVER.md
+++ b/docs/XFTP-SERVER.md
@@ -72,7 +72,7 @@ Manual installation is the most advanced deployment that provides the most flexi
 
 1. Install binary:
 
-   - Using offical binaries:
+   - Using official binaries:
 
      ```sh
      curl -L https://github.com/simplex-chat/simplexmq/releases/latest/download/xftp-server-ubuntu-20_04-x86-64 -o /usr/local/bin/xftp-server && chmod +x /usr/local/bin/xftp-server
@@ -129,7 +129,7 @@ Manual installation is the most advanced deployment that provides the most flexi
 
    And execute `sudo systemctl daemon-reload`.
 
-### Docker сontainer
+### Docker container
 
 You can deploy smp-server using Docker Compose. This is second recommended option due to its popularity and relatively easy deployment.
 
@@ -197,9 +197,9 @@ xftp-server can also be deployed to serve from [tor](https://www.torproject.org)
 
 1. Install tor:
 
-   We're assuming you're using Ubuntu/Debian based distributions. If not, please refer to [offical tor documentation](https://community.torproject.org/onion-services/setup/install/) or your distribution guide.
+   We're assuming you're using Ubuntu/Debian based distributions. If not, please refer to [official tor documentation](https://community.torproject.org/onion-services/setup/install/) or your distribution guide.
 
-   - Configure offical Tor PPA repository:
+   - Configure official Tor PPA repository:
 
      ```sh
      CODENAME="$(lsb_release -c | awk '{print $2}')"
@@ -238,9 +238,9 @@ xftp-server can also be deployed to serve from [tor](https://www.torproject.org)
      And insert the following lines to the bottom of configuration. Please note lines starting with `#`: this is comments about each individual options.
 
      ```sh
-     # Enable log (otherwise, tor doesn't seemd to deploy onion address)
+     # Enable log (otherwise, tor doesn't seemed to deploy onion address)
      Log notice file /var/log/tor/notices.log
-     # Enable single hop routing (2 options below are dependencies of third). Will reduce latency in exchange of anonimity (since tor runs alongside xftp-server and onion address will be displayed in clients, this is totally fine)
+     # Enable single hop routing (2 options below are dependencies of third). Will reduce latency in exchange of anonymity (since tor runs alongside xftp-server and onion address will be displayed in clients, this is totally fine)
      SOCKSPort 0
      HiddenServiceNonAnonymousMode 1
      HiddenServiceSingleHopMode 1
@@ -257,7 +257,7 @@ xftp-server can also be deployed to serve from [tor](https://www.torproject.org)
 
 3. Start tor:
 
-   Enable `systemd` service and start tor. Offical `tor` is a bit flunky on the first start and may not create onion host address, so we're restarting it just in case.
+   Enable `systemd` service and start tor. Official `tor` is a bit flunky on the first start and may not create onion host address, so we're restarting it just in case.
 
    ```sh
    systemctl enable tor && systemctl start tor && systemctl restart tor
@@ -356,7 +356,7 @@ To password-protect your `xftp-server`, change it in the configuration:
       ```
 ---
 
-After that, your installation is complete and you should see in your teminal output something like this:
+After that, your installation is complete and you should see in your terminal output something like this:
 
 ```sh
 Certificate request self-signature ok
@@ -398,7 +398,7 @@ xftp://<fingerprint>[:<password>]@<public_hostname>[,<onion_hostname>]
 
 - **optional** `<password>`
 
-  Your configured password of `xftp-server`. You can check your configured pasword in `/etc/opt/simplex-xftp/file-server.ini`, under `[AUTH]` section in `create_password:` field.
+  Your configured password of `xftp-server`. You can check your configured password in `/etc/opt/simplex-xftp/file-server.ini`, under `[AUTH]` section in `create_password:` field.
 
 - `<public_hostname>`, **optional** `<onion_hostname>`
 
@@ -609,8 +609,8 @@ To update your XFTP server to latest version, choose your installation method an
         sudo systemctl start xftp-server
         ```
 
-   - [Offical installation script](https://github.com/simplex-chat/simplexmq#using-installation-script)
-     1. Execute the followin command:
+   - [Official installation script](https://github.com/simplex-chat/simplexmq#using-installation-script)
+     1. Execute the following command:
         ```sh
         sudo simplex-servers-update
         ```


### PR DESCRIPTION
Found via `codespell -S lang,rfcs,dependencies,*.pdf -L bu`