### PR TITLE
adding github alt mirros to docs

### DIFF
--- a/docs/DOWNLOADS.md
+++ b/docs/DOWNLOADS.md
@@ -9,9 +9,7 @@ revision: 09.09.2024
 
 You can get the latest beta releases from [GitHub](https://github.com/simplex-chat/simplex-chat/releases).
 
-In case you cannot access GitHub, you can also download SimpleX from the following mirrors:
-
-1. [git.simplex.chat](https://git.simplex.chat/simplex-chat/simplex-chat/releases)
+If you cannot access GitHub, you can download SimpleX Chat apps from our mirror at [git.simplex.chat](https://git.simplex.chat/simplex-chat/simplex-chat/releases)
 
 - [desktop](#desktop-app)
 - [mobile](#mobile-apps)


### PR DESCRIPTION
This commit updates the documentations downloads page

 * https://simplex.chat/downloads/

I added a list of mirrors, which currently just includes the simplex self-hosted forgejo site (git.simplex.chat).

This is necessary, since GitHub has been throwing up authwalls on read-only pages, including the "releases" section -- preventing some users (especially high-risk users using hardened browsers, VPNs, and Tor) from being able to download SimpleX from GitHub.

For more info, see:

 * https://github.com/simplex-chat/simplex-chat/issues/6671
 * https://gh.bloat.cat/simplex-chat/simplex-chat/issues/6671

Closes simplex-chat/simplex-chat#6671