### PR TITLE
fix: jump to message in search

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
@@ -753,7 +753,9 @@ fun ChatView(
             changeNtfsState = { enabled, currentValue -> toggleNotifications(chatRh, chatInfo, enabled, chatModel, currentValue) },
             onSearchValueChanged = onSearchValueChanged,
             closeSearch = {
-              onSearchValueChanged("")
+              if (chatModel.openAroundItemId.value == null) {
+                onSearchValueChanged("")
+              }
               showSearch.value = false
               searchText.value = ""
               contentFilter.value = null


### PR DESCRIPTION
## Summary
- Fix navigating to a message from search results when the message is far up in the chat history — previously the view would fail to scroll and stay on the latest messages
## Changes
- Prevent `closeSearch` from triggering async `apiFindMessages` reload when `openAroundItemId` is already set (race condition that replaced correctly loaded items with latest messages)

## Test plan
- [ ] Search for a message in a chat with long history
- [ ] Tap the Go button on a search result that is far up in the timeline — should navigate to it
- [ ] Verify normal search close (tapping X) still reloads messages correctly
- [ ] Verify content filter changes still work