### PR TITLE
core: fix divide by zero when terminal reports zero width

### DIFF
--- a/src/Simplex/Chat/Terminal/Output.hs
+++ b/src/Simplex/Chat/Terminal/Output.hs
@@ -101,7 +101,7 @@ withChatTerm ChatTerminal {termDevice = TerminalDevice t} action = withTerm t $ 
 
 newChatTerminal :: WithTerminal t => t -> ChatOpts -> IO ChatTerminal
 newChatTerminal t opts = do
-  termSize <- withTerm t . runTerminalT $ getWindowSize
+  termSize <- safeSize <$> (withTerm t . runTerminalT $ getWindowSize)
   let lastRow = height termSize - 1
   termState <- newTVarIO mkTermState
   liveMessageState <- newTVarIO Nothing
@@ -123,6 +123,9 @@ newChatTerminal t opts = do
         activeTo,
         currentRemoteUsers
       }
+
+safeSize :: Size -> Size
+safeSize Size {height = h, width = w} = Size {height = max 1 h, width = max 1 w}
 
 mkTermState :: TerminalState
 mkTermState =


### PR DESCRIPTION
## Summary

- Clamp terminal dimensions to a minimum of 1 in `newChatTerminal` to prevent divide by zero in environments that report zero-sized terminals (e.g. emacs eshell)
- Fixes all three division sites in `Output.hs` (`inputHeight`, `positionRowColumn`, `lineCount`) and the broken arrow key arithmetic in `Input.hs`

Fixes #5548

## Test plan

- [ ] Run CLI inside emacs eshell — should no longer crash with "divide by zero"
- [ ] Run CLI in a normal terminal — no change in behavior