### PR TITLE
directory: expand service README

### DIFF
--- a/apps/simplex-directory-service/README.md
+++ b/apps/simplex-directory-service/README.md
@@ -72,33 +72,24 @@ simplex-directory-service \
 
 ---
 
-## Running Your Own Website
+## Hosting the Directory Page
 
-The bot writes `listing.json`, `promoted.json`, and group images to `--web-folder` (updated every 5 minutes or on group approval).
+The `web/` folder has a ready-to-use directory page — serve it with any static web server. No build step needed. Dark mode follows system preference. `directory.js` is a symlink to `website/src/js/directory.js` so it stays in sync.
 
-**Step 1 — point `--web-folder` at the website output directory:**
+The file must be served under a URL path starting with `/directory` (e.g. `http://example.com/directory.html` or `http://example.com/directory/`) — `directory.js` skips initialisation otherwise.
+
+By default the page shows the official SimpleX directory at `https://directory.simplex.chat/data/`. To use your own bot's data instead, change this line near the bottom of `directory.js`:
+```js
+const simplexDirectoryDataURL = 'https://your-domain.example/data/';
+```
+
+Then run the bot with `--web-folder` pointing to that path. The bot writes `listing.json`, `promoted.json`, and group images there (refreshed every 5 minutes or on approval):
 ```sh
 simplex-directory-service \
   --super-users 2:alice \
   --database /path/to/db \
-  --web-folder /path/to/simplex-chat/website/_site/directory-data
+  --web-folder /var/www/your-domain.example/data
 ```
-
-**Step 2 — switch the data URL in `website/src/js/directory.js`.** The file contains two URL definitions (around line 484); comment out the production one and uncomment the localhost one:
-```js
-// const simplexDirectoryDataURL = 'https://directory.simplex.chat/data/';
-const simplexDirectoryDataURL = 'http://localhost:8080/directory-data/';
-```
-
-**Step 3 — build the website and host `_site/` with a static server:**
-```sh
-# from the website/ directory:
-./run.sh              # runs web.sh (copies assets, npm install, full build) then starts eleventy dev server
-```
-
-For production self-hosting, serve the generated `website/_site/` directory with any static web server (nginx, Caddy, Apache, etc.) rather than using the eleventy dev server. Point the server's root at `_site/` and ensure `directory-data/` within it is writable by the bot process.
-
-> **Note:** Re-running `./run.sh` or `npm run build` will overwrite `_site/`. Generate the bot's listing files with `--web-folder` **after** the build, or store them outside `_site/` and symlink/alias the path in your web server config.
 
 ---
 

--- a/apps/simplex-directory-service/README.md
+++ b/apps/simplex-directory-service/README.md
@@ -1,5 +1,285 @@
 # SimpleX Directory Service
 
-The service is currently a chat bot that allows to register and search for groups.
+Chat bot for registering and searching groups. Superusers and admins are configured via CLI flags.
 
-Superusers are configured via CLI options.
+---
+
+## Prerequisites
+
+**System packages (Ubuntu/Debian):**
+```sh
+sudo apt install build-essential libsqlite3-dev libssl-dev libgmp-dev zlib1g-dev
+```
+
+**Haskell toolchain:**
+- GHC 9.6.3 — install via [GHCup](https://www.haskell.org/ghcup/)
+- Cabal 3.10.2+
+
+---
+
+## Building
+
+```sh
+git clone https://github.com/simplex-chat/simplex-chat
+cd simplex-chat
+cabal build simplex-directory-service
+```
+
+The compiled binary is placed at:
+```
+dist-newstyle/build/<arch>-linux/ghc-<ver>/simplex-chat-<ver>/x/simplex-directory-service/build/simplex-directory-service/simplex-directory-service
+```
+
+Or run directly without installing:
+```sh
+cabal run simplex-directory-service -- <flags>
+```
+
+---
+
+## Running the Bot
+
+### Getting your contact ID (bootstrap)
+
+`--super-users` is required and takes `CONTACT_ID:DISPLAY_NAME`. On a fresh database, use `--run-cli` with a placeholder to connect, then find your real ID:
+
+```sh
+simplex-directory-service --run-cli --super-users 999:nobody --database /path/to/db
+# connect from your phone, then in the bot terminal:
+/contacts           # lists connected contacts by name
+/i alice            # shows full info for contact "alice", including their contact ID
+# note the ID, then restart:
+simplex-directory-service --super-users 2:alice --database /path/to/db
+```
+
+Both `contactId` and `localDisplayName` must match exactly.
+
+### Minimal run
+
+```sh
+simplex-directory-service \
+  --super-users 2:alice \
+  --database /path/to/db
+```
+
+### All flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--super-users ID:NAME[,...]` | *(required)* | Super-user contacts (comma-separated) |
+| `--admin-users ID:NAME[,...]` | none | Admin-only contacts |
+| `--owners-group ID:NAME` | none | Group to invite listed-group owners into |
+| `-d / --database PATH` | `~/.simplex/simplex_directory_service` | DB file prefix |
+| `--directory-file PATH` | none | Append-only state log |
+| `--web-folder PATH` | none | Write static listing JSON + images here |
+| `--no-address` | off | Skip creating/checking the bot contact address |
+| `--service-name NAME` | `SimpleX Directory` | Bot display name |
+| `--run-cli` | off | Run as interactive CLI (useful for bootstrap) |
+
+---
+
+## Running Your Own Website
+
+The bot writes `listing.json`, `promoted.json`, and group images to `--web-folder` (updated every 5 minutes or on group approval).
+
+**Step 1 — point `--web-folder` at the website output directory:**
+```sh
+simplex-directory-service \
+  --super-users 2:alice \
+  --database /path/to/db \
+  --web-folder /path/to/simplex-chat/website/_site/directory-data
+```
+
+**Step 2 — switch the data URL in `website/src/js/directory.js`.** The file contains two URL definitions (around line 488); comment out the production one and uncomment the localhost one:
+```js
+// const simplexDirectoryDataURL = 'https://directory.simplex.chat/data/';
+const simplexDirectoryDataURL = 'http://localhost:8080/directory-data/';
+```
+
+**Step 3 — build the website and host `_site/` with a static server:**
+```sh
+# from the website/ directory:
+./run.sh              # runs web.sh (copies assets, npm install, full build) then starts eleventy dev server
+```
+
+For production self-hosting, serve the generated `website/_site/` directory with any static web server (nginx, Caddy, Apache, etc.) rather than using the eleventy dev server. Point the server's root at `_site/` and ensure `directory-data/` within it is writable by the bot process.
+
+> **Note:** Re-running `./run.sh` or `npm run build` will overwrite `_site/`. Generate the bot's listing files with `--web-folder` **after** the build, or store them outside `_site/` and symlink/alias the path in your web server config.
+
+---
+
+## Command Reference
+
+This is a reference for all commands accepted by the SimpleX Directory bot. For a guided walkthrough of group submission see [DIRECTORY.md](../../docs/DIRECTORY.md).
+
+---
+
+### 1. Searching
+
+The bot sends a welcome message automatically when you first connect.
+
+| Action | Syntax | Effect |
+|---|---|---|
+| Search | `<text>` | Returns up to 10 groups whose name or welcome message matches; sorted by member count |
+| Next page | `/next` or `.` | Next page of the most recent search |
+| Recent groups | `/new` | Groups added most recently |
+| All groups | `/all` | All listed groups, sorted by member count |
+| Help | `/help [registration\|r\|commands\|c]` | Show registration or commands help (default: registration) |
+
+---
+
+### 2. Registering a Group
+
+Registration is a three-step process — see [DIRECTORY.md](../../docs/DIRECTORY.md) for full details:
+
+1. Invite the directory bot to your group as `admin`.
+2. Add the link the bot sends you to the group's welcome message.
+3. Wait for admin approval (usually within 24 hours).
+
+If a group with the same name is already registered, the bot asks you to confirm with `/confirm`.
+
+---
+
+### 3. Managing Your Groups (user commands)
+
+#### List groups
+
+```
+/list
+/ls
+```
+
+Shows all groups you have registered with their current status.
+
+#### Confirm duplicate name
+
+```
+/confirm <ID>:<name>
+```
+
+Confirms registration when another group with the same display name already exists. `ID` and `name` are provided in the bot's prompt.
+
+#### View or set default join role
+
+```
+/role <ID>[:<name>] [member|observer]
+```
+
+Omit the role argument to view the current setting. `member` (default) lets new joiners post immediately; `observer` makes them read-only until promoted.
+
+#### View or configure anti-spam filter
+
+```
+/filter <ID>[:<name>] [preset | flags]
+```
+
+Omit the argument to view the current filter.
+
+**Presets** (mutually exclusive):
+
+| Preset | Effect |
+|---|---|
+| `off` | No filter |
+| `basic` | Reject joins from profiles without images that have no name set |
+| `moderate` (or `mod`) | Reject all no-name profiles; require captcha for profiles without images |
+| `strong` | Reject all no-name profiles; require captcha for all profiles |
+
+**Flags** (combine freely):
+
+```
+/filter <ID>[:<name>] [name[=all|=noimage]] [captcha[=all|=noimage]] [observer[=all|=noimage]]
+```
+
+| Flag | Condition | Effect |
+|---|---|---|
+| `name` | `=all` (default) or `=noimage` | Reject joins from profiles with no name set |
+| `captcha` | `=all` (default) or `=noimage` | Require captcha to join |
+| `observer` | `=all` (default) or `=noimage` | Make new members observers instead of members |
+
+`=noimage` means the condition applies only to profiles that have no profile image.
+
+#### View or upgrade group link
+
+```
+/link <ID>[:<name>]
+```
+
+Shows the current directory-managed join link. If the link is outdated the bot upgrades it.
+
+#### Remove group from directory
+
+```
+/delete <ID>:<name>
+```
+
+Permanently removes the group from the directory. The group can be re-registered later.
+
+---
+
+### 4. Admin Commands
+
+Admins receive a notification whenever a group enters pending state. The `<approval-id>` in `/approve` is the integer from that notification (or from `/pending`); it increments each time a group re-enters pending state so that stale approvals are rejected.
+
+| Command | Syntax | Effect |
+|---|---|---|
+| Approve | `/approve <ID>:<name> <approval-id> [promote=on\|off]` | List group in directory; notifies owner |
+| Reject | `/reject <ID>:<name>` | Reject pending group; notifies owner |
+| Suspend | `/suspend <ID>:<name>` | Hide group from directory; notifies owner |
+| Resume | `/resume <ID>:<name>` | Re-list a suspended group; notifies owner |
+| List recent | `/last [N]` | Show last N registered groups (default: 10) |
+| List pending | `/pending [N]` | Show N groups awaiting approval (default: 10) |
+| Message owner | `/owner <ID>:<name> <message>` | Forward a message to the group owner |
+| Invite owner | `/invite <ID>:<name>` | Invite the group owner to the owners' group |
+
+---
+
+### 5. Super-User Commands
+
+| Command | Syntax | Effect |
+|---|---|---|
+| Feature group | `/promote <ID>:<name> on\|off` | Add or remove group from promoted listing |
+| Execute API command | `/exec <command>` or `/x <command>` | Run a raw SimpleX Chat API command |
+
+---
+
+### 6. Group Lifecycle
+
+```
+Invited by owner
+      │
+      ▼
+PendingConfirmation  ──(/confirm)──▶  Proposed
+      │                                   │
+      └───────────────────────────────────┤
+                                          ▼
+                                    PendingUpdate
+                               (add bot link to welcome)
+                                          │
+                                          ▼
+                                   PendingApproval
+                                   (admin reviews)
+                                          │
+                              ┌───────────┴───────────┐
+                              ▼                       ▼
+                           Active             (profile change
+                          (listed)          → re-enters pending)
+                       ┌────┴─────┐
+                       ▼         ▼
+                  Suspended  SuspendedBadRoles
+                 (by admin)  (roles changed)
+                       │         │
+                       └────┬────┘
+                            ▼
+                          Removed
+```
+
+**State notes:**
+
+- **PendingConfirmation** — bot has been invited but a group with the same display name is already registered. Owner must run `/confirm`.
+- **Proposed** — name accepted; owner has not yet added the bot link to the welcome message.
+- **PendingUpdate** — bot link added; awaiting admin approval.
+- **PendingApproval** — submitted for review. The `approval-id` shown to admins increments each time the group re-enters this state (e.g. after a profile change).
+- **Active** — listed in directory; visible in search results.
+- **Suspended** — hidden from directory by admin action; owner is notified.
+- **SuspendedBadRoles** — hidden automatically when the directory bot loses its `admin` role or the registering owner loses their `owner` role in the group.
+- **Removed** — delisted permanently (by owner via `/delete`, or after removal from the group).

--- a/apps/simplex-directory-service/README.md
+++ b/apps/simplex-directory-service/README.md
@@ -6,12 +6,6 @@ Chat bot for registering and searching groups. Superusers and admins are configu
 
 ## Prerequisites
 
-**System packages (Ubuntu/Debian):**
-```sh
-sudo apt install build-essential libsqlite3-dev libssl-dev libgmp-dev zlib1g-dev
-```
-
-**Haskell toolchain:**
 - GHC 9.6.3 — install via [GHCup](https://www.haskell.org/ghcup/)
 - Cabal 3.10.2+
 

--- a/apps/simplex-directory-service/README.md
+++ b/apps/simplex-directory-service/README.md
@@ -84,7 +84,7 @@ simplex-directory-service \
   --web-folder /path/to/simplex-chat/website/_site/directory-data
 ```
 
-**Step 2 — switch the data URL in `website/src/js/directory.js`.** The file contains two URL definitions (around line 488); comment out the production one and uncomment the localhost one:
+**Step 2 — switch the data URL in `website/src/js/directory.js`.** The file contains two URL definitions (around line 484); comment out the production one and uncomment the localhost one:
 ```js
 // const simplexDirectoryDataURL = 'https://directory.simplex.chat/data/';
 const simplexDirectoryDataURL = 'http://localhost:8080/directory-data/';
@@ -212,12 +212,11 @@ Permanently removes the group from the directory. The group can be re-registered
 
 ### 4. Admin Commands
 
-Admins receive a notification whenever a group enters pending state. The `<approval-id>` in `/approve` is the integer from that notification (or from `/pending`); it increments each time a group re-enters pending state so that stale approvals are rejected.
+Admins receive a notification whenever a group enters the PendingApproval state. The `<approval-id>` in `/approve` is the integer from that notification (or from `/pending`); it increments each time a group re-enters the PendingApproval state so that stale approvals are rejected.
 
 | Command | Syntax | Effect |
 |---|---|---|
 | Approve | `/approve <ID>:<name> <approval-id> [promote=on\|off]` | List group in directory; notifies owner |
-| Reject | `/reject <ID>:<name>` | Reject pending group; notifies owner |
 | Suspend | `/suspend <ID>:<name>` | Hide group from directory; notifies owner |
 | Resume | `/resume <ID>:<name>` | Re-list a suspended group; notifies owner |
 | List recent | `/last [N]` | Show last N registered groups (default: 10) |

--- a/apps/simplex-directory-service/README.md
+++ b/apps/simplex-directory-service/README.md
@@ -101,7 +101,7 @@ This is a reference for all commands accepted by the SimpleX Directory bot. For 
 
 ### 1. Searching
 
-The bot sends a welcome message automatically when you first connect.
+The bot sends a welcome message automatically when you connect.
 
 | Action | Syntax | Effect |
 |---|---|---|
@@ -121,11 +121,13 @@ Registration is a three-step process — see [DIRECTORY.md](../../docs/DIRECTORY
 2. Add the link the bot sends you to the group's welcome message.
 3. Wait for admin approval (usually within 24 hours).
 
-If a group with the same name is already registered, the bot asks you to confirm with `/confirm`.
+If a group with the same display name is already registered (but not yet listed or suspended), the bot asks you to confirm with `/confirm`. If the name is already listed or suspended in the directory, registration is blocked.
 
 ---
 
 ### 3. Managing Your Groups (user commands)
+
+> **Note on `<ID>` vs `<ID>:<name>`:** Commands shown with `<ID>[:<name>]` (`/role`, `/filter`, `/link`) accept just the ID — the name is optional. All other group commands (`/confirm`, `/delete`, and all admin/super-user commands) require both ID and name as `<ID>:<name>`. The bot provides the exact `ID:name` string in its messages so you can copy it directly.
 
 #### List groups
 
@@ -142,7 +144,9 @@ Shows all groups you have registered with their current status.
 /confirm <ID>:<name>
 ```
 
-Confirms registration when another group with the same display name already exists. `ID` and `name` are provided in the bot's prompt.
+When you invite the bot to a group whose display name matches an already-registered group, the bot pauses registration and asks for explicit confirmation. This prevents accidental registration of another group that shares a name. `/confirm` acknowledges the duplicate and proceeds with registration. `ID` and `name` are provided in the bot's prompt.
+
+If a group with the same name is already *listed* or *suspended* in the directory, registration is blocked entirely and `/confirm` is not offered.
 
 #### View or set default join role
 
@@ -213,6 +217,7 @@ Admins receive a notification whenever a group enters the PendingApproval state.
 | List recent | `/last [N]` | Show last N registered groups (default: 10) |
 | List pending | `/pending [N]` | Show N groups awaiting approval (default: 10) |
 | Message owner | `/owner <ID>:<name> <message>` | Forward a message to the group owner |
+| Reject | `/reject <ID>:<name>` | *(Reserved, currently a no-op)* |
 | Invite owner | `/invite <ID>:<name>` | Invite the group owner to the owners' group |
 
 ---
@@ -231,38 +236,52 @@ Admins receive a notification whenever a group enters the PendingApproval state.
 ```
 Invited by owner
       │
-      ▼
-PendingConfirmation  ──(/confirm)──▶  Proposed
-      │                                   │
-      └───────────────────────────────────┤
-                                          ▼
-                                    PendingUpdate
-                               (add bot link to welcome)
-                                          │
-                                          ▼
-                                   PendingApproval
-                                   (admin reviews)
-                                          │
-                              ┌───────────┴───────────┐
-                              ▼                       ▼
-                           Active             (profile change
-                          (listed)          → re-enters pending)
-                       ┌────┴─────┐
-                       ▼         ▼
-                  Suspended  SuspendedBadRoles
-                 (by admin)  (roles changed)
-                       │         │
-                       └────┬────┘
-                            ▼
-                          Removed
+      ├── (unique name) ──────────────────────────┐
+      │                                           │
+      └── (duplicate name*) ─▶ PendingConfirmation│
+                                    │             │
+                               (/confirm)         │
+                                    │             │
+                                    ├─────────────┘
+                                    ▼
+                                  Proposed
+                                    │
+                                    ▼
+                              PendingUpdate
+                         (add bot link to welcome)
+                                    │
+                                    ▼
+                             PendingApproval
+                             (admin reviews)
+                                    │
+                        ┌───────────┴───────────┐
+                        ▼                       ▼
+                     Active              (profile change**
+                    (listed)            → re-enters pending)
+                 ┌────┴─────┐
+                 ▼          ▼
+            Suspended  SuspendedBadRoles
+           (by admin)  (roles changed)
+                 │          │
+                 └────┬─────┘
+                      ▼
+                    Removed
 ```
+
+\* Only when the duplicate is registered but not yet listed or suspended.
+If the name is already listed or suspended, registration is blocked entirely.
+
+\*\* Profile changes only trigger re-approval when fields other than the
+directory bot link are modified. If the only change is swapping the old bot
+link for the new one, or changing only whitespace in the description, the
+group stays Active.
 
 **State notes:**
 
-- **PendingConfirmation** — bot has been invited but a group with the same display name is already registered. Owner must run `/confirm`.
-- **Proposed** — name accepted; owner has not yet added the bot link to the welcome message.
-- **PendingUpdate** — bot link added; awaiting admin approval.
-- **PendingApproval** — submitted for review. The `approval-id` shown to admins increments each time the group re-enters this state (e.g. after a profile change).
+- **PendingConfirmation** — bot has been invited but a group with the same display name is already registered (in a pending state). Owner must run `/confirm` to proceed. If a group with the same name is already listed or suspended, registration is blocked entirely.
+- **Proposed** — name is unique (or duplicate confirmed via `/confirm`); bot is joining the group.
+- **PendingUpdate** — bot has joined the group and created the group link; owner must add it to the group's welcome message.
+- **PendingApproval** — submitted for review. The `approval-id` shown to admins increments each time the group re-enters this state (e.g. after a profile change). An Active group re-enters this state when its profile is modified, unless the only change is swapping the old directory bot link for the new one or changing only whitespace in the description, in which case the group stays Active.
 - **Active** — listed in directory; visible in search results.
 - **Suspended** — hidden from directory by admin action; owner is notified.
 - **SuspendedBadRoles** — hidden automatically when the directory bot loses its `admin` role or the registering owner loses their `owner` role in the group.

--- a/apps/simplex-directory-service/README.md
+++ b/apps/simplex-directory-service/README.md
@@ -263,63 +263,47 @@ Admins receive a notification whenever a group enters the PendingApproval state.
 
 ### 6. Group Lifecycle
 
+Forward path, from invitation to being listed:
+
 ```
-                     Invited by owner
-                            │
-               ┌────────────┴────────────┐
-         unique name                duplicate name*
-               │                          │
-               │                          ▼
-               │                  PendingConfirmation
-               │                          │
-               │                      (/confirm)
-               │                          │
-               └────────────┬─────────────┘
-                            ▼
-                         Proposed
-                            │   (bot joins the group, creates the link)
-                            ▼
-                      PendingUpdate  ◀────── (Active group, if its bot
-               (owner adds the link to welcome)   link is removed)
-                            │
-                            ▼
-                     PendingApproval ◀────── (Active group, on most
-                     (admin reviews)            profile changes**)
-                            │
-                        (/approve)
-                            │
-                            ▼
-         ┌──────────────── Active ──────────────┐
-         │                (listed)              │
-         ▼                   │                  ▼
-    Suspended                │           SuspendedBadRoles
-   (by admin;                │          (bot/owner role lost;
-    /resume re-lists)        │           auto-restored to
-         │                   │           Active when fixed)
-         │                   │                  │
-         └───────────────────┼──────────────────┘
-                             ▼
-                          Removed
-         (owner /delete; owner removed from / left the
-          group; bot removed from group; or group deleted)
+                       Invited by owner
+                              │
+                 ┌────────────┴────────────┐
+           unique name                duplicate name*
+                 │                          │
+                 │                          ▼
+                 │                  PendingConfirmation
+                 │                          │  owner runs /confirm
+                 └────────────┬─────────────┘
+                              ▼
+                          Proposed
+                              │  bot joins the group and creates the link
+                              ▼
+                        PendingUpdate
+                              │  owner adds the link to the group welcome
+                              ▼
+                       PendingApproval
+                              │  admin runs /approve
+                              ▼
+                            Active            (listed; visible in search)
 ```
 
-\* Only when the duplicate is registered but not yet listed or suspended.
-If the name is already listed or suspended, registration is blocked entirely.
+**Transitions out of Active:**
 
-\*\* Profile changes only trigger re-approval when fields other than the
-directory bot link are modified. If the only change is swapping the old bot
-link for the new one, or changing only whitespace in the description, the
-group stays Active. If the link is removed entirely, the group returns to
-PendingUpdate instead.
+- → **PendingUpdate** — the directory bot link is removed from the welcome message.
+- → **PendingApproval** — most other profile changes (see ** below); the `approval-id` shown to admins is bumped each time, so stale `/approve` commands are rejected.
+- → **Suspended** — an admin runs `/suspend`; `/resume` re-lists the group.
+- → **SuspendedBadRoles** — the directory bot loses its `admin` role, or the registering owner loses their `owner` role, in the group; automatically restored to **Active** once the roles are corrected.
+- → **Removed** — the owner runs `/delete`, the owner is removed from or leaves the group, the bot is removed from the group, or the group is deleted. The group can be re-registered afterwards.
+
+\* Only when the duplicate is registered but not yet listed or suspended. If the name is already listed or suspended, registration is blocked entirely.
+
+\*\* Profile changes only trigger re-approval when fields other than the directory bot link are modified. If the only change is swapping the old bot link for the new one, or changing only whitespace in the description, the group stays Active.
 
 **State notes:**
 
-- **PendingConfirmation** — bot has been invited but a group with the same display name is already registered (in a pending state). Owner must run `/confirm` to proceed. If a group with the same name is already listed or suspended, registration is blocked entirely.
-- **Proposed** — name is unique (or duplicate confirmed via `/confirm`); bot is joining the group.
-- **PendingUpdate** — bot has joined the group and created the group link; owner must add it to the group's welcome message. An Active group also returns here if the directory bot link is later removed from the welcome message.
-- **PendingApproval** — submitted for review. The `approval-id` shown to admins increments each time the group re-enters this state (e.g. after a profile change). An Active group re-enters this state when its profile is modified, unless the only change is swapping the old directory bot link for the new one or changing only whitespace in the description, in which case the group stays Active.
-- **Active** — listed in directory; visible in search results.
-- **Suspended** — hidden from directory by admin action (`/suspend`); restored with `/resume`; owner is notified.
-- **SuspendedBadRoles** — hidden automatically when the directory bot loses its `admin` role, or the registering owner loses their `owner` role, in the group; automatically restored to Active once the roles are corrected.
-- **Removed** — delisted permanently: by owner via `/delete`, when the registering owner is removed from or leaves the group, when the bot is removed from the group, or when the group is deleted. The group can be re-registered afterwards.
+- **PendingConfirmation** — the bot was invited but a group with the same display name is already registered (in a pending state); the owner must run `/confirm` to proceed.
+- **Proposed** — the name is unique (or the duplicate was confirmed via `/confirm`); the bot is joining the group.
+- **PendingUpdate** — the bot has joined the group and created the join link; the owner must add it to the group's welcome message.
+- **PendingApproval** — submitted for admin review. The join link works even before approval.
+- **Active** — listed in the directory and visible in search results.

--- a/apps/simplex-directory-service/README.md
+++ b/apps/simplex-directory-service/README.md
@@ -16,12 +16,16 @@ Chat bot for registering and searching groups. Superusers and admins are configu
 ```sh
 git clone https://github.com/simplex-chat/simplex-chat
 cd simplex-chat
+# OpenSSL build configuration (required) — copy the file for your OS:
+cp scripts/cabal.project.local.linux cabal.project.local   # on macOS: scripts/cabal.project.local.mac
 cabal build simplex-directory-service
 ```
 
-The compiled binary is placed at:
-```
-dist-newstyle/build/<arch>-linux/ghc-<ver>/simplex-chat-<ver>/x/simplex-directory-service/build/simplex-directory-service/simplex-directory-service
+See [docs/CONTRIBUTING.md](../../docs/CONTRIBUTING.md) for the full build setup (toolchain, OpenSSL headers, branch compatibility).
+
+Find the compiled binary with:
+```sh
+cabal list-bin simplex-directory-service
 ```
 
 Or run directly without installing:
@@ -35,18 +39,20 @@ cabal run simplex-directory-service -- <flags>
 
 ### Getting your contact ID (bootstrap)
 
-`--super-users` is required and takes `CONTACT_ID:DISPLAY_NAME`. On a fresh database, use `--run-cli` with a placeholder to connect, then find your real ID:
+`--super-users` is required and takes one or more `CONTACT_ID:DISPLAY_NAME` pairs. On a fresh database you don't yet know your contact ID, so start the bot with `--run-cli` and a placeholder, connect to it, then look up your real ID:
 
 ```sh
 simplex-directory-service --run-cli --super-users 999:nobody --database /path/to/db
-# connect from your phone, then in the bot terminal:
+# on startup the bot prints (and, unless --no-address, creates) its contact address:
+#   "Bot's contact address is: simplex:/contact#..."
+# connect to it from your SimpleX Chat app, then in the bot terminal:
 /contacts           # lists connected contacts by name
 /i alice            # shows full info for contact "alice", including their contact ID
-# note the ID, then restart:
+# note the ID, then restart without --run-cli:
 simplex-directory-service --super-users 2:alice --database /path/to/db
 ```
 
-Both `contactId` and `localDisplayName` must match exactly.
+In each `--super-users` / `--admin-users` pair both `contactId` and `localDisplayName` must match the contact exactly. (A mismatched name doesn't stop the bot from sending admin notifications to that contact ID, but commands from that contact will be rejected.)
 
 ### Minimal run
 
@@ -56,34 +62,56 @@ simplex-directory-service \
   --database /path/to/db
 ```
 
-### All flags
+### Flags
+
+`simplex-directory-service` also accepts the standard SimpleX Chat core options (custom SMP/XFTP servers, `--socks-proxy`, network settings, etc.) — run `simplex-directory-service --help` for the complete list. The directory-specific options are:
 
 | Flag | Default | Description |
 |---|---|---|
 | `--super-users ID:NAME[,...]` | *(required)* | Super-user contacts (comma-separated) |
-| `--admin-users ID:NAME[,...]` | none | Admin-only contacts |
-| `--owners-group ID:NAME` | none | Group to invite listed-group owners into |
-| `-d / --database PATH` | `~/.simplex/simplex_directory_service` | DB file prefix |
-| `--directory-file PATH` | none | Append-only state log |
-| `--web-folder PATH` | none | Write static listing JSON + images here |
-| `--no-address` | off | Skip creating/checking the bot contact address |
-| `--service-name NAME` | `SimpleX Directory` | Bot display name |
-| `--run-cli` | off | Run as interactive CLI (useful for bootstrap) |
+| `--admin-users ID:NAME[,...]` | none | Admin-only contacts (comma-separated) |
+| `--owners-group ID:NAME` | none | Group (by group ID) that owners of listed groups are invited into — automatically on listing, or via `/invite` |
+| `-d / --database PATH` | `~/.simplex/simplex_directory_service` | Database file path prefix |
+| `--directory-file PATH` | none | Append-only log of directory state (see [Directory state log](#directory-state-log)) |
+| `--migrate-directory-file check\|import\|export\|listing` | — | Check, import (log → DB), export (DB → log), or regenerate listing files, then exit |
+| `--web-folder PATH` | none | Write static listing JSON + group images here (see [Hosting the directory page](#hosting-the-directory-page)) |
+| `--no-address` | off | Skip checking/creating the bot's contact address |
+| `--service-name NAME` | `SimpleX Directory` | Bot display name (without `*` characters) |
+| `--profile-name-limit N` | unlimited | Max display-name length allowed to connect / join groups (used by the `name` join filter) |
+| `--blocked-words-file PATH` | none | Words not allowed in profiles (used by the `name` join filter and profile review) |
+| `--blocked-fragments-file PATH` | none | Word fragments not allowed in profiles |
+| `--blocked-extenstion-rules PATH` | none | Substitution rules that expand the blocked-words list (the flag is spelled this way in the binary) |
+| `--name-spelling-file PATH` | none | Character-substitution rules for matching disguised names |
+| `--captcha-generator PATH` | none | Executable that renders a captcha image; without it captchas are sent as plain text |
+| `--voice-captcha-generator PATH` | none | Executable that renders a voice captcha |
+| `--run-cli` | off | Run an interactive CLI alongside the bot (useful for bootstrap) |
+| `-v / --version` | — | Print version and exit |
+
+---
+
+## Directory State Log
+
+`--directory-file` keeps an append-only log of every change to directory state (registrations, status changes, promotions) alongside the SQLite database. It is optional but recommended for operability: it is human-inspectable and can be checked, exported, or re-imported with `--migrate-directory-file`. Without it, directory state lives only in the database.
 
 ---
 
 ## Hosting the Directory Page
 
-The `web/` folder has a ready-to-use directory page — serve it with any static web server. No build step needed. Dark mode follows system preference. `directory.js` is a symlink to `website/src/js/directory.js` so it stays in sync.
+The `web/` folder contains a ready-to-use page (`directory.html`) that renders a bot's directory as a searchable, paginated list — no build step. Dark mode follows the system preference.
 
-The file must be served under a URL path starting with `/directory` (e.g. `http://example.com/directory.html` or `http://example.com/directory/`) — `directory.js` skips initialisation otherwise.
+A few things to know before deploying it:
 
-By default the page shows the official SimpleX directory at `https://directory.simplex.chat/data/`. To use your own bot's data instead, change this line near the bottom of `directory.js`:
-```js
-const simplexDirectoryDataURL = 'https://your-domain.example/data/';
-```
+- **Copy the files out of the repo.** `web/directory.js` is a symlink to `website/src/js/directory.js` (kept in sync with the main website), so don't edit it in place — copy `directory.html` and the *contents* of `directory.js` to your web root and edit the copy. The data URL can't be overridden from `directory.html` because `directory.js` declares it as a top-level `const`.
+- **Serve it under a `/directory` path.** `directory.js` only initialises when the page path starts with `/directory` (e.g. `https://example.com/directory.html` or `https://example.com/directory/`).
+- **Provide the fallback image.** Groups without a profile image (and any image that fails to load) fall back to `/img/group.svg`, resolved from the site root — copy `website/src/img/group.svg` to `<web-root>/img/group.svg`.
+- **Point it at your bot's data.** Near the bottom of `directory.js`, change:
+  ```js
+  const simplexDirectoryDataURL = 'https://your-domain.example/data/';
+  ```
+  (the default is the official directory, `https://directory.simplex.chat/data/`). The page fetches `listing.json` from that URL and loads group images relative to it.
+- **Optional:** the "Also available as a SimpleX chat bot" link in `directory.html` points at the official directory bot — update it to your bot's address.
 
-Then run the bot with `--web-folder` pointing to that path. The bot writes `listing.json`, `promoted.json`, and group images there (refreshed every 5 minutes or on approval):
+Then run the bot with `--web-folder` pointing at the folder served at that URL. The bot writes `listing.json` (used by the page), `promoted.json` (the promoted subset — written but not rendered by the bundled page), and group images, refreshing every 5 minutes and immediately when a group is approved or its listing/promotion status changes:
 ```sh
 simplex-directory-service \
   --super-users 2:alice \
@@ -106,10 +134,10 @@ The bot sends a welcome message automatically when you connect.
 | Action | Syntax | Effect |
 |---|---|---|
 | Search | `<text>` | Returns up to 10 groups whose name or welcome message matches; sorted by member count |
-| Next page | `/next` or `.` | Next page of the most recent search |
+| Next page | `/next` or `.` | Next page of the most recent search (after ~5 min of inactivity, or with no recent search, falls back to listing all groups) |
 | Recent groups | `/new` | Groups added most recently |
 | All groups | `/all` | All listed groups, sorted by member count |
-| Help | `/help [registration\|r\|commands\|c]` | Show registration or commands help (default: registration) |
+| Help | `/help [registration\|r\|commands\|c]`, or `/h` | Show registration or commands help (default: registration) |
 
 ---
 
@@ -119,7 +147,7 @@ Registration is a three-step process — see [DIRECTORY.md](../../docs/DIRECTORY
 
 1. Invite the directory bot to your group as `admin`.
 2. Add the link the bot sends you to the group's welcome message.
-3. Wait for admin approval (usually within 24 hours).
+3. Wait for admin approval (usually within a day, except holidays).
 
 If a group with the same display name is already registered (but not yet listed or suspended), the bot asks you to confirm with `/confirm`. If the name is already listed or suspended in the directory, registration is blocked.
 
@@ -127,7 +155,7 @@ If a group with the same display name is already registered (but not yet listed 
 
 ### 3. Managing Your Groups (user commands)
 
-> **Note on `<ID>` vs `<ID>:<name>`:** Commands shown with `<ID>[:<name>]` (`/role`, `/filter`, `/link`) accept just the ID — the name is optional. All other group commands (`/confirm`, `/delete`, and all admin/super-user commands) require both ID and name as `<ID>:<name>`. The bot provides the exact `ID:name` string in its messages so you can copy it directly.
+> **Note on `<ID>` vs `<ID>:<name>`:** Commands shown with `<ID>[:<name>]` (`/role`, `/filter`, `/link`) accept just the ID — the name is optional. `/confirm`, `/delete`, and all admin/super-user commands require both, written as `<ID>:<name>`. For user commands the ID is the registration ID shown by `/list`; for admin and super-user commands it's the group ID included in the bot's admin notifications. When the bot expects an `<ID>:<name>` argument it normally quotes the whole command for you (e.g. for `/confirm` and `/approve`), so you can copy it directly; for `/delete` you build it from the ID and name shown by `/list`.
 
 #### List groups
 
@@ -136,7 +164,7 @@ If a group with the same display name is already registered (but not yet listed 
 /ls
 ```
 
-Shows all groups you have registered with their current status.
+Shows all groups you have registered, with their current status, member count, and the `/role` and `/filter` commands for each.
 
 #### Confirm duplicate name
 
@@ -162,16 +190,16 @@ Omit the role argument to view the current setting. `member` (default) lets new 
 /filter <ID>[:<name>] [preset | flags]
 ```
 
-Omit the argument to view the current filter.
+Omit the argument to view the current filter. Filters apply to people joining via the directory-managed link.
 
 **Presets** (mutually exclusive):
 
 | Preset | Effect |
 |---|---|
 | `off` | No filter |
-| `basic` | Reject joins from profiles without images that have no name set |
-| `moderate` (or `mod`) | Reject all no-name profiles; require captcha for profiles without images |
-| `strong` | Reject all no-name profiles; require captcha for all profiles |
+| `basic` | For profiles without an image: reject long or inappropriate names |
+| `moderate` (or `mod`) | Reject long/inappropriate names from all profiles; require captcha from profiles without an image |
+| `strong` | Reject long/inappropriate names from all profiles; require captcha from all profiles |
 
 **Flags** (combine freely):
 
@@ -181,11 +209,13 @@ Omit the argument to view the current filter.
 
 | Flag | Condition | Effect |
 |---|---|---|
-| `name` | `=all` (default) or `=noimage` | Reject joins from profiles with no name set |
-| `captcha` | `=all` (default) or `=noimage` | Require captcha to join |
+| `name` | `=all` (default) or `=noimage` | Reject joins from profiles whose name is too long (`--profile-name-limit`) or contains blocked words/fragments (`--blocked-words-file` / `--blocked-fragments-file`) |
+| `captcha` | `=all` (default) or `=noimage` | Require the joiner to solve a captcha |
 | `observer` | `=all` (default) or `=noimage` | Make new members observers instead of members |
 
-`=noimage` means the condition applies only to profiles that have no profile image.
+`=noimage` means the condition applies only to profiles that have no profile image (`=no_image` and `=no-image` are also accepted).
+
+> The `name` filter only has an effect when the bot was started with `--profile-name-limit` and/or `--blocked-words-file` / `--blocked-fragments-file`; otherwise it does nothing. The `captcha` filter sends a much stronger challenge when `--captcha-generator` (or `--voice-captcha-generator`) is configured — without it the captcha text is sent as a plain message.
 
 #### View or upgrade group link
 
@@ -218,7 +248,7 @@ Admins receive a notification whenever a group enters the PendingApproval state.
 | List pending | `/pending [N]` | Show N groups awaiting approval (default: 10) |
 | Message owner | `/owner <ID>:<name> <message>` | Forward a message to the group owner |
 | Reject | `/reject <ID>:<name>` | *(Reserved, currently a no-op)* |
-| Invite owner | `/invite <ID>:<name>` | Invite the group owner to the owners' group |
+| Invite owner | `/invite <ID>:<name>` | Invite the group owner to the owners' group (requires `--owners-group`) |
 
 ---
 
@@ -226,7 +256,7 @@ Admins receive a notification whenever a group enters the PendingApproval state.
 
 | Command | Syntax | Effect |
 |---|---|---|
-| Feature group | `/promote <ID>:<name> on\|off` | Add or remove group from promoted listing |
+| Feature group | `/promote <ID>:<name> on\|off` | Add or remove group from the promoted listing (`promoted.json`) |
 | Execute API command | `/exec <command>` or `/x <command>` | Run a raw SimpleX Chat API command |
 
 ---
@@ -234,38 +264,44 @@ Admins receive a notification whenever a group enters the PendingApproval state.
 ### 6. Group Lifecycle
 
 ```
-Invited by owner
-      │
-      ├── (unique name) ──────────────────────────┐
-      │                                           │
-      └── (duplicate name*) ─▶ PendingConfirmation│
-                                    │             │
-                               (/confirm)         │
-                                    │             │
-                                    ├─────────────┘
-                                    ▼
-                                  Proposed
-                                    │
-                                    ▼
-                              PendingUpdate
-                         (add bot link to welcome)
-                                    │
-                                    ▼
-                             PendingApproval
-                             (admin reviews)
-                                    │
-                        ┌───────────┴───────────┐
-                        ▼                       ▼
-                     Active              (profile change**
-                    (listed)            → re-enters pending)
-                 ┌────┴─────┐
-                 ▼          ▼
-            Suspended  SuspendedBadRoles
-           (by admin)  (roles changed)
-                 │          │
-                 └────┬─────┘
-                      ▼
-                    Removed
+                     Invited by owner
+                            │
+               ┌────────────┴────────────┐
+         unique name                duplicate name*
+               │                          │
+               │                          ▼
+               │                  PendingConfirmation
+               │                          │
+               │                      (/confirm)
+               │                          │
+               └────────────┬─────────────┘
+                            ▼
+                         Proposed
+                            │   (bot joins the group, creates the link)
+                            ▼
+                      PendingUpdate  ◀────── (Active group, if its bot
+               (owner adds the link to welcome)   link is removed)
+                            │
+                            ▼
+                     PendingApproval ◀────── (Active group, on most
+                     (admin reviews)            profile changes**)
+                            │
+                        (/approve)
+                            │
+                            ▼
+         ┌──────────────── Active ──────────────┐
+         │                (listed)              │
+         ▼                   │                  ▼
+    Suspended                │           SuspendedBadRoles
+   (by admin;                │          (bot/owner role lost;
+    /resume re-lists)        │           auto-restored to
+         │                   │           Active when fixed)
+         │                   │                  │
+         └───────────────────┼──────────────────┘
+                             ▼
+                          Removed
+         (owner /delete; owner removed from / left the
+          group; bot removed from group; or group deleted)
 ```
 
 \* Only when the duplicate is registered but not yet listed or suspended.
@@ -274,15 +310,16 @@ If the name is already listed or suspended, registration is blocked entirely.
 \*\* Profile changes only trigger re-approval when fields other than the
 directory bot link are modified. If the only change is swapping the old bot
 link for the new one, or changing only whitespace in the description, the
-group stays Active.
+group stays Active. If the link is removed entirely, the group returns to
+PendingUpdate instead.
 
 **State notes:**
 
 - **PendingConfirmation** — bot has been invited but a group with the same display name is already registered (in a pending state). Owner must run `/confirm` to proceed. If a group with the same name is already listed or suspended, registration is blocked entirely.
 - **Proposed** — name is unique (or duplicate confirmed via `/confirm`); bot is joining the group.
-- **PendingUpdate** — bot has joined the group and created the group link; owner must add it to the group's welcome message.
+- **PendingUpdate** — bot has joined the group and created the group link; owner must add it to the group's welcome message. An Active group also returns here if the directory bot link is later removed from the welcome message.
 - **PendingApproval** — submitted for review. The `approval-id` shown to admins increments each time the group re-enters this state (e.g. after a profile change). An Active group re-enters this state when its profile is modified, unless the only change is swapping the old directory bot link for the new one or changing only whitespace in the description, in which case the group stays Active.
 - **Active** — listed in directory; visible in search results.
-- **Suspended** — hidden from directory by admin action; owner is notified.
-- **SuspendedBadRoles** — hidden automatically when the directory bot loses its `admin` role or the registering owner loses their `owner` role in the group.
-- **Removed** — delisted permanently (by owner via `/delete`, or after removal from the group).
+- **Suspended** — hidden from directory by admin action (`/suspend`); restored with `/resume`; owner is notified.
+- **SuspendedBadRoles** — hidden automatically when the directory bot loses its `admin` role, or the registering owner loses their `owner` role, in the group; automatically restored to Active once the roles are corrected.
+- **Removed** — delisted permanently: by owner via `/delete`, when the registering owner is removed from or leaves the group, when the bot is removed from the group, or when the group is deleted. The group can be re-registered afterwards.

--- a/apps/simplex-directory-service/web/directory.html
+++ b/apps/simplex-directory-service/web/directory.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SimpleX Directory</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      padding: 16px;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      font-size: 15px;
+      line-height: 1.5;
+      background: #fff;
+      color: #111;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body { background: #061f38; color: #f0f0f0; }
+    }
+
+    .container {
+      max-width: 800px;
+      margin: 0 auto;
+    }
+
+    h1 {
+      font-size: 2rem;
+      font-weight: 700;
+      text-align: center;
+      color: #0053d0;
+      margin: 0 0 12px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      h1 { color: #70f0f9; }
+    }
+
+    p { margin: 0 0 8px; }
+
+    a { color: #0053d0; }
+    @media (prefers-color-scheme: dark) { a { color: #70f0f9; } }
+
+    /* ── Directory entries ── */
+    #directory .entry {
+      display: flex;
+      align-items: flex-start;
+      margin-bottom: 20px;
+      padding: 16px;
+      word-break: break-word;
+    }
+
+    #directory .entry a {
+      order: -1;
+      object-fit: cover;
+      margin-right: 16px;
+      margin-bottom: 16px;
+    }
+
+    #directory .entry a img {
+      min-width: 104px;
+      min-height: 104px;
+      width: 104px;
+      height: 104px;
+      border-radius: 24px;
+    }
+
+    #directory .entry h2 { margin: 0 0 5px; }
+    #directory .entry p  { margin: 0 0 5px; }
+
+    #directory .entry .secret {
+      filter: blur(5px);
+      cursor: pointer;
+      transition: filter 0.1s ease;
+      user-select: none;
+    }
+    #directory .entry .secret.visible { filter: none; user-select: auto; }
+
+    #directory .entry .read-more {
+      color: #0053d0;
+      text-decoration: underline;
+      cursor: pointer;
+    }
+    #directory .entry .read-less { color: darkgray; cursor: pointer; }
+
+    .dark #directory .entry .read-more { color: #70f0f9; }
+
+    #directory .entry .red     { color: #dd0000; }
+    #directory .entry .green   { color: #20bd3d; }
+    #directory .entry .blue    { color: #0053d0; }
+    #directory .entry .cyan    { color: #0ac4d1; }
+    #directory .entry .yellow  { color: #debd00; }
+    #directory .entry .magenta { color: magenta; }
+
+    #directory .entry .small-text { font-size: 0.8em; color: #888; }
+
+    .dark #directory .entry .small-text { color: #999; }
+    .dark #directory .entry .green      { color: #4dda67; }
+    .dark #directory .entry .blue       { color: #00a2ff; }
+    .dark #directory .entry .cyan       { color: #70f0f9; }
+    .dark #directory .entry .yellow     { color: #ffd700; }
+
+    /* ── Pagination ── */
+    .pagination {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: 4px;
+      margin-top: 20px;
+      padding: 10px 0;
+    }
+
+    .pagination button {
+      padding: 8px 12px;
+      border: none;
+      background: transparent;
+      color: #374151;
+      cursor: pointer;
+      border-radius: 50%;
+      font-size: 14px;
+      min-width: 40px;
+      height: 40px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: background-color 0.2s;
+    }
+    .dark .pagination button { color: #70f0f9; }
+    .pagination button:hover  { background: #f3f4f6; }
+    .dark .pagination button:hover { background: #0b2a50; }
+    .pagination button.active { font-weight: bold; color: #0b2a59; }
+    .dark .pagination button.active { color: #70f0f9; }
+    .pagination button.text-btn { border-radius: 20px; min-width: auto; height: 40px; padding: 8px 16px; }
+    .pagination button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+    @media (max-width: 768px) {
+      .pagination { gap: 2px; padding: 8px 0; }
+      .pagination button { font-size: 12px; min-width: 32px; height: 32px; padding: 4px 8px; }
+      .pagination button.text-btn { padding: 4px 8px; height: 32px; border-radius: 16px; font-size: 12px; }
+    }
+    @media (max-width: 480px) {
+      .pagination button:not(.text-btn):not(.active):not(.neighbor) { display: none; }
+      .pagination button.active, .pagination button.neighbor { display: flex; }
+    }
+
+    /* ── Search ── */
+    .search-container {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 16px;
+    }
+
+    #search {
+      flex-grow: 1;
+      width: 100%;
+      max-width: 540px;
+      padding: 8px 12px 8px 32px;
+      font-size: 15px;
+      font-family: inherit;
+      border: none;
+      border-radius: 10px;
+      background-color: #fff;
+      color: #000;
+      outline: solid 1px #f2f2ff;
+      transition: background-color 0.2s, box-shadow 0.2s;
+      background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZT0iIzg4ODg4OCI+CjxjaXJjbGUgY3g9IjEwLjUiIGN5PSIxMC41IiByPSI3LjUiIC8+CjxsaW5lIHgxPSIxNiIgeTE9IjE2IiB4Mj0iMjEiIHkyPSIyMSIgLz4KPC9nPgo8L3N2Zz4=');
+      background-position: 8px center;
+      background-repeat: no-repeat;
+      background-size: 18px;
+    }
+    #search::placeholder { color: #8e8e93; }
+
+    .dark #search {
+      background-color: #0b2a50;
+      color: #fff;
+      background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZT0iI2JiYmJiYiI+CjxjaXJjbGUgY3g9IjEwLjUiIGN5PSIxMC41IiByPSI3LjUiIC8+CjxsaW5lIHgxPSIxNiIgeTE9IjE2IiB4Mj0iMjEiIHkyPSIyMSIgLz4KPC9nPgo8L3N2Zz4=');
+      outline: none;
+    }
+    .dark #search::placeholder { color: #8e8e93; }
+
+    #top-pagination { margin-bottom: 0; }
+  </style>
+</head>
+<body>
+  <script>
+    // Mirror system dark-mode preference into the .dark class used by directory.js
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.body.classList.add('dark');
+    }
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
+      document.body.classList.toggle('dark', e.matches);
+    });
+  </script>
+
+  <div class="container">
+    <h1>SimpleX Directory</h1>
+    <p>Communities you can join via <a href="https://simplex.chat/downloads" target="_blank">SimpleX Chat</a>.</p>
+    <p>Also available as a <a href="https://smp4.simplex.im/a#lXUjJW5vHYQzoLYgmi8GbxkGP41_kjefFvBrdwg-0Ok" target="_blank">SimpleX chat bot</a>.</p>
+    <div class="search-container">
+      <input id="search" autocomplete="off">
+      <div id="top-pagination" class="pagination">
+        <button class="text-btn live">Active</button>
+        <button class="text-btn new">New</button>
+        <button class="text-btn top">All</button>
+      </div>
+    </div>
+    <div id="directory" style="min-height: 200px;"></div>
+    <div id="bottom-pagination" class="pagination"></div>
+  </div>
+
+  <script>
+    const isMobile = {
+      Android: () => navigator.userAgent.match(/Android/i),
+      iOS: () => navigator.userAgent.match(/iPhone|iPad|iPod/i),
+      any: () => navigator.userAgent.match(/Android|iPhone|iPad|iPod/i)
+    };
+  </script>
+  <script src="directory.js"></script>
+</body>
+</html>

--- a/apps/simplex-directory-service/web/directory.js
+++ b/apps/simplex-directory-service/web/directory.js
@@ -1,0 +1,1 @@
+../../../website/src/js/directory.js


### PR DESCRIPTION
## Summary

- Add build prerequisites (system packages, GHC 9.6.3 / Cabal 3.10.2+) and `cabal build` / `cabal run` instructions
- Document running the bot: bootstrap flow to discover contact ID, minimal invocation, and full CLI flag reference
- Document self-hosting the directory website via `--web-folder` + static server
- Add full bot command reference: search/browse, group registration, user group management (list, role, filter, link, delete), admin commands, super-user commands, and group lifecycle diagram

## Test plan

- [ ] README renders correctly on GitHub
- [ ] All commands and flags match current `simplex-directory-service` implementation