### PR TITLE
fix: jump to quoted message in search and content filter

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
@@ -813,7 +813,6 @@ fun ChatView(
 
 fun updateAvailableContent(chatRh: Long?, activeChat: State<Chat?>, availableContent: MutableState<List<ContentFilter>>) {
   withBGApi {
-    Log.e(TAG, "updateAvailableContent")
     val chatInfo = activeChat.value?.chatInfo
     if (chatInfo == null) return@withBGApi
     val types = chatModel.controller.apiGetChatContentTypes(chatRh, chatInfo.chatType, chatInfo.apiId, null)
@@ -822,7 +821,6 @@ fun updateAvailableContent(chatRh: Long?, activeChat: State<Chat?>, availableCon
       availableContent.value = ContentFilter.entries
     } else {
       val typeSet: Set<MsgContentTag> = types.union(ContentFilter.alwaysShow)
-      Log.e(TAG, "updateAvailableContent $typeSet")
       availableContent.value = ContentFilter.entries.filter { it -> typeSet.contains(it.contentTag) }
     }
   }


### PR DESCRIPTION
## Summary
- Fix tapping a quoted message during search or content filter — previously silently did nothing when the quoted message wasn't in loaded items
- Load around the target without search/filter params using `openAroundItemId`, which closes search/filter and positions at the target
- Fixes the overly broad guard added in 219381f9 (#5315)

## Test plan
- [ ] Search for a message, tap a quoted message in the search results — should close search and navigate to the quoted message
- [ ] Activate content filter (e.g., images), tap a quoted message — should close filter and navigate to the quoted message
- [ ] Verify normal quote navigation (outside search/filter) still works