### PR TITLE
android: fix inconsistent short emoji detection

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/EmojiItemView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/EmojiItemView.kt
@@ -45,5 +45,5 @@ private val emojiRegex = Regex(emojiStr)
 
 fun isShortEmoji(str: String): Boolean {
   val s = str.trim()
-  return s.codePoints().count() in 1..5 && emojiRegex.matches(str)
+  return s.codePoints().count() in 1..5 && emojiRegex.matches(s)
 }


### PR DESCRIPTION
## summary
`isShortEmoji()` currently trims the input for the codepoint count, but applies the emoji regex to the untrimmed value. This makes whitespace handling inconsistent and unclear.

## change
Use the trimmed value consistently for both checks.

## context
This behavior appears to have been introduced when the previous `allMatch(::isEmoji)` check was replaced with `emojiRegex.matches(...)`, while keeping the trimmed value for the length check.