### PR TITLE
scripts: pin ubuntu manifest digest hash for reproducibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,7 @@ jobs:
             arch: x86_64
             runner: "ubuntu-22.04"
             ghc: "8.10.7"
+            hash: 'sha256:5c8b2c0a6c745bc177669abfaa716b4bc57d58e2ea3882fb5da67f4d59e3dda5'
             should_run: ${{ !(github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v')) }}
           - os: 22.04
             os_underscore: 22_04
@@ -118,24 +119,28 @@ jobs:
             runner: "ubuntu-22.04"
             should_run: true
             ghc: ${{ needs.variables.outputs.GHC_VER }}
+            hash: 'sha256:5c8b2c0a6c745bc177669abfaa716b4bc57d58e2ea3882fb5da67f4d59e3dda5'
           - os: 24.04
             os_underscore: 24_04
             arch: x86_64
             runner: "ubuntu-24.04"
             should_run: true
             ghc: ${{ needs.variables.outputs.GHC_VER }}
+            hash: 'sha256:98ff7968124952e719a8a69bb3cccdd217f5fe758108ac4f21ad22e1df44d237'
           - os: 22.04
             os_underscore: 22_04
             arch: aarch64
             runner: "ubuntu-22.04-arm"
             should_run: true
             ghc: ${{ needs.variables.outputs.GHC_VER }}
+            hash: 'sha256:6a62a4157b8775eaf4959cb629e757d32d39d1f4c8ac1b0ddc2510b555cf72f3'
           - os: 24.04
             os_underscore: 24_04
             arch: aarch64
             runner: "ubuntu-24.04-arm"
             should_run: true
             ghc: ${{ needs.variables.outputs.GHC_VER }}
+            hash: 'sha256:68434214381cb38287104e629fe8ee720167dd98cbb36ab1cbbab342515fa6ab'
     steps:
       - name: Checkout Code
         if: matrix.should_run == true
@@ -182,6 +187,7 @@ jobs:
           tags: build/${{ matrix.os }}:latest
           build-args: |
             TAG=${{ matrix.os }}
+            HASH=${{ matrix.hash }}
             GHC=${{ matrix.ghc }}
             USER_UID=${{ steps.ids.outputs.uid }}
             USER_GID=${{ steps.ids.outputs.gid }}

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.7.0-labs
 ARG TAG=24.04
-FROM ubuntu:${TAG} AS build
+ARG HASH=sha256:98ff7968124952e719a8a69bb3cccdd217f5fe758108ac4f21ad22e1df44d237
+FROM ubuntu:${TAG}@${HASH} AS build
 
 ### Build stage
 

--- a/scripts/simplex-chat-reproduce-builds.sh
+++ b/scripts/simplex-chat-reproduce-builds.sh
@@ -38,7 +38,11 @@ git -C "${tempdir}" clone "${repo}.git" &&\
     cd "${tempdir}/${repo_name}" &&\
     git checkout "${TAG}"
 
-for os in '22.04' '24.04'; do
+oses="22.04@sha256:5c8b2c0a6c745bc177669abfaa716b4bc57d58e2ea3882fb5da67f4d59e3dda5 24.04@sha256:98ff7968124952e719a8a69bb3cccdd217f5fe758108ac4f21ad22e1df44d237"
+
+for os_pair in ${oses}; do
+    os="${os_pair%@*}"
+    hash="${os_pair#*@}"
     os_url="$(printf '%s' "${os}" | tr '.' '_')"
 
     cli_name="simplex-chat-ubuntu-${os_url}-x86_64"
@@ -49,6 +53,7 @@ for os in '22.04' '24.04'; do
     docker build \
         --no-cache \
         --build-arg TAG="${os}" \
+        --build-arg HASH="${hash}" \
         --build-arg GHC="${ghc}" \
         --build-arg=USER_UID="$(id -u)" \
         --build-arg=USER_GID="$(id -g)" \


### PR DESCRIPTION
Hi 👋

Simplex Chat for Desktop was reproducible for v6.4.10; I tested it when it was released. However, my GitHub Action recently triggered a new check for v6.4.10, and it now appears that it is no longer reproducible.

I examined the differences between the binaries using diffoscope and observed the following:

```diff
│  String dump of section '.comment':
│ +  [     0]  GCC: (Ubuntu 11.4.0-1ubuntu1~22.04.2) 11.4.0
│ -  [     0]  GCC: (Ubuntu 11.4.0-1ubuntu1~22.04.3) 11.4.0
...
│ │ │ │ +GCC: (Ubuntu 11.4.0-1ubuntu1~22.04.2) 11.4.0
│ │ │ │ -GCC: (Ubuntu 11.4.0-1ubuntu1~22.04.3) 11.4.0
```

You are using "FROM ubuntu:TAG" with TAG=22.04, for example. However, Ubuntu released a new image under the same tag (22.04.3).

## Proposed in this MR

Pin the Ubuntu base image by specifying the manifest digest instead of relying on the mutable tag. This ensures that even if Ubuntu updates the 22.04 tag, your Dockerfile.build will still use the exact same image manifest.

You can check the corresponding `manifest digest` hashes here : 

- 22.04: https://hub.docker.com/layers/library/ubuntu/22.04/
- 24.04: https://hub.docker.com/layers/library/ubuntu/24.04/