### PR TITLE
directory: show knocking status in listings, trigger re-review on knocking change

### DIFF
--- a/apps/simplex-directory-service/src/Directory/Service.hs
+++ b/apps/simplex-directory-service/src/Directory/Service.hs
@@ -326,10 +326,10 @@ directoryServiceEvent st opts@DirectoryOpts {adminUsers, superUsers, serviceName
           notifyAdminUsers msg
           logError msg
     groupInfoText p@GroupProfile {description = d} = groupNameDescr p <> maybe "" ("\nWelcome message:\n" <>) d
-    knockingStr :: Maybe GroupMemberAdmission -> Text
+    knockingStr :: Maybe GroupMemberAdmission -> [Text]
     knockingStr = \case
-      Just GroupMemberAdmission {review = Just MCAll} -> "\nMember admission: enabled"
-      _ -> ""
+      Just GroupMemberAdmission {review = Just MCAll} -> ["New members are reviewed by admins"]
+      _ -> []
     groupNameDescr GroupProfile {displayName = n, fullName = fn, shortDescr = sd_} =
       n <> maybe "" (\d' -> " (" <> d' <> ")") descr
       where
@@ -1003,7 +1003,7 @@ directoryServiceEvent st opts@DirectoryOpts {adminUsers, superUsers, serviceName
             foundGroup (GroupInfo {groupId, groupProfile = p@GroupProfile {image = image_, memberAdmission}, groupSummary = GroupSummary {currentMembers}}, _) =
               let membersStr = "_" <> tshow currentMembers <> " members_"
                   showId = if isAdmin then tshow groupId <> ". " else ""
-                  text = showId <> groupInfoText p <> "\n" <> membersStr <> knockingStr memberAdmission
+                  text = T.unlines $ [showId <> groupInfoText p, membersStr] ++ knockingStr memberAdmission
                in (Nothing, maybe (MCText text) (\image -> MCImage {text, image}) image_)
             moreMsg = (Nothing, MCText $ "Send /next for " <> tshow moreGroups <> " more result(s).")
 
@@ -1192,8 +1192,7 @@ directoryServiceEvent st opts@DirectoryOpts {adminUsers, superUsers, serviceName
               membersStr = "_" <> tshow (currentMembers groupSummary) <> " members_"
               cmds = "/'role " <> tshow useGroupId <> "', /'filter " <> tshow useGroupId <> "'"
               ownerStr = maybe "" (("Owner: " <>) . either (("getContact error: " <>) . T.pack) localDisplayName') ct_
-              knockStr = ["Member admission: enabled" | Just GroupMemberAdmission {review = Just MCAll} <- [memberAdmission]]
-              text = T.unlines $ [tshow useGroupId <> ". " <> groupInfoText p] ++ [ownerStr | isAdmin] ++ [membersStr, statusStr] ++ knockStr ++ [cmds]
+              text = T.unlines $ [tshow useGroupId <> ". " <> groupInfoText p] ++ [ownerStr | isAdmin] ++ [membersStr, statusStr] ++ knockingStr memberAdmission ++ [cmds]
               msg = maybe (MCText text) (\image -> MCImage {text, image}) image_
            in (Nothing, msg)
 

--- a/website/src/js/directory.js
+++ b/website/src/js/directory.js
@@ -248,7 +248,7 @@ function displayEntries(entries) {
 
       if (entryType?.admission?.review === "all") {
         const knockingElement = document.createElement('p');
-        knockingElement.textContent = 'Member admission: enabled';
+        knockingElement.textContent = 'New members are reviewed by admins';
         knockingElement.className = 'text-sm';
         textContainer.appendChild(knockingElement);
       }


### PR DESCRIPTION
## Summary

- Fix `sameProfile` to include `memberAdmission` so toggling knocking on a listed group triggers re-review and regenerates the web listing JSON with the updated `admission` field
- Show \"Knocking: enabled\" in bot search results (`/search`, `/next`) for groups with `review = MCAll`
- Show \"Knocking: enabled\" in bot `/list` output between status and commands lines
- Show \"Knocking: enabled\" in web directory UI under the member count

## Test plan

- [ ] Toggle knocking on an active listed group; verify bot sends "updated, hidden until approved" message and notifies admins
- [ ] Search for a group with knocking enabled; verify "Knocking: enabled" appears in the result
- [ ] Send `/list`; verify groups with knocking show "Knocking: enabled" line
- [ ] After approving a group with knocking, check `data/listing.json` and confirm `"admission": {"review": "all"}` is present
- [ ] Load the directory page and verify groups with knocking show "Knocking: enabled" under the member count

🤖 Generated with [Claude Code](https://claude.com/claude-code)