### PR TITLE
desktop: fix nanohttpd jitpack dependency

### DIFF
--- a/apps/multiplatform/common/build.gradle.kts
+++ b/apps/multiplatform/common/build.gradle.kts
@@ -118,8 +118,8 @@ kotlin {
         implementation("org.slf4j:slf4j-simple:2.0.12")
         implementation("uk.co.caprica:vlcj:4.8.3")
         implementation("net.java.dev.jna:jna:5.14.0")
-        implementation("com.github.NanoHttpd.nanohttpd:nanohttpd:efb2ebf85a")
-        implementation("com.github.NanoHttpd.nanohttpd:nanohttpd-websocket:efb2ebf85a")
+        implementation("com.github.NanoHttpd.nanohttpd:nanohttpd:efb2ebf")
+        implementation("com.github.NanoHttpd.nanohttpd:nanohttpd-websocket:efb2ebf")
         implementation("com.squareup.okhttp3:okhttp:4.12.0")
       }
     }


### PR DESCRIPTION
Jitpack stopped serving nanohttpd under the 10-char commit hash efb2ebf85a (returns 404), while the 7-char short hash efb2ebf resolves to the same commit and jars. Switch to the short form to unbreak desktopCompileClasspath.