### PR TITLE
ui: fix filter button order during active call

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
@@ -1172,25 +1172,6 @@ fun BoxScope.ChatInfoToolbar(
     chatInfo.contact.active &&
     activeCall == null
 
-  // Content filter button: always in bar on desktop and for groups; on Android for direct chats it
-  // goes into the three-dots menu UNLESS calls are unavailable, in which case it appears in the bar
-  if (showContentFilterButton && (appPlatform.isDesktop || chatInfo is ChatInfo.Group ||
-      (appPlatform.isAndroid && chatInfo is ChatInfo.Direct && !canStartCall && activeCall == null))) {
-    val enabled = chatInfo !is ChatInfo.Local || chatInfo.noteFolder.ready
-    barButtons.add {
-      IconButton(
-        { showContentFilterMenu.value = true },
-        enabled = enabled
-      ) {
-        Icon(
-          painterResource(MR.images.ic_photo_library),
-          null,
-          tint = MaterialTheme.colors.primary
-        )
-      }
-    }
-  }
-
   // Chat-type specific buttons
   when (chatInfo) {
     is ChatInfo.Local -> {
@@ -1283,6 +1264,26 @@ fun BoxScope.ChatInfoToolbar(
       }
     }
     else -> {}
+  }
+
+  // Content filter button: always in bar on desktop and for groups; on Android for direct chats it
+  // goes into the three-dots menu UNLESS calls are unavailable, in which case it appears in the bar.
+  // Must be after chat-type buttons so call buttons appear before filter during active call.
+  if (showContentFilterButton && (appPlatform.isDesktop || chatInfo is ChatInfo.Group ||
+      (appPlatform.isAndroid && chatInfo is ChatInfo.Direct && !canStartCall && activeCall == null))) {
+    val enabled = chatInfo !is ChatInfo.Local || chatInfo.noteFolder.ready
+    barButtons.add {
+      IconButton(
+        { showContentFilterMenu.value = true },
+        enabled = enabled
+      ) {
+        Icon(
+          painterResource(MR.images.ic_photo_library),
+          null,
+          tint = MaterialTheme.colors.primary
+        )
+      }
+    }
   }
 
   val enableNtfs = chatInfo.chatSettings?.enableNtfs


### PR DESCRIPTION
## Summary
- During an active call, the content filter button appeared before the call timer and end call button in the toolbar
- Moved content filter button after chat-type specific buttons so call controls always appear first in the toolbar

## Test plan
- [ ] Start a call in a direct chat on desktop
- [ ] Verify call timer and end call button appear before the content filter button
- [ ] Verify normal (no-call) button order is unchanged: call button, filter button, menu