### PR TITLE
directory: reflect search/filter state in URL hash

### DIFF
--- a/website/src/js/directory.js
+++ b/website/src/js/directory.js
@@ -29,25 +29,42 @@ async function initDirectory() {
 
   function applyHash() {
     const hash = location.hash;
-    let search = '';
-    try { if (hash.startsWith('#q=')) search = decodeURIComponent(hash.slice(3)); } catch(e) {}
-    const mode = hash === '#active' ? 'live' : hash === '#new' ? 'new' : 'top';
-    const btn = mode === 'live' ? liveBtn : mode === 'new' ? newBtn : topBtn;
-    const comparator = mode === 'live' ? byActiveAtDesc : mode === 'new' ? byCreatedAtDesc : bySortPriority;
-    if (search) searchInput.value = search;
+    let mode, comparator, btn, search = '';
+    switch (hash) {
+      case '#active':
+        mode = 'live';
+        comparator = byActiveAtDesc;
+        btn = liveBtn;
+      case '#new':
+        mode = 'new';
+        comparator = byCreatedAtDesc;
+        btn = newBtn;
+      default:
+        mode = 'top';
+        comparator = bySortPriority;
+        btn = topBtn;
+        try {
+          if (hash.startsWith('#q=')) {
+            search = decodeURIComponent(hash.slice(3));
+            if (search) searchInput.value = search;
+          }
+        } catch(e) {}
+      }
     currentSortMode = '';
     currentSearch = '';
     currentPage = 1;
-    renderEntries(mode, comparator, btn, search, true);
+    renderEntries(mode, comparator, btn, search);
   }
 
-  function renderEntries(mode, comparator, btn, search = '', replaceHash = false) {
+  function renderEntries(mode, comparator, btn, search = '') {
     if (currentSortMode === mode && search == currentSearch) return;
     currentSortMode = mode;
-    const hash = search ? '#q=' + encodeURIComponent(search) : mode === 'live' ? '#active' : mode === 'new' ? '#new' : '';
+    const hash = search ? '#q=' + encodeURIComponent(search)
+              : mode === 'live' ? '#active'
+              : mode === 'new' ? '#new'
+              : '';
     const url = hash || (location.pathname + location.search);
-    if (replaceHash) history.replaceState(null, '', url);
-    else history.pushState(null, '', url);
+    history.replaceState(null, '', url);
     liveBtn.classList.remove('active');
     newBtn.classList.remove('active');
     topBtn.classList.remove('active');


### PR DESCRIPTION
## Summary
- Show current directory view in the URL fragment (`#active`, `#new`, `#q=<query>`) so links can be shared and bookmarked
- Restore view from URL hash on page load
- Browser Back/Forward navigates between views (button clicks push history; typing replaces state)

## Test plan
- [ ] Open `/directory.html` — defaults to All view, no hash in URL
- [ ] Click Active — URL shows `#active`, listing filters to active groups
- [ ] Click New — URL shows `#new`
- [ ] Type a search query — URL shows `#q=<encoded query>`
- [ ] Copy URL with hash, open in new tab — view is restored
- [ ] Press browser Back — returns to previous view
- [ ] Clear search — hash is removed, All view restored