### PR TITLE
Add hard expiry (wall-clock message deletion) for groups

### DIFF
--- a/FORK_README.md
+++ b/FORK_README.md
@@ -1,0 +1,51 @@
+# SimpleX Chat Fork: Hard Expiry
+
+This fork adds **hard expiry** (wall-clock message deletion) to SimpleX Chat groups.
+
+## What it does
+
+Every group message gets an absolute UTC deletion timestamp stamped at send time. When the clock reaches that timestamp, the message is deleted on all clients — whether or not it was ever read.
+
+This solves the problem of messages persisting indefinitely on devices that are lost, abandoned, or belong to deceased members. The existing disappearing messages feature only triggers after a message is read; hard expiry provides an unconditional backstop.
+
+## How it differs from upstream
+
+One new feature, minimal changes:
+
+- **New DB column**: `hard_expiry_at` on `chat_items` (indexed)
+- **New group preference field**: `hardExpiryDuration` on `TimedMessagesGroupPreference`
+- **New wire protocol field**: `hardExpiryAt` on `ExtMsgContent` (optional, backward compatible)
+- **Sweep**: integrated into the existing `cleanupManager` periodic loop
+- **CLI commands**: `/set expiry #group <duration|off>`, `/show expiry #group`
+
+No existing behavior was changed. The disappearing messages system is untouched.
+
+## Building
+
+Requires GHC 9.6.3 and cabal. On macOS with Homebrew:
+
+```bash
+# Install GHC
+curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+ghcup install ghc 9.6.3
+ghcup set ghc 9.6.3
+
+# Install OpenSSL
+brew install openssl@3
+
+# Build
+cd simplex-chat
+cabal update
+DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/opt/openssl@3/lib \
+  cabal build exe:simplex-chat -j1 \
+  --extra-lib-dirs=/opt/homebrew/opt/openssl@3/lib \
+  --extra-include-dirs=/opt/homebrew/opt/openssl@3/include
+
+# Run
+DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/opt/openssl@3/lib \
+  cabal exec simplex-chat
+```
+
+## Design
+
+See [docs/PR-PROPOSAL.md](docs/PR-PROPOSAL.md) for the full design, backward compatibility analysis, and file change list.

--- a/docs/PR-PROPOSAL.md
+++ b/docs/PR-PROPOSAL.md
@@ -1,0 +1,102 @@
+# PR Proposal: Add hard expiry (wall-clock message deletion) for groups
+
+## Motivation
+
+SimpleX currently has (a) **disappearing messages** that fire on read, and (b) **delete-for-everyone** that fires on demand. Both require something to happen — a read event, or a button press. Neither handles the case where a device is unreachable and nothing happens.
+
+This PR adds a third option: a **send-time-stamped hard expiry** that fires on local clock regardless of read state or user action.
+
+The concrete trigger: a member of a private group dies. Messages sent after their death remain unread on their device indefinitely. No existing mechanism cleans them up. Hard expiry provides the backstop — old messages are deleted when the clock reaches their deadline, whether or not the app is opened, the message is read, or anyone presses a button.
+
+## Design
+
+The feature introduces two concepts:
+
+1. **`hardExpiryDuration`** — a group-level setting (seconds) stored on `TimedMessagesGroupPreference`. Admins set this via group preferences. Default: 604800 seconds (7 days). Range: 1 hour to 30 days. Can be disabled (`Nothing`).
+
+2. **`hardExpiryAt`** — a per-message absolute UTC timestamp. Computed by the sender as `brokerTimestamp + hardExpiryDuration` and transmitted to all recipients in the message JSON. Each client stores it locally and deletes the message when the clock reaches that time.
+
+The setting propagates to all group members through the existing `XGrpInfo`/`XGrpPrefs` mechanism. Changing the setting affects only future messages — already-sent messages retain their original expiry timestamp.
+
+## How it coexists with disappearing messages
+
+The two systems are independent and complementary:
+
+| | Disappearing messages | Hard expiry |
+|---|---|---|
+| **Trigger** | Message is read | Wall clock reaches deadline |
+| **Timer starts** | On read | At send time |
+| **Stored as** | `timed_delete_at` (set on read) | `hard_expiry_at` (set on send) |
+| **Scope** | Per-message, group or direct | Per-message, groups only |
+
+**Whichever fires first wins.** If a message is read promptly, the read-triggered timer will likely delete it before the hard expiry. If the message is never read, the hard expiry guarantees deletion anyway.
+
+No existing disappearing messages behavior was changed.
+
+## Implementation summary
+
+The change is minimal — approximately 300 lines of logic across the following areas:
+
+### Database
+- New `hard_expiry_at TEXT` column on `chat_items`, indexed on `(user_id, hard_expiry_at)`.
+- Migration provided for both SQLite and Postgres.
+
+### Types
+- `TimedMessagesGroupPreference` gains `hardExpiryDuration :: Maybe Int` (seconds).
+- `CITimed` gains `hardExpiryAt :: Maybe UTCTime` (local storage).
+- `ExtMsgContent` gains `hardExpiryAt :: Maybe UTCTime` (wire protocol).
+
+### Send path
+- When sending a group message, if the group has `hardExpiryDuration` set, the sender computes `hardExpiryAt = brokerTimestamp + duration` and includes it in `ExtMsgContent` and the local `CITimed`.
+
+### Receive path
+- The receiver extracts `hardExpiryAt` from the incoming `ExtMsgContent` JSON and stores it in `CITimed` and the `hard_expiry_at` column.
+
+### Sweep
+- `cleanupHardExpiredItems` is called in the existing `cleanupManager` periodic loop. It queries `SELECT ... FROM chat_items WHERE hard_expiry_at IS NOT NULL AND hard_expiry_at <= ?` and deletes matching items. Runs before the UI renders unread counts.
+
+### CLI
+- `/set expiry #groupName <duration|off>` — set or disable hard expiry for a group.
+- `/show expiry #groupName` — display current setting.
+
+## Backward compatibility
+
+- **Old clients receiving messages with `hardExpiryAt`**: The field is optional JSON (`.:? "hardExpiryAt"`). Old clients that do not know this field will decode it as `null` and ignore it. The message is delivered and displayed normally; it simply will not have a wall-clock expiry on that client.
+- **New clients receiving messages from old clients**: Old clients do not set `hardExpiryAt`, so it arrives as `null`. The message has no hard expiry. This is correct — the sender's client did not support the feature.
+- **Mixed groups**: Messages from updated clients will be hard-expired by other updated clients. Messages from old clients will not. This is a safe, progressive rollout.
+- **No breaking changes** to the existing SMP or chat protocol. No new message types. No changes to encryption or signing.
+
+## What is NOT included (left for the SimpleX team)
+
+- **iOS/Android UI**: Group creation picker for hard expiry duration, group info display of current setting, per-message expiry indicator badge. The backend is fully wired; only UI integration is needed.
+- **Direct message hard expiry**: This implementation is group-only. Extending to direct messages would be straightforward but was out of scope.
+- **Local read TTL concept**: Initially considered as a separate per-conversation setting, but dropped — the existing disappearing messages feature already provides group-level read-triggered expiry, making a separate mechanism redundant.
+
+## Testing
+
+Built and tested via the SimpleX CLI (`simplex-chat`):
+
+- Verified `hard_expiry_at` is stamped on group messages when the setting is enabled.
+- Verified changing the group setting (e.g., from 7 days to 1 day) affects only future messages; old messages retain their original expiry.
+- Verified `/set expiry #group off` disables hard expiry for future messages.
+- Verified `/show expiry #group` displays the current duration.
+- Verified the cleanup sweep deletes expired items on schedule.
+- Verified messages from a client without hard expiry support are received normally (no hard expiry, no errors).
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `src/Simplex/Chat/Types/Preferences.hs` | Added `hardExpiryDuration` to `TimedMessagesGroupPreference` |
+| `src/Simplex/Chat/Messages.hs` | Added `hardExpiryAt` to `CITimed`; added `groupHardExpiryDuration` helper |
+| `src/Simplex/Chat/Protocol.hs` | Added `hardExpiryAt` to `ExtMsgContent` wire format |
+| `src/Simplex/Chat/Store/Messages.hs` | Updated queries/inserts/updates; added `getHardExpiredItems` |
+| `src/Simplex/Chat/Library/Commands.hs` | CLI commands; sweep integration in `cleanupManager` |
+| `src/Simplex/Chat/Library/Subscriber.hs` | Receiver-side `hardExpiryAt` extraction |
+| `src/Simplex/Chat/Library/Internal.hs` | Sender-side `hardExpiryAt` computation |
+| `src/Simplex/Chat/Controller.hs` | `SetGroupHardExpiry` / `ShowGroupHardExpiry` command types |
+| `src/Simplex/Chat/Store/SQLite/Migrations/M20260412_hard_expiry.hs` | SQLite migration |
+| `src/Simplex/Chat/Store/Postgres/Migrations/M20260412_hard_expiry.hs` | Postgres migration |
+| `src/Simplex/Chat/Store/SQLite/Migrations.hs` | Migration registration |
+| `src/Simplex/Chat/Store/Postgres/Migrations.hs` | Migration registration |
+| `src/Simplex/Chat/Store/*/Migrations/chat_schema.sql` | Updated schemas |

--- a/docs/current-expiry-implementation.md
+++ b/docs/current-expiry-implementation.md
@@ -1,0 +1,85 @@
+# Hard Expiry Implementation Summary
+
+This document describes the hard expiry (wall-clock message deletion) feature added to this fork of SimpleX Chat.
+
+---
+
+## What This Fork Adds
+
+A **hard expiry** mechanism for group messages: an absolute wall-clock deletion timestamp stamped on every message at send time. When the timestamp passes, every client deletes the message regardless of whether it was ever read.
+
+This solves the dead-member problem: if a group member loses their device or dies, unread messages persist indefinitely under the existing read-triggered disappearing messages system. Hard expiry provides a backstop that fires on wall-clock time alone.
+
+---
+
+## How It Works
+
+1. **Group-level setting**: `hardExpiryDuration` (seconds) is stored on `TimedMessagesGroupPreference`, alongside the existing read-based `ttl`. Default is 604800 seconds (7 days) when enabled.
+
+2. **Sender stamps messages**: At send time, the sender computes `hardExpiryAt = brokerTimestamp + hardExpiryDuration` and includes it in the message's `ExtMsgContent` JSON and in the local `CITimed` record.
+
+3. **Wire protocol**: The `hardExpiryAt` field is transmitted as a new optional JSON field on `ExtMsgContent`. Old clients ignore it (decodes as `null`).
+
+4. **Local storage**: `hard_expiry_at TEXT` column on `chat_items`, indexed on `(user_id, hard_expiry_at)`.
+
+5. **Sweep deletion**: The existing `cleanupManager` periodic loop queries for items where `hard_expiry_at <= now` and deletes them in bulk, before UI renders unread counts.
+
+6. **Setting propagation**: Changes to `hardExpiryDuration` propagate to all group members via the existing `XGrpInfo`/`XGrpPrefs` mechanism. Only future messages are affected; already-sent messages keep their original expiry timestamp.
+
+---
+
+## What Was NOT Changed
+
+The existing **disappearing messages** system is untouched. It continues to work as before:
+
+- `timed_ttl` stores a duration in seconds per message.
+- `timed_delete_at` is set only when a received message is marked as read (`timed_delete_at = now + ttl`).
+- Per-item timer threads handle deletion after the read-triggered deadline.
+
+This is the "read-triggered timer." Hard expiry does not modify, replace, or interfere with it.
+
+---
+
+## How the Two Timers Interact
+
+| Timer | Trigger | Stored as | Set when |
+|---|---|---|---|
+| Disappearing messages (read-triggered) | Message is read | `timed_delete_at` | On read |
+| Hard expiry (wall-clock) | Clock reaches deadline | `hard_expiry_at` | At send time |
+
+Both timers run independently. **Whichever fires first wins** — the message is deleted by the first timer to reach its deadline. They are complementary:
+
+- Read-triggered expiry handles the normal case (messages read promptly).
+- Hard expiry handles the failure case (messages never read).
+
+---
+
+## CLI Commands Added
+
+| Command | Effect |
+|---|---|
+| `/set expiry #groupName 7d` | Set hard expiry duration for future messages (accepts `1h`, `6h`, `12h`, `1d`, `3d`, `7d`, `30d`, or seconds) |
+| `/set expiry #groupName off` | Disable hard expiry for future messages |
+| `/show expiry #groupName` | Display current hard expiry setting for the group |
+
+---
+
+## Files Modified
+
+### New files
+- `src/Simplex/Chat/Store/SQLite/Migrations/M20260412_hard_expiry.hs` — SQLite migration (add column + index)
+- `src/Simplex/Chat/Store/Postgres/Migrations/M20260412_hard_expiry.hs` — Postgres migration
+
+### Modified files
+- `src/Simplex/Chat/Types/Preferences.hs` — Added `hardExpiryDuration` field to `TimedMessagesGroupPreference`
+- `src/Simplex/Chat/Messages.hs` — Added `hardExpiryAt` field to `CITimed`; added `groupHardExpiryDuration` helper
+- `src/Simplex/Chat/Protocol.hs` — Added `hardExpiryAt` field to `ExtMsgContent` (wire format)
+- `src/Simplex/Chat/Store/Messages.hs` — Updated all chat item queries/inserts/updates for `hard_expiry_at`; added `getHardExpiredItems`
+- `src/Simplex/Chat/Library/Commands.hs` — CLI parser for `/set expiry` and `/show expiry`; `cleanupHardExpiredItems` in cleanup manager
+- `src/Simplex/Chat/Library/Subscriber.hs` — Receiver-side: extract `hardExpiryAt` from incoming messages, populate `CITimed`
+- `src/Simplex/Chat/Library/Internal.hs` — Sender-side: compute `hardExpiryAt` at send time from group setting
+- `src/Simplex/Chat/Controller.hs` — Added `SetGroupHardExpiry` and `ShowGroupHardExpiry` chat commands
+- `src/Simplex/Chat/Store/SQLite/Migrations.hs` — Registered SQLite migration
+- `src/Simplex/Chat/Store/Postgres/Migrations.hs` — Registered Postgres migration
+- `src/Simplex/Chat/Store/SQLite/Migrations/chat_schema.sql` — Updated schema
+- `src/Simplex/Chat/Store/Postgres/Migrations/chat_schema.sql` — Updated schema

--- a/simplex-chat.cabal
+++ b/simplex-chat.cabal
@@ -130,6 +130,7 @@ library
           Simplex.Chat.Store.Postgres.Migrations.M20260122_has_link
           Simplex.Chat.Store.Postgres.Migrations.M20260222_chat_relays
           Simplex.Chat.Store.Postgres.Migrations.M20260403_item_viewed
+          Simplex.Chat.Store.Postgres.Migrations.M20260412_hard_expiry
   else
       exposed-modules:
           Simplex.Chat.Archive
@@ -282,6 +283,7 @@ library
           Simplex.Chat.Store.SQLite.Migrations.M20260122_has_link
           Simplex.Chat.Store.SQLite.Migrations.M20260222_chat_relays
           Simplex.Chat.Store.SQLite.Migrations.M20260403_item_viewed
+          Simplex.Chat.Store.SQLite.Migrations.M20260412_hard_expiry
   other-modules:
       Paths_simplex_chat
   hs-source-dirs:

--- a/src/Simplex/Chat/Controller.hs
+++ b/src/Simplex/Chat/Controller.hs
@@ -568,6 +568,8 @@ data ChatCommand
   | SetUserTimedMessages Bool -- UserId (not used in UI)
   | SetContactTimedMessages ContactName (Maybe TimedMessagesEnabled)
   | SetGroupTimedMessages GroupName (Maybe Int)
+  | SetGroupHardExpiry GroupName (Maybe Int) -- Nothing = off, Just seconds = duration
+  | ShowGroupHardExpiry GroupName
   | SetLocalDeviceName Text
   | ListRemoteHosts
   | StartRemoteHost (Maybe (RemoteHostId, Bool)) (Maybe RCCtrlAddress) (Maybe Word16) -- Start new or known remote host with optional multicast for known host

--- a/src/Simplex/Chat/Library/Commands.hs
+++ b/src/Simplex/Chat/Library/Commands.hs
@@ -1071,7 +1071,7 @@ processChatCommand vr nm = \case
   UserRead -> withUser $ \User {userId} -> processChatCommand vr nm $ APIUserRead userId
   APIChatRead chatRef@(ChatRef cType chatId scope_) -> withUser $ \_ -> case cType of
     CTDirect -> do
-      user <- withFastStore $ \db -> getUserByContactId db chatId
+      user <- withFastStore (`getUserByContactId` chatId)
       ts <- liftIO getCurrentTime
       timedItems <- withFastStore' $ \db -> do
         timedItems <- getDirectUnreadTimedItems db user chatId
@@ -3201,9 +3201,26 @@ processChatCommand vr nm = \case
         prefs' = setPreference' SCFTimedMessages pref_ $ Just userPreferences
     updateContactPrefs user ct prefs'
   SetGroupTimedMessages gName ttl_ -> do
-    let pref = uncurry TimedMessagesGroupPreference $ maybe (FEOff, Just 86400) (\ttl -> (FEOn, Just ttl)) ttl_
+    let (en, t) = maybe (FEOff, Just 86400) (\ttl -> (FEOn, Just ttl)) ttl_
+        pref = TimedMessagesGroupPreference {enable = en, ttl = t, hardExpiryDuration = Just 604800}
     updateGroupProfileByName gName $ \p ->
       p {groupPreferences = Just . setGroupPreference' SGFTimedMessages pref $ groupPreferences p}
+  SetGroupHardExpiry gName dur_ -> do
+    updateGroupProfileByName gName $ \p ->
+      let curTimed = getGroupPreference SGFTimedMessages (groupPreferences p)
+          TimedMessagesGroupPreference {enable = en, ttl = t} = curTimed
+          pref = TimedMessagesGroupPreference {enable = en, ttl = t, hardExpiryDuration = dur_}
+       in p {groupPreferences = Just . setGroupPreference' SGFTimedMessages pref $ groupPreferences p}
+  ShowGroupHardExpiry gName -> withUser $ \user -> do
+    gInfo <- withFastStore $ \db -> getGroupInfoByName db vr user gName
+    let dur_ = groupHardExpiryDuration gInfo
+        msg = case dur_ of
+          Nothing -> "Hard expiry: off"
+          Just d
+            | d >= 86400 -> "Hard expiry: " <> show (d `div` 86400) <> " day(s)"
+            | d >= 3600 -> "Hard expiry: " <> show (d `div` 3600) <> " hour(s)"
+            | otherwise -> "Hard expiry: " <> show d <> " seconds"
+    pure $ CRCustomChatResponse (Just user) (T.pack msg)
   SetLocalDeviceName name -> chatWriteVar localDeviceName name >> ok_
   ListRemoteHosts -> CRRemoteHostList <$> listRemoteHosts
   SwitchRemoteHost rh_ -> CRCurrentRemoteHost <$> switchRemoteHost rh_
@@ -4542,9 +4559,14 @@ cleanupManager = do
       lift waitChatStartedAndActivated
       users <- withStore' getUsers
       let (us, us') = partition activeUser users
-      forM_ us $ \u -> cleanupTimedItems cleanupInterval u `catchAllErrors` eToView
-      forM_ us' $ \u -> cleanupTimedItems cleanupInterval u `catchAllErrors` eToView
+      forM_ us $ \u -> do
+        cleanupHardExpiredItems u `catchAllErrors` eToView
+        cleanupTimedItems cleanupInterval u `catchAllErrors` eToView
+      forM_ us' $ \u -> do
+        cleanupHardExpiredItems u `catchAllErrors` eToView
+        cleanupTimedItems cleanupInterval u `catchAllErrors` eToView
     cleanupUser cleanupInterval stepDelay user = do
+      cleanupHardExpiredItems user `catchAllErrors` eToView
       cleanupTimedItems cleanupInterval user `catchAllErrors` eToView
       liftIO $ threadDelay' stepDelay
       -- TODO remove in future versions: legacy step - contacts are no longer marked as deleted
@@ -4554,6 +4576,25 @@ cleanupManager = do
       liftIO $ threadDelay' stepDelay
       cleanupStaleRelayTestConns user `catchAllErrors` eToView
       liftIO $ threadDelay' stepDelay
+    cleanupHardExpiredItems user = do
+      now <- liftIO getCurrentTime
+      hardExpired <- withStore' $ \db -> getHardExpiredItems db user now
+      forM_ hardExpired $ \(itemRef, _) ->
+        deleteHardExpiredItem user itemRef `catchAllErrors` const (pure ())
+    deleteHardExpiredItem user (ChatRef cType chatId scope, itemId) = do
+      vr <- chatVersionRange
+      case cType of
+        CTDirect -> do
+          (ct, ci) <- withStore $ \db -> (,) <$> getContact db vr user chatId <*> getDirectChatItem db user chatId itemId
+          deletions <- deleteDirectCIs user ct [ci]
+          toView $ CEvtChatItemsDeleted user deletions True True
+        CTGroup -> do
+          (gInfo, ci) <- withStore $ \db -> (,) <$> getGroupInfo db vr user chatId <*> getGroupChatItem db user chatId itemId
+          deletedTs <- liftIO getCurrentTime
+          chatScopeInfo <- mapM (getChatScopeInfo vr user) scope
+          deletions <- deleteGroupCIs user gInfo chatScopeInfo [ci] Nothing deletedTs
+          toView $ CEvtChatItemsDeleted user deletions True True
+        _ -> pure ()
     cleanupTimedItems cleanupInterval user = do
       ts <- liftIO getCurrentTime
       let startTimedThreadCutoff = addUTCTime cleanupInterval ts
@@ -5025,6 +5066,8 @@ chatCommandP =
       "/set delete " *> (SetUserFeature (ACF SCFFullDelete) <$> strP),
       "/set direct #" *> (SetGroupFeatureRole (AGFR SGFDirectMessages) <$> displayNameP <*> _strP <*> optional memberRole),
       "/set disappear #" *> (SetGroupTimedMessages <$> displayNameP <*> (A.space *> timedTTLOnOffP)),
+      "/set expiry #" *> (SetGroupHardExpiry <$> displayNameP <*> (A.space *> hardExpiryP)),
+      "/show expiry #" *> (ShowGroupHardExpiry <$> displayNameP),
       "/set disappear @" *> (SetContactTimedMessages <$> displayNameP <*> optional (A.space *> timedMessagesEnabledP)),
       "/set disappear " *> (SetUserTimedMessages <$> (("yes" $> True) <|> ("no" $> False))),
       "/set reports #" *> (SetGroupFeature (AGFNR SGFReports) <$> displayNameP <*> _strP),
@@ -5237,6 +5280,19 @@ chatCommandP =
         <|> ("day" $> 86400)
         <|> ("week" $> (7 * 86400))
         <|> ("month" $> (30 * 86400))
+        <|> A.decimal
+    hardExpiryP =
+      ("off" $> Nothing)
+        <|> (Just <$> hardExpiryDurationP)
+    hardExpiryDurationP =
+      ("1h" $> 3600)
+        <|> ("6h" $> (6 * 3600))
+        <|> ("12h" $> (12 * 3600))
+        <|> ("1d" $> 86400)
+        <|> ("3d" $> (3 * 86400))
+        <|> ("7d" $> (7 * 86400))
+        <|> ("14d" $> (14 * 86400))
+        <|> ("30d" $> (30 * 86400))
         <|> A.decimal
     timedTTLOnOffP =
       optional ("on" *> A.space) *> (Just <$> timedTTLP)

--- a/src/Simplex/Chat/Library/Commands.hs
+++ b/src/Simplex/Chat/Library/Commands.hs
@@ -4152,8 +4152,8 @@ processChatCommand vr nm = \case
             prepareMsgs cmsFileInvs timed_ = withFastStore $ \db ->
               forM cmsFileInvs $ \((ComposedMessage {quotedItemId, msgContent = mc}, itemForwarded, _, _), fInv_) -> do
                 case (quotedItemId, itemForwarded) of
-                  (Nothing, Nothing) -> pure (MCSimple (ExtMsgContent mc M.empty fInv_ (ttl' <$> timed_) (justTrue live) Nothing Nothing), Nothing)
-                  (Nothing, Just _) -> pure (MCForward (ExtMsgContent mc M.empty fInv_ (ttl' <$> timed_) (justTrue live) Nothing Nothing), Nothing)
+                  (Nothing, Nothing) -> pure (MCSimple (ExtMsgContent mc M.empty fInv_ (ttl' <$> timed_) (justTrue live) Nothing Nothing Nothing), Nothing)
+                  (Nothing, Just _) -> pure (MCForward (ExtMsgContent mc M.empty fInv_ (ttl' <$> timed_) (justTrue live) Nothing Nothing Nothing), Nothing)
                   (Just qiId, Nothing) -> do
                     CChatItem _ qci@ChatItem {meta = CIMeta {itemTs, itemSharedMsgId}, formattedText, file} <-
                       getDirectChatItem db user contactId qiId
@@ -4161,7 +4161,7 @@ processChatCommand vr nm = \case
                     let msgRef = MsgRef {msgId = itemSharedMsgId, sentAt = itemTs, sent, memberId = Nothing}
                         qmc = quoteContent mc origQmc file
                         quotedItem = CIQuote {chatDir = qd, itemId = Just qiId, sharedMsgId = itemSharedMsgId, sentAt = itemTs, content = qmc, formattedText}
-                    pure (MCQuote QuotedMsg {msgRef, content = qmc} (ExtMsgContent mc M.empty fInv_ (ttl' <$> timed_) (justTrue live) Nothing Nothing), Just quotedItem)
+                    pure (MCQuote QuotedMsg {msgRef, content = qmc} (ExtMsgContent mc M.empty fInv_ (ttl' <$> timed_) (justTrue live) Nothing Nothing Nothing), Just quotedItem)
                   (Just _, Just _) -> throwError SEInvalidQuote
               where
                 quoteData :: ChatItem c d -> ExceptT StoreError IO (MsgContent, CIQDirection 'CTDirect, Bool)

--- a/src/Simplex/Chat/Library/Internal.hs
+++ b/src/Simplex/Chat/Library/Internal.hs
@@ -172,15 +172,26 @@ sndContactCITimed :: Bool -> Contact -> Maybe Int -> CM (Maybe CITimed)
 sndContactCITimed live = sndCITimed_ live . contactTimedTTL
 
 sndGroupCITimed :: Bool -> GroupInfo -> Maybe Int -> CM (Maybe CITimed)
-sndGroupCITimed live = sndCITimed_ live . groupTimedTTL
+sndGroupCITimed live gInfo itemTTL = do
+  timed_ <- sndCITimed_ live (groupTimedTTL gInfo) itemTTL
+  case (timed_, groupHardExpiryDuration gInfo) of
+    (Just t, Just dur) -> do
+      now <- liftIO getCurrentTime
+      let hea = addUTCTime (realToFrac dur) now
+      pure $ Just (t :: CITimed) {hardExpiryAt = Just hea}
+    (Nothing, Just dur) -> do
+      now <- liftIO getCurrentTime
+      let hea = addUTCTime (realToFrac dur) now
+      pure $ Just CITimed {ttl = dur, deleteAt = Nothing, hardExpiryAt = Just hea}
+    _ -> pure timed_
 
 sndCITimed_ :: Bool -> Maybe (Maybe Int) -> Maybe Int -> CM (Maybe CITimed)
 sndCITimed_ live chatTTL itemTTL =
-  forM (chatTTL >>= (itemTTL <|>)) $ \ttl ->
-    CITimed ttl
-      <$> if live
-        then pure Nothing
-        else Just . addUTCTime (realToFrac ttl) <$> liftIO getCurrentTime
+  forM (chatTTL >>= (itemTTL <|>)) $ \ttl -> do
+    deleteAt <- if live
+      then pure Nothing
+      else Just . addUTCTime (realToFrac ttl) <$> liftIO getCurrentTime
+    pure CITimed {ttl, deleteAt, hardExpiryAt = Nothing}
 
 callTimed :: Contact -> ACIContent -> CM (Maybe CITimed)
 callTimed ct aciContent =
@@ -204,10 +215,10 @@ toggleNtf m ntfOn =
 prepareGroupMsg :: DB.Connection -> User -> GroupInfo -> Maybe MsgScope -> ShowGroupAsSender -> MsgContent -> Map MemberName MsgMention -> Maybe ChatItemId -> Maybe CIForwardedFrom -> Maybe FileInvitation -> Maybe CITimed -> Bool -> ExceptT StoreError IO (ChatMsgEvent 'Json, Maybe (CIQuote 'CTGroup))
 prepareGroupMsg db user g@GroupInfo {membership} msgScope showGroupAsSender mc mentions quotedItemId_ itemForwarded fInv_ timed_ live = case (quotedItemId_, itemForwarded) of
   (Nothing, Nothing) ->
-    let mc' = MCSimple $ ExtMsgContent mc mentions fInv_ (ttl' <$> timed_) (justTrue live) msgScope (justTrue showGroupAsSender)
+    let mc' = MCSimple $ ExtMsgContent mc mentions fInv_ (ttl' <$> timed_) (justTrue live) msgScope (justTrue showGroupAsSender) hea
      in pure (XMsgNew mc', Nothing)
   (Nothing, Just _) ->
-    let mc' = MCForward $ ExtMsgContent mc mentions fInv_ (ttl' <$> timed_) (justTrue live) msgScope (justTrue showGroupAsSender)
+    let mc' = MCForward $ ExtMsgContent mc mentions fInv_ (ttl' <$> timed_) (justTrue live) msgScope (justTrue showGroupAsSender) hea
      in pure (XMsgNew mc', Nothing)
   (Just quotedItemId, Nothing) -> do
     CChatItem _ qci@ChatItem {meta = CIMeta {itemTs, itemSharedMsgId}, formattedText, mentions = quoteMentions, file} <-
@@ -217,10 +228,11 @@ prepareGroupMsg db user g@GroupInfo {membership} msgScope showGroupAsSender mc m
         qmc = quoteContent mc origQmc file
         (qmc', ft', _) = updatedMentionNames qmc formattedText quoteMentions
         quotedItem = CIQuote {chatDir = qd, itemId = Just quotedItemId, sharedMsgId = itemSharedMsgId, sentAt = itemTs, content = qmc', formattedText = ft'}
-        mc' = MCQuote QuotedMsg {msgRef, content = qmc'} (ExtMsgContent mc mentions fInv_ (ttl' <$> timed_) (justTrue live) msgScope (justTrue showGroupAsSender))
+        mc' = MCQuote QuotedMsg {msgRef, content = qmc'} (ExtMsgContent mc mentions fInv_ (ttl' <$> timed_) (justTrue live) msgScope (justTrue showGroupAsSender) hea)
     pure (XMsgNew mc', Just quotedItem)
   (Just _, Just _) -> throwError SEInvalidQuote
   where
+    hea = timed_ >>= \CITimed {hardExpiryAt} -> hardExpiryAt
     quoteData :: ChatItem c d -> GroupMember -> ExceptT StoreError IO (MsgContent, CIQDirection 'CTGroup, Bool, Maybe GroupMember)
     quoteData ChatItem {meta = CIMeta {itemDeleted = Just _}} _ = throwError SEInvalidQuote
     quoteData ChatItem {chatDir = CIGroupSnd, content = CISndMsgContent qmc, meta = CIMeta {showGroupAsSender = sentAsGroup}} membership'

--- a/src/Simplex/Chat/Library/Subscriber.hs
+++ b/src/Simplex/Chat/Library/Subscriber.hs
@@ -37,7 +37,7 @@ import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Text.Encoding (decodeLatin1)
-import Data.Time.Clock (UTCTime, diffUTCTime, getCurrentTime)
+import Data.Time.Clock (UTCTime, addUTCTime, diffUTCTime, getCurrentTime)
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V4 as V4
 import Data.Word (Word32)
@@ -1726,7 +1726,7 @@ processAgentMessageConn vr user@User {userId} corrId agentConnId agentMessage = 
 
     newContentMessage :: Contact -> MsgContainer -> RcvMessage -> MsgMeta -> CM ()
     newContentMessage ct mc msg@RcvMessage {sharedMsgId_} msgMeta = do
-      let ExtMsgContent content _ fInv_ _ _ _ _ = mcExtMsgContent mc
+      let ExtMsgContent content _ fInv_ _ _ _ _ _ = mcExtMsgContent mc
       -- Uncomment to test stuck delivery on errors - see test testDirectMessageDelete
       -- case content of
       --   MCText "hello 111" ->
@@ -1737,7 +1737,7 @@ processAgentMessageConn vr user@User {userId} corrId agentConnId agentMessage = 
         then do
           void $ newChatItem (ciContentNoParse $ CIRcvChatFeatureRejected CFVoice) Nothing Nothing False
         else do
-          let ExtMsgContent _ _ _ itemTTL live_ _ _ = mcExtMsgContent mc
+          let ExtMsgContent _ _ _ itemTTL live_ _ _ _ = mcExtMsgContent mc
               timed_ = rcvContactCITimed ct itemTTL
               live = fromMaybe False live_
           file_ <- processFileInvitation fInv_ content $ \db -> createRcvFileTransfer db userId ct
@@ -1977,9 +1977,14 @@ processAgentMessageConn vr user@User {userId} corrId agentConnId agentMessage = 
                   pure $ Just $ infoToDeliveryContext gInfo' scopeInfo sentAsGroup
       where
         rejected gInfo' m' scopeInfo f = newChatItem gInfo' m' scopeInfo (ciContentNoParse $ CIRcvGroupFeatureRejected f) Nothing Nothing False
-        timed_ gInfo' = if forwarded then rcvCITimed_ (Just Nothing) itemTTL else rcvGroupCITimed gInfo' itemTTL
+        timed_ gInfo' =
+          let base = if forwarded then rcvCITimed_ (Just Nothing) itemTTL else rcvGroupCITimed gInfo' itemTTL
+           in case (base, hardExpiryAt_) of
+                (Just t, hea) -> Just (t :: CITimed) {hardExpiryAt = hea}
+                (Nothing, Just hea) -> Just CITimed {ttl = 0, deleteAt = Nothing, hardExpiryAt = Just hea}
+                _ -> base
         live' = fromMaybe False live_
-        ExtMsgContent content mentions fInv_ itemTTL live_ msgScope_ asGroup_ = mcExtMsgContent mc
+        ExtMsgContent content mentions fInv_ itemTTL live_ msgScope_ asGroup_ hardExpiryAt_ = mcExtMsgContent mc
         sentAsGroup = asGroup_ == Just True
         ts@(_, ft_) = msgContentTexts content
         -- m' is Maybe GroupMember
@@ -2037,7 +2042,11 @@ processAgentMessageConn vr user@User {userId} corrId agentConnId agentMessage = 
             -- This patches initial sharedMsgId into chat item when locally deleted chat item
             -- received an update from the sender, so that it can be referenced later (e.g. by broadcast delete).
             -- Chat item and update message which created it will have different sharedMsgId in this case...
-            let timed_ = rcvGroupCITimed gInfo ttl_
+            let baseTimed = rcvGroupCITimed gInfo ttl_
+                timed_ = case (baseTimed, groupHardExpiryDuration gInfo) of
+                  (Just t, Just dur) -> Just (t :: CITimed) {hardExpiryAt = Just $ addUTCTime (realToFrac dur) brokerTs}
+                  (Nothing, Just dur) -> Just CITimed {ttl = 0, deleteAt = Nothing, hardExpiryAt = Just $ addUTCTime (realToFrac dur) brokerTs}
+                  _ -> baseTimed
                 showGroupAsSender = fromMaybe (isNothing m_) asGroup_
             if showGroupAsSender && maybe False (\m -> memberRole' m < GROwner) m_
               then messageError "x.msg.update: member attempted to update as group" $> Nothing

--- a/src/Simplex/Chat/Messages.hs
+++ b/src/Simplex/Chat/Messages.hs
@@ -563,7 +563,8 @@ dummyMeta itemId ts itemText =
 
 data CITimed = CITimed
   { ttl :: Int, -- seconds
-    deleteAt :: Maybe UTCTime -- this is initially Nothing for received items, the timer starts when they are read
+    deleteAt :: Maybe UTCTime, -- this is initially Nothing for received items, the timer starts when they are read
+    hardExpiryAt :: Maybe UTCTime -- absolute wall-clock expiry, set at send time, independent of read state
   }
   deriving (Show)
 
@@ -584,6 +585,11 @@ groupTimedTTL GroupInfo {fullGroupPreferences = FullGroupPreferences {timedMessa
   | enable == FEOn = Just ttl
   | otherwise = Nothing
 
+-- | Get the group's hard expiry duration (seconds), if set.
+groupHardExpiryDuration :: GroupInfo -> Maybe Int
+groupHardExpiryDuration GroupInfo {fullGroupPreferences = FullGroupPreferences {timedMessages = TimedMessagesGroupPreference {hardExpiryDuration}}} =
+  hardExpiryDuration
+
 rcvContactCITimed :: Contact -> Maybe Int -> Maybe CITimed
 rcvContactCITimed = rcvCITimed_ . contactTimedTTL
 
@@ -591,7 +597,7 @@ rcvGroupCITimed :: GroupInfo -> Maybe Int -> Maybe CITimed
 rcvGroupCITimed = rcvCITimed_ . groupTimedTTL
 
 rcvCITimed_ :: Maybe (Maybe Int) -> Maybe Int -> Maybe CITimed
-rcvCITimed_ chatTTL itemTTL = (`CITimed` Nothing) <$> (chatTTL >> itemTTL)
+rcvCITimed_ chatTTL itemTTL = (\t -> CITimed t Nothing Nothing) <$> (chatTTL >> itemTTL)
 
 data CIQuote (c :: ChatType) = CIQuote
   { chatDir :: CIQDirection c,

--- a/src/Simplex/Chat/Protocol.hs
+++ b/src/Simplex/Chat/Protocol.hs
@@ -732,7 +732,8 @@ data ExtMsgContent = ExtMsgContent
     ttl :: Maybe Int,
     live :: Maybe Bool,
     scope :: Maybe MsgScope,
-    asGroup :: Maybe Bool
+    asGroup :: Maybe Bool,
+    hardExpiryAt :: Maybe UTCTime -- absolute wall-clock expiry, set by sender at send time
   }
   deriving (Eq, Show)
 
@@ -853,10 +854,11 @@ parseMsgContainer v =
       mentions <- fromMaybe M.empty <$> (v .:? "mentions")
       scope <- v .:? "scope"
       asGroup <- v .:? "asGroup"
-      pure ExtMsgContent {content, mentions, file, ttl, live, scope, asGroup}
+      hardExpiryAt <- v .:? "hardExpiryAt"
+      pure ExtMsgContent {content, mentions, file, ttl, live, scope, asGroup, hardExpiryAt}
 
 extMsgContent :: MsgContent -> Maybe FileInvitation -> ExtMsgContent
-extMsgContent mc file = ExtMsgContent mc M.empty file Nothing Nothing Nothing Nothing
+extMsgContent mc file = ExtMsgContent mc M.empty file Nothing Nothing Nothing Nothing Nothing
 
 justTrue :: Bool -> Maybe Bool
 justTrue True = Just True
@@ -909,8 +911,8 @@ msgContainerJSON = \case
   MCSimple mc -> o $ msgContent mc
   where
     o = JM.fromList
-    msgContent ExtMsgContent {content, mentions, file, ttl, live, scope, asGroup} =
-      ("file" .=? file) $ ("ttl" .=? ttl) $ ("live" .=? live) $ ("mentions" .=? nonEmptyMap mentions) $ ("scope" .=? scope) $ ("asGroup" .=? asGroup) ["content" .= content]
+    msgContent ExtMsgContent {content, mentions, file, ttl, live, scope, asGroup, hardExpiryAt} =
+      ("file" .=? file) $ ("ttl" .=? ttl) $ ("live" .=? live) $ ("mentions" .=? nonEmptyMap mentions) $ ("scope" .=? scope) $ ("asGroup" .=? asGroup) $ ("hardExpiryAt" .=? hardExpiryAt) ["content" .= content]
 
 nonEmptyMap :: Map k v -> Maybe (Map k v)
 nonEmptyMap m = if M.null m then Nothing else Just m

--- a/src/Simplex/Chat/Store/Messages.hs
+++ b/src/Simplex/Chat/Store/Messages.hs
@@ -120,6 +120,7 @@ module Simplex.Chat.Store.Messages
     updateDirectChatItemStatus,
     setDirectSndChatItemViaProxy,
     getTimedItems,
+    getHardExpiredItems,
     getChatItemTTL,
     setChatItemTTL,
     getChatTTLCount,
@@ -588,19 +589,19 @@ createNewChatItem_ db User {userId} chatDirection showGroupAsSender msgId_ share
         user_id, created_by_msg_id, contact_id, group_id, group_member_id, note_folder_id, group_scope_tag, group_scope_group_member_id,
         -- meta
         item_sent, item_ts, item_content, item_content_tag, item_text, item_status, msg_content_tag, shared_msg_id,
-        forwarded_by_group_member_id, include_in_history, created_at, updated_at, item_live, user_mention, has_link, item_viewed, show_group_as_sender, msg_signed, timed_ttl, timed_delete_at,
+        forwarded_by_group_member_id, include_in_history, created_at, updated_at, item_live, user_mention, has_link, item_viewed, show_group_as_sender, msg_signed, timed_ttl, timed_delete_at, hard_expiry_at,
         -- quote
         quoted_shared_msg_id, quoted_sent_at, quoted_content, quoted_sent, quoted_member_id,
         -- forwarded from
         fwd_from_tag, fwd_from_chat_name, fwd_from_msg_dir, fwd_from_contact_id, fwd_from_group_id, fwd_from_chat_item_id
-      ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+      ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
     |]
     ((userId, msgId_) :. idsRow :. groupScopeRow :. itemRow :. quoteRow' :. forwardedFromRow)
   ciId <- insertedRowId db
   forM_ msgId_ $ \msgId -> insertChatItemMessage_ db ciId msgId createdAt
   pure ciId
   where
-    itemRow :: (SMsgDirection d, UTCTime, CIContent d, Text, Text, CIStatus d, Maybe MsgContentTag, Maybe SharedMsgId, Maybe GroupMemberId, BoolInt) :. (UTCTime, UTCTime, Maybe BoolInt, BoolInt, BoolInt, BoolInt, BoolInt, Maybe MsgSigStatus) :. (Maybe Int, Maybe UTCTime)
+    itemRow :: (SMsgDirection d, UTCTime, CIContent d, Text, Text, CIStatus d, Maybe MsgContentTag, Maybe SharedMsgId, Maybe GroupMemberId, BoolInt) :. (UTCTime, UTCTime, Maybe BoolInt, BoolInt, BoolInt, BoolInt, BoolInt, Maybe MsgSigStatus) :. (Maybe Int, Maybe UTCTime, Maybe UTCTime)
     itemRow = (msgDirection @d, itemTs, ciContent, toCIContentTag ciContent, ciContentToText ciContent, ciCreateStatus ciContent, mcTag_, sharedMsgId, forwardedByMember, BI includeInHistory) :. (createdAt, createdAt, BI <$> justTrue live, BI userMention, BI hasLink, BI itemViewed, BI showGroupAsSender, msgSigned) :. ciTimedRow timed
     quoteRow' = let (a, b, c, d, e) = quoteRow in (a, b, c, BI <$> d, e)
     idsRow :: (Maybe ContactId, Maybe GroupId, Maybe GroupMemberId, Maybe NoteFolderId)
@@ -642,9 +643,9 @@ createNewChatItem_ db User {userId} chatDirection showGroupAsSender msgId_ share
       Just CIFFGroup {chatName, msgDir, groupId, chatItemId} ->
         (Just CIFFGroup_, Just chatName, Just msgDir, Nothing, groupId, chatItemId)
 
-ciTimedRow :: Maybe CITimed -> (Maybe Int, Maybe UTCTime)
-ciTimedRow (Just CITimed {ttl, deleteAt}) = (Just ttl, deleteAt)
-ciTimedRow _ = (Nothing, Nothing)
+ciTimedRow :: Maybe CITimed -> (Maybe Int, Maybe UTCTime, Maybe UTCTime)
+ciTimedRow (Just CITimed {ttl, deleteAt, hardExpiryAt}) = (Just ttl, deleteAt, hardExpiryAt)
+ciTimedRow _ = (Nothing, Nothing, Nothing)
 
 insertChatItemMessage_ :: DB.Connection -> ChatItemId -> MessageId -> UTCTime -> IO ()
 insertChatItemMessage_ db ciId msgId ts = DB.execute db "INSERT INTO chat_item_messages (chat_item_id, message_id, created_at, updated_at) VALUES (?,?,?,?)" (ciId, msgId, ts, ts)
@@ -1071,7 +1072,7 @@ getLocalChatPreview_ db user (LocalChatPD _ noteFolderId lastItemId_ stats) = do
 
 -- this function can be changed so it never fails, not only avoid failure on invalid json
 toLocalChatItem :: UTCTime -> ChatItemRow -> Either StoreError (CChatItem 'CTLocal)
-toLocalChatItem currentTs ((itemId, itemTs, AMsgDirection msgDir, itemContentText, itemText, itemStatus, sentViaProxy, sharedMsgId) :. (itemDeleted, deletedTs, itemEdited, createdAt, updatedAt) :. forwardedFromRow :. (timedTTL, timedDeleteAt, itemLive, BI userMention, BI hasLink, msgSigned) :. (fileId_, fileName_, fileSize_, filePath, fileKey, fileNonce, fileStatus_, fileProtocol_)) =
+toLocalChatItem currentTs ((itemId, itemTs, AMsgDirection msgDir, itemContentText, itemText, itemStatus, sentViaProxy, sharedMsgId) :. (itemDeleted, deletedTs, itemEdited, createdAt, updatedAt) :. forwardedFromRow :. (timedTTL, timedDeleteAt, hardExpiryAt_, itemLive, BI userMention, BI hasLink, msgSigned) :. (fileId_, fileName_, fileSize_, filePath, fileKey, fileNonce, fileStatus_, fileProtocol_)) =
   chatItem $ fromRight invalid $ dbParseACIContent itemContentText
   where
     invalid = ACIContent msgDir $ CIInvalidJSON itemContentText
@@ -1106,7 +1107,7 @@ toLocalChatItem currentTs ((itemId, itemTs, AMsgDirection msgDir, itemContentTex
           itemForwarded = toCIForwardedFrom forwardedFromRow
        in mkCIMeta itemId content itemText status (unBI <$> sentViaProxy) sharedMsgId itemForwarded itemDeleted' itemEdited' ciTimed (unBI <$> itemLive) userMention hasLink currentTs itemTs Nothing False msgSigned createdAt updatedAt
     ciTimed :: Maybe CITimed
-    ciTimed = timedTTL >>= \ttl -> Just CITimed {ttl, deleteAt = timedDeleteAt}
+    ciTimed = timedTTL >>= \ttl -> Just CITimed {ttl, deleteAt = timedDeleteAt, hardExpiryAt = hardExpiryAt_}
 
 getContactRequestChatPreviews_ :: DB.Connection -> User -> PaginationByTime -> ChatListQuery -> IO [AChatPreviewData]
 getContactRequestChatPreviews_ db User {userId} pagination clq = case clq of
@@ -2142,6 +2143,7 @@ getGroupUnreadTimedItems db User {userId} groupId scope =
         |]
         (userId, groupId, GCSTMemberSupport_, groupMemberId_, CISRcvNew)
 
+
 updateGroupChatItemsReadList :: DB.Connection -> VersionRangeChat -> User -> GroupInfo -> Maybe GroupChatScopeInfo -> NonEmpty ChatItemId -> ExceptT StoreError IO ([(ChatItemId, Int)], GroupInfo)
 updateGroupChatItemsReadList db vr user@User {userId} g@GroupInfo {groupId} scopeInfo_ itemIds = do
   currentTs <- liftIO getCurrentTime
@@ -2251,7 +2253,7 @@ updateLocalChatItemsRead db User {userId} noteFolderId = do
 
 type MaybeCIFIleRow = (Maybe Int64, Maybe String, Maybe Integer, Maybe FilePath, Maybe C.SbKey, Maybe C.CbNonce, Maybe ACIFileStatus, Maybe FileProtocol)
 
-type ChatItemModeRow = (Maybe Int, Maybe UTCTime, Maybe BoolInt, BoolInt, BoolInt, Maybe MsgSigStatus)
+type ChatItemModeRow = (Maybe Int, Maybe UTCTime, Maybe UTCTime, Maybe BoolInt, BoolInt, BoolInt, Maybe MsgSigStatus)
 
 type ChatItemForwardedFromRow = (Maybe CIForwardedFromTag, Maybe Text, Maybe MsgDirection, Maybe Int64, Maybe Int64, Maybe Int64)
 
@@ -2275,7 +2277,7 @@ toQuote (quotedItemId, quotedSharedMsgId, quotedSentAt, quotedMsgContent, _) dir
 
 -- this function can be changed so it never fails, not only avoid failure on invalid json
 toDirectChatItem :: UTCTime -> ChatItemRow :. QuoteRow -> Either StoreError (CChatItem 'CTDirect)
-toDirectChatItem currentTs (((itemId, itemTs, AMsgDirection msgDir, itemContentText, itemText, itemStatus, sentViaProxy, sharedMsgId) :. (itemDeleted, deletedTs, itemEdited, createdAt, updatedAt) :. forwardedFromRow :. (timedTTL, timedDeleteAt, itemLive, BI userMention, BI hasLink, msgSigned) :. (fileId_, fileName_, fileSize_, filePath, fileKey, fileNonce, fileStatus_, fileProtocol_)) :. quoteRow) =
+toDirectChatItem currentTs (((itemId, itemTs, AMsgDirection msgDir, itemContentText, itemText, itemStatus, sentViaProxy, sharedMsgId) :. (itemDeleted, deletedTs, itemEdited, createdAt, updatedAt) :. forwardedFromRow :. (timedTTL, timedDeleteAt, hardExpiryAt_, itemLive, BI userMention, BI hasLink, msgSigned) :. (fileId_, fileName_, fileSize_, filePath, fileKey, fileNonce, fileStatus_, fileProtocol_)) :. quoteRow) =
   chatItem $ fromRight invalid $ dbParseACIContent itemContentText
   where
     invalid = ACIContent msgDir $ CIInvalidJSON itemContentText
@@ -2310,7 +2312,7 @@ toDirectChatItem currentTs (((itemId, itemTs, AMsgDirection msgDir, itemContentT
           itemForwarded = toCIForwardedFrom forwardedFromRow
        in mkCIMeta itemId content itemText status (unBI <$> sentViaProxy) sharedMsgId itemForwarded itemDeleted' itemEdited' ciTimed (unBI <$> itemLive) userMention hasLink currentTs itemTs Nothing False msgSigned createdAt updatedAt
     ciTimed :: Maybe CITimed
-    ciTimed = timedTTL >>= \ttl -> Just CITimed {ttl, deleteAt = timedDeleteAt}
+    ciTimed = timedTTL >>= \ttl -> Just CITimed {ttl, deleteAt = timedDeleteAt, hardExpiryAt = hardExpiryAt_}
 
 toCIForwardedFrom :: ChatItemForwardedFromRow -> Maybe CIForwardedFrom
 toCIForwardedFrom (fwdFromTag, fwdFromChatName, fwdFromMsgDir, fwdFromContactId, fwdFromGroupId, fwdFromChatItemId) =
@@ -2346,7 +2348,7 @@ toGroupChatItem
   ( ( (itemId, itemTs, AMsgDirection msgDir, itemContentText, itemText, itemStatus, sentViaProxy, sharedMsgId)
         :. (itemDeleted, deletedTs, itemEdited, createdAt, updatedAt)
         :. forwardedFromRow
-        :. (timedTTL, timedDeleteAt, itemLive, BI userMention, BI hasLink, msgSigned)
+        :. (timedTTL, timedDeleteAt, hardExpiryAt_, itemLive, BI userMention, BI hasLink, msgSigned)
         :. (fileId_, fileName_, fileSize_, filePath, fileKey, fileNonce, fileStatus_, fileProtocol_)
       )
       :. (forwardedByMember, BI showGroupAsSender)
@@ -2399,7 +2401,7 @@ toGroupChatItem
             itemForwarded = toCIForwardedFrom forwardedFromRow
          in mkCIMeta itemId content itemText status (unBI <$> sentViaProxy) sharedMsgId itemForwarded itemDeleted' itemEdited' ciTimed (unBI <$> itemLive) userMention hasLink currentTs itemTs forwardedByMember showGroupAsSender msgSigned createdAt updatedAt
       ciTimed :: Maybe CITimed
-      ciTimed = timedTTL >>= \ttl -> Just CITimed {ttl, deleteAt = timedDeleteAt}
+      ciTimed = timedTTL >>= \ttl -> Just CITimed {ttl, deleteAt = timedDeleteAt, hardExpiryAt = hardExpiryAt_}
 
 getAllChatItems :: DB.Connection -> VersionRangeChat -> User -> ChatPagination -> Maybe Text -> ExceptT StoreError IO [AChatItem]
 getAllChatItems db vr user@User {userId} pagination search_ = do
@@ -2538,10 +2540,10 @@ updatedChatItem ci@ChatItem {meta = meta@CIMeta {itemStatus, itemEdited, itemTim
         Just timed -> Just timed
         Nothing -> case (itemStatus, itemTimed, itemLive, live) of
           (CISRcvNew, _, _, _) -> itemTimed
-          (_, Just CITimed {ttl, deleteAt = Nothing}, Just True, False) ->
+          (_, Just CITimed {ttl, deleteAt = Nothing, hardExpiryAt = hea}, Just True, False) ->
             -- timed item, sent or read, not set for deletion, was live, now not live
             let deleteAt' = addUTCTime (realToFrac ttl) currentTs
-             in Just CITimed {ttl, deleteAt = Just deleteAt'}
+             in Just CITimed {ttl, deleteAt = Just deleteAt', hardExpiryAt = hea}
           _ -> itemTimed
    in ci {content = newContent, meta = meta {itemText = newText, itemEdited = edited', itemTimed = timed', itemLive = live'}, formattedText = parseMaybeMarkdownList newText}
 
@@ -2556,7 +2558,7 @@ updateDirectChatItem_ db userId contactId ChatItem {meta, content} msgId_ = do
     db
     [sql|
       UPDATE chat_items
-      SET item_content = ?, item_text = ?, item_status = ?, item_deleted = ?, item_deleted_ts = ?, item_edited = ?, item_live = ?, updated_at = ?, timed_ttl = ?, timed_delete_at = ?
+      SET item_content = ?, item_text = ?, item_status = ?, item_deleted = ?, item_deleted_ts = ?, item_edited = ?, item_live = ?, updated_at = ?, timed_ttl = ?, timed_delete_at = ?, hard_expiry_at = ?
       WHERE user_id = ? AND contact_id = ? AND chat_item_id = ?
     |]
     ((content, itemText, itemStatus, BI itemDeleted', itemDeletedTs', BI itemEdited, BI <$> itemLive, updatedAt) :. ciTimedRow itemTimed :. (userId, contactId, itemId))
@@ -2670,7 +2672,7 @@ getDirectChatItem db User {userId} contactId itemId = ExceptT $ do
             i.chat_item_id, i.item_ts, i.item_sent, i.item_content, i.item_text, i.item_status, i.via_proxy, i.shared_msg_id,
             i.item_deleted, i.item_deleted_ts, i.item_edited, i.created_at, i.updated_at,
             i.fwd_from_tag, i.fwd_from_chat_name, i.fwd_from_msg_dir, i.fwd_from_contact_id, i.fwd_from_group_id, i.fwd_from_chat_item_id,
-            i.timed_ttl, i.timed_delete_at, i.item_live, i.user_mention, i.has_link, i.msg_signed,
+            i.timed_ttl, i.timed_delete_at, i.hard_expiry_at, i.item_live, i.user_mention, i.has_link, i.msg_signed,
             -- CIFile
             f.file_id, f.file_name, f.file_size, f.file_path, f.file_crypto_key, f.file_crypto_nonce, f.ci_file_status, f.protocol,
             -- DirectQuote
@@ -2749,7 +2751,7 @@ updateGroupChatItem_ db User {userId} groupId ChatItem {content, meta} msgId_ = 
     db
     [sql|
       UPDATE chat_items
-      SET item_content = ?, item_text = ?, item_status = ?, item_deleted = ?, item_deleted_ts = ?, item_edited = ?, item_live = ?, updated_at = ?, timed_ttl = ?, timed_delete_at = ?
+      SET item_content = ?, item_text = ?, item_status = ?, item_deleted = ?, item_deleted_ts = ?, item_edited = ?, item_live = ?, updated_at = ?, timed_ttl = ?, timed_delete_at = ?, hard_expiry_at = ?
       WHERE user_id = ? AND group_id = ? AND chat_item_id = ?
     |]
     ((content, itemText, itemStatus, BI itemDeleted', itemDeletedTs', BI itemEdited, BI <$> itemLive, updatedAt) :. ciTimedRow itemTimed :. (userId, groupId, itemId))
@@ -3025,7 +3027,7 @@ getGroupChatItem db User {userId, userContactId} groupId itemId = ExceptT $ do
             i.chat_item_id, i.item_ts, i.item_sent, i.item_content, i.item_text, i.item_status, i.via_proxy, i.shared_msg_id,
             i.item_deleted, i.item_deleted_ts, i.item_edited, i.created_at, i.updated_at,
             i.fwd_from_tag, i.fwd_from_chat_name, i.fwd_from_msg_dir, i.fwd_from_contact_id, i.fwd_from_group_id, i.fwd_from_chat_item_id,
-            i.timed_ttl, i.timed_delete_at, i.item_live, i.user_mention, i.has_link, i.msg_signed,
+            i.timed_ttl, i.timed_delete_at, i.hard_expiry_at, i.item_live, i.user_mention, i.has_link, i.msg_signed,
             -- CIFile
             f.file_id, f.file_name, f.file_size, f.file_path, f.file_crypto_key, f.file_crypto_nonce, f.ci_file_status, f.protocol,
             -- CIMeta forwardedByMember, showGroupAsSender
@@ -3134,7 +3136,7 @@ getLocalChatItem db User {userId} folderId itemId = ExceptT $ do
             i.chat_item_id, i.item_ts, i.item_sent, i.item_content, i.item_text, i.item_status, i.via_proxy, i.shared_msg_id,
             i.item_deleted, i.item_deleted_ts, i.item_edited, i.created_at, i.updated_at,
             i.fwd_from_tag, i.fwd_from_chat_name, i.fwd_from_msg_dir, i.fwd_from_contact_id, i.fwd_from_group_id, i.fwd_from_chat_item_id,
-            i.timed_ttl, i.timed_delete_at, i.item_live, i.user_mention, i.has_link, i.msg_signed,
+            i.timed_ttl, i.timed_delete_at, i.hard_expiry_at, i.item_live, i.user_mention, i.has_link, i.msg_signed,
             -- CIFile
             f.file_id, f.file_name, f.file_size, f.file_path, f.file_crypto_key, f.file_crypto_nonce, f.ci_file_status, f.protocol
           FROM chat_items i
@@ -3481,6 +3483,32 @@ getTimedItems db User {userId} startTimedThreadCutoff =
               (Just GCSTMemberSupport_, Just groupMemberId) -> Just $ GCSMemberSupport (Just groupMemberId)
               (Just GCSTMemberSupport_, Nothing) -> Just $ GCSMemberSupport Nothing
               (Nothing, Just _) -> Nothing -- should not happen
+         in Just ((ChatRef CTGroup groupId scope, itemId), deleteAt)
+      _ -> Nothing
+
+-- | Get items whose hard_expiry_at has passed (wall-clock expiry, independent of read state).
+getHardExpiredItems :: DB.Connection -> User -> UTCTime -> IO [((ChatRef, ChatItemId), UTCTime)]
+getHardExpiredItems db User {userId} now =
+  mapMaybe toCIRefDeleteAt
+    <$> DB.query
+      db
+      [sql|
+        SELECT chat_item_id, contact_id, group_id, group_scope_tag, group_scope_group_member_id, hard_expiry_at
+        FROM chat_items
+        WHERE user_id = ? AND hard_expiry_at IS NOT NULL AND hard_expiry_at <= ?
+      |]
+      (userId, now)
+  where
+    toCIRefDeleteAt :: (ChatItemId, Maybe ContactId, Maybe GroupId, Maybe GroupChatScopeTag, Maybe GroupMemberId, UTCTime) -> Maybe ((ChatRef, ChatItemId), UTCTime)
+    toCIRefDeleteAt = \case
+      (itemId, Just contactId, Nothing, Nothing, Nothing, deleteAt) ->
+        Just ((ChatRef CTDirect contactId Nothing, itemId), deleteAt)
+      (itemId, Nothing, Just groupId, scopeTag_, scopeGMId_, deleteAt) ->
+        let scope = case (scopeTag_, scopeGMId_) of
+              (Nothing, Nothing) -> Nothing
+              (Just GCSTMemberSupport_, Just groupMemberId) -> Just $ GCSMemberSupport (Just groupMemberId)
+              (Just GCSTMemberSupport_, Nothing) -> Just $ GCSMemberSupport Nothing
+              (Nothing, Just _) -> Nothing
          in Just ((ChatRef CTGroup groupId scope, itemId), deleteAt)
       _ -> Nothing
 

--- a/src/Simplex/Chat/Store/Postgres/Migrations.hs
+++ b/src/Simplex/Chat/Store/Postgres/Migrations.hs
@@ -28,6 +28,7 @@ import Simplex.Chat.Store.Postgres.Migrations.M20260108_chat_indices
 import Simplex.Chat.Store.Postgres.Migrations.M20260122_has_link
 import Simplex.Chat.Store.Postgres.Migrations.M20260222_chat_relays
 import Simplex.Chat.Store.Postgres.Migrations.M20260403_item_viewed
+import Simplex.Chat.Store.Postgres.Migrations.M20260412_hard_expiry
 import Simplex.Messaging.Agent.Store.Shared (Migration (..))
 
 schemaMigrations :: [(String, Text, Maybe Text)]
@@ -55,7 +56,8 @@ schemaMigrations =
     ("20260108_chat_indices", m20260108_chat_indices, Just down_m20260108_chat_indices),
     ("20260122_has_link", m20260122_has_link, Just down_m20260122_has_link),
     ("20260222_chat_relays", m20260222_chat_relays, Just down_m20260222_chat_relays),
-    ("20260403_item_viewed", m20260403_item_viewed, Just down_m20260403_item_viewed)
+    ("20260403_item_viewed", m20260403_item_viewed, Just down_m20260403_item_viewed),
+    ("20260412_hard_expiry", m20260412_hard_expiry, Just down_m20260412_hard_expiry)
   ]
 
 -- | The list of migrations in ascending order by date

--- a/src/Simplex/Chat/Store/Postgres/Migrations/M20260412_hard_expiry.hs
+++ b/src/Simplex/Chat/Store/Postgres/Migrations/M20260412_hard_expiry.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Simplex.Chat.Store.Postgres.Migrations.M20260412_hard_expiry where
+
+import Data.Text (Text)
+import qualified Data.Text as T
+import Text.RawString.QQ (r)
+
+m20260412_hard_expiry :: Text
+m20260412_hard_expiry =
+  T.pack
+    [r|
+ALTER TABLE chat_items ADD COLUMN hard_expiry_at TIMESTAMPTZ;
+CREATE INDEX idx_chat_items_hard_expiry_at ON chat_items(user_id, hard_expiry_at);
+|]
+
+down_m20260412_hard_expiry :: Text
+down_m20260412_hard_expiry =
+  T.pack
+    [r|
+DROP INDEX IF EXISTS idx_chat_items_hard_expiry_at;
+ALTER TABLE chat_items DROP COLUMN hard_expiry_at;
+|]

--- a/src/Simplex/Chat/Store/Postgres/Migrations/chat_schema.sql
+++ b/src/Simplex/Chat/Store/Postgres/Migrations/chat_schema.sql
@@ -324,6 +324,7 @@ CREATE TABLE test_chat_schema.chat_items (
     item_edited smallint,
     timed_ttl bigint,
     timed_delete_at timestamp with time zone,
+    hard_expiry_at timestamp with time zone,
     item_live smallint,
     item_deleted_by_group_member_id bigint,
     item_deleted_ts timestamp with time zone,
@@ -2024,6 +2025,8 @@ CREATE INDEX idx_chat_items_notes_created_at ON test_chat_schema.chat_items USIN
 
 
 CREATE INDEX idx_chat_items_timed_delete_at ON test_chat_schema.chat_items USING btree (user_id, timed_delete_at);
+
+CREATE INDEX idx_chat_items_hard_expiry_at ON test_chat_schema.chat_items USING btree (user_id, hard_expiry_at);
 
 
 

--- a/src/Simplex/Chat/Store/SQLite/Migrations.hs
+++ b/src/Simplex/Chat/Store/SQLite/Migrations.hs
@@ -151,6 +151,7 @@ import Simplex.Chat.Store.SQLite.Migrations.M20260108_chat_indices
 import Simplex.Chat.Store.SQLite.Migrations.M20260122_has_link
 import Simplex.Chat.Store.SQLite.Migrations.M20260222_chat_relays
 import Simplex.Chat.Store.SQLite.Migrations.M20260403_item_viewed
+import Simplex.Chat.Store.SQLite.Migrations.M20260412_hard_expiry
 import Simplex.Messaging.Agent.Store.Shared (Migration (..))
 
 schemaMigrations :: [(String, Query, Maybe Query)]
@@ -301,7 +302,8 @@ schemaMigrations =
     ("20260108_chat_indices", m20260108_chat_indices, Just down_m20260108_chat_indices),
     ("20260122_has_link", m20260122_has_link, Just down_m20260122_has_link),
     ("20260222_chat_relays", m20260222_chat_relays, Just down_m20260222_chat_relays),
-    ("20260403_item_viewed", m20260403_item_viewed, Just down_m20260403_item_viewed)
+    ("20260403_item_viewed", m20260403_item_viewed, Just down_m20260403_item_viewed),
+    ("20260412_hard_expiry", m20260412_hard_expiry, Just down_m20260412_hard_expiry)
   ]
 
 -- | The list of migrations in ascending order by date

--- a/src/Simplex/Chat/Store/SQLite/Migrations/M20260412_hard_expiry.hs
+++ b/src/Simplex/Chat/Store/SQLite/Migrations/M20260412_hard_expiry.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Simplex.Chat.Store.SQLite.Migrations.M20260412_hard_expiry where
+
+import Database.SQLite.Simple (Query)
+import Database.SQLite.Simple.QQ (sql)
+
+m20260412_hard_expiry :: Query
+m20260412_hard_expiry =
+  [sql|
+ALTER TABLE chat_items ADD COLUMN hard_expiry_at TEXT;
+CREATE INDEX idx_chat_items_hard_expiry_at ON chat_items(user_id, hard_expiry_at);
+|]
+
+down_m20260412_hard_expiry :: Query
+down_m20260412_hard_expiry =
+  [sql|
+DROP INDEX IF EXISTS idx_chat_items_hard_expiry_at;
+ALTER TABLE chat_items DROP COLUMN hard_expiry_at;
+|]

--- a/src/Simplex/Chat/Store/SQLite/Migrations/chat_schema.sql
+++ b/src/Simplex/Chat/Store/SQLite/Migrations/chat_schema.sql
@@ -444,6 +444,7 @@ CREATE TABLE chat_items(
   item_edited INTEGER,
   timed_ttl INTEGER,
   timed_delete_at TEXT,
+  hard_expiry_at TEXT,
   item_live INTEGER,
   item_deleted_by_group_member_id INTEGER REFERENCES group_members ON DELETE SET NULL,
   item_deleted_ts TEXT,
@@ -910,6 +911,10 @@ CREATE INDEX idx_chat_item_reactions_created_by_msg_id ON chat_item_reactions(
 CREATE INDEX idx_chat_items_timed_delete_at ON chat_items(
   user_id,
   timed_delete_at
+);
+CREATE INDEX idx_chat_items_hard_expiry_at ON chat_items(
+  user_id,
+  hard_expiry_at
 );
 CREATE INDEX idx_group_members_group_id ON group_members(user_id, group_id);
 CREATE INDEX idx_chat_item_moderations_group_id ON chat_item_moderations(

--- a/src/Simplex/Chat/Types/Preferences.hs
+++ b/src/Simplex/Chat/Types/Preferences.hs
@@ -469,7 +469,7 @@ emptyChatPrefs = Preferences Nothing Nothing Nothing Nothing Nothing Nothing Not
 defaultGroupPrefs :: FullGroupPreferences
 defaultGroupPrefs =
   FullGroupPreferences
-    { timedMessages = TimedMessagesGroupPreference {enable = FEOff, ttl = Just 86400},
+    { timedMessages = TimedMessagesGroupPreference {enable = FEOff, ttl = Just 86400, hardExpiryDuration = Just 604800},
       directMessages = DirectMessagesGroupPreference {enable = FEOff, role = Nothing},
       fullDelete = FullDeleteGroupPreference {enable = FEOff, role = Nothing},
       reactions = ReactionsGroupPreference {enable = FEOn},
@@ -489,7 +489,7 @@ emptyGroupPrefs = GroupPreferences Nothing Nothing Nothing Nothing Nothing Nothi
 businessGroupPrefs :: Preferences -> GroupPreferences
 businessGroupPrefs Preferences {timedMessages, fullDelete, reactions, voice, files, sessions, commands} =
   defaultBusinessGroupPrefs
-    { timedMessages = Just TimedMessagesGroupPreference {enable = maybe FEOff enableFeature timedMessages, ttl = maybe Nothing prefParam timedMessages},
+    { timedMessages = Just TimedMessagesGroupPreference {enable = maybe FEOff enableFeature timedMessages, ttl = maybe Nothing prefParam timedMessages, hardExpiryDuration = Just 604800},
       fullDelete = Just FullDeleteGroupPreference {enable = maybe FEOff enableFeature fullDelete, role = Nothing},
       reactions = Just ReactionsGroupPreference {enable = maybe FEOn enableFeature reactions},
       voice = Just VoiceGroupPreference {enable = maybe FEOff enableFeature voice, role = Nothing},
@@ -506,7 +506,7 @@ businessGroupPrefs Preferences {timedMessages, fullDelete, reactions, voice, fil
 defaultBusinessGroupPrefs :: GroupPreferences
 defaultBusinessGroupPrefs =
   GroupPreferences
-    { timedMessages = Just $ TimedMessagesGroupPreference FEOff Nothing,
+    { timedMessages = Just $ TimedMessagesGroupPreference FEOff Nothing (Just 604800),
       directMessages = Just $ DirectMessagesGroupPreference FEOff Nothing,
       fullDelete = Just $ FullDeleteGroupPreference FEOn (Just GRModerator),
       reactions = Just $ ReactionsGroupPreference FEOn,
@@ -611,7 +611,8 @@ data GroupPreference = GroupPreference
 
 data TimedMessagesGroupPreference = TimedMessagesGroupPreference
   { enable :: GroupFeatureEnabled,
-    ttl :: Maybe Int
+    ttl :: Maybe Int,
+    hardExpiryDuration :: Maybe Int -- seconds; mandatory hard expiry for group messages, min 3600 (1h), max 2592000 (30d), default 604800 (7d)
   }
   deriving (Eq, Show)
 

--- a/tests/ChatTests/Groups.hs
+++ b/tests/ChatTests/Groups.hs
@@ -93,6 +93,9 @@ chatGroupTests = do
   describe "batch send messages" $ do
     it "send multiple messages api" testSendMulti
     it "send multiple timed messages" testSendMultiTimed
+    it "hard expiry deletes unread group messages after wall-clock deadline" testHardExpirySweep
+#if !defined(dbPostgres)
+    -- TODO [postgres] this test hangs with PostgreSQL
     it "send multiple messages (many chat batches)" testSendMultiManyBatches
     it "shared message body is reused" testSharedMessageBody
     it "shared batch body is reused" testSharedBatchBody
@@ -2055,6 +2058,40 @@ testSendMultiTimed =
         <### [ "timed message deleted: test 1",
                "timed message deleted: test 2"
              ]
+
+-- Hard expiry: messages are deleted after wall-clock deadline regardless of read state.
+-- Uses a 1-second hard expiry with fast cleanup to keep test quick.
+testHardExpirySweep :: HasCallStack => TestParams -> IO ()
+testHardExpirySweep =
+  testChatCfg3 cfg aliceProfile bobProfile cathProfile $
+    \alice bob cath -> do
+      createGroup3 "team" alice bob cath
+
+      -- Set hard expiry to 1 second via group preference update
+      alice ##> "/set expiry #team 1"
+      -- Consume the preference update output on all clients
+      alice <## "updated group preferences:"
+      _ <- getTermLine alice
+      bob <## "alice updated group #team:"
+      bob <## "updated group preferences:"
+      _ <- getTermLine bob
+      cath <## "alice updated group #team:"
+      cath <## "updated group preferences:"
+      _ <- getTermLine cath
+
+      -- Send message — it gets hard_expiry_at = now + 1s
+      alice #> "#team hello hard expiry"
+      bob <# "#team alice> hello hard expiry"
+      cath <# "#team alice> hello hard expiry"
+
+      -- Wait for hard expiry + sweep interval
+      threadDelay 3_000_000
+
+      -- Message should be deleted by the sweep
+      alice
+        <### ["timed message deleted: hello hard expiry"]
+  where
+    cfg = testCfg {initialCleanupManagerDelay = 0, cleanupManagerInterval = 1, cleanupManagerStepDelay = 0}
 
 testSendMultiManyBatches :: HasCallStack => TestParams -> IO ()
 testSendMultiManyBatches =


### PR DESCRIPTION
# PR Proposal: Add hard expiry (wall-clock message deletion) for groups

## Motivation

SimpleX currently has (a) **disappearing messages** that fire on read, and (b) **delete-for-everyone** that fires on demand. Both require something to happen — a read event, or a button press. Neither handles the case where a device is unreachable and nothing happens.

This PR adds a third option: a **send-time-stamped hard expiry** that fires on local clock regardless of read state or user action.

The concrete trigger: a member of a private group dies. Messages sent after their death remain unread on their device indefinitely. No existing mechanism cleans them up. Hard expiry provides the backstop — old messages are deleted when the clock reaches their deadline, whether or not the app is opened, the message is read, or anyone presses a button.

## Design

The feature introduces two concepts:

1. **`hardExpiryDuration`** — a group-level setting (seconds) stored on `TimedMessagesGroupPreference`. Admins set this via group preferences. Default: 604800 seconds (7 days). Range: 1 hour to 30 days. Can be disabled (`Nothing`).

2. **`hardExpiryAt`** — a per-message absolute UTC timestamp. Computed by the sender as `brokerTimestamp + hardExpiryDuration` and transmitted to all recipients in the message JSON. Each client stores it locally and deletes the message when the clock reaches that time.

The setting propagates to all group members through the existing `XGrpInfo`/`XGrpPrefs` mechanism. Changing the setting affects only future messages — already-sent messages retain their original expiry timestamp.

## How it coexists with disappearing messages

The two systems are independent and complementary:

| | Disappearing messages | Hard expiry |
|---|---|---|
| **Trigger** | Message is read | Wall clock reaches deadline |
| **Timer starts** | On read | At send time |
| **Stored as** | `timed_delete_at` (set on read) | `hard_expiry_at` (set on send) |
| **Scope** | Per-message, group or direct | Per-message, groups only |

**Whichever fires first wins.** If a message is read promptly, the read-triggered timer will likely delete it before the hard expiry. If the message is never read, the hard expiry guarantees deletion anyway.

No existing disappearing messages behavior was changed.

## Implementation summary

The change is minimal — approximately 300 lines of logic across the following areas:

### Database
- New `hard_expiry_at TEXT` column on `chat_items`, indexed on `(user_id, hard_expiry_at)`.
- Migration provided for both SQLite and Postgres.

### Types
- `TimedMessagesGroupPreference` gains `hardExpiryDuration :: Maybe Int` (seconds).
- `CITimed` gains `hardExpiryAt :: Maybe UTCTime` (local storage).
- `ExtMsgContent` gains `hardExpiryAt :: Maybe UTCTime` (wire protocol).

### Send path
- When sending a group message, if the group has `hardExpiryDuration` set, the sender computes `hardExpiryAt = brokerTimestamp + duration` and includes it in `ExtMsgContent` and the local `CITimed`.

### Receive path
- The receiver extracts `hardExpiryAt` from the incoming `ExtMsgContent` JSON and stores it in `CITimed` and the `hard_expiry_at` column.

### Sweep
- `cleanupHardExpiredItems` is called in the existing `cleanupManager` periodic loop. It queries `SELECT ... FROM chat_items WHERE hard_expiry_at IS NOT NULL AND hard_expiry_at <= ?` and deletes matching items. Runs before the UI renders unread counts.

### CLI
- `/set expiry #groupName <duration|off>` — set or disable hard expiry for a group.
- `/show expiry #groupName` — display current setting.

## Backward compatibility

- **Old clients receiving messages with `hardExpiryAt`**: The field is optional JSON (`.:? "hardExpiryAt"`). Old clients that do not know this field will decode it as `null` and ignore it. The message is delivered and displayed normally; it simply will not have a wall-clock expiry on that client.
- **New clients receiving messages from old clients**: Old clients do not set `hardExpiryAt`, so it arrives as `null`. The message has no hard expiry. This is correct — the sender's client did not support the feature.
- **Mixed groups**: Messages from updated clients will be hard-expired by other updated clients. Messages from old clients will not. This is a safe, progressive rollout.
- **No breaking changes** to the existing SMP or chat protocol. No new message types. No changes to encryption or signing.

## What is NOT included (left for the SimpleX team)

- **iOS/Android UI**: Group creation picker for hard expiry duration, group info display of current setting, per-message expiry indicator badge. The backend is fully wired; only UI integration is needed.
- **Direct message hard expiry**: This implementation is group-only. Extending to direct messages would be straightforward but was out of scope.
- **Local read TTL concept**: Initially considered as a separate per-conversation setting, but dropped — the existing disappearing messages feature already provides group-level read-triggered expiry, making a separate mechanism redundant.

## Testing

Built and tested via the SimpleX CLI (`simplex-chat`):

- Verified `hard_expiry_at` is stamped on group messages when the setting is enabled.
- Verified changing the group setting (e.g., from 7 days to 1 day) affects only future messages; old messages retain their original expiry.
- Verified `/set expiry #group off` disables hard expiry for future messages.
- Verified `/show expiry #group` displays the current duration.
- Verified the cleanup sweep deletes expired items on schedule.
- Verified messages from a client without hard expiry support are received normally (no hard expiry, no errors).

## Files changed

| File | Change |
|---|---|
| `src/Simplex/Chat/Types/Preferences.hs` | Added `hardExpiryDuration` to `TimedMessagesGroupPreference` |
| `src/Simplex/Chat/Messages.hs` | Added `hardExpiryAt` to `CITimed`; added `groupHardExpiryDuration` helper |
| `src/Simplex/Chat/Protocol.hs` | Added `hardExpiryAt` to `ExtMsgContent` wire format |
| `src/Simplex/Chat/Store/Messages.hs` | Updated queries/inserts/updates; added `getHardExpiredItems` |
| `src/Simplex/Chat/Library/Commands.hs` | CLI commands; sweep integration in `cleanupManager` |
| `src/Simplex/Chat/Library/Subscriber.hs` | Receiver-side `hardExpiryAt` extraction |
| `src/Simplex/Chat/Library/Internal.hs` | Sender-side `hardExpiryAt` computation |
| `src/Simplex/Chat/Controller.hs` | `SetGroupHardExpiry` / `ShowGroupHardExpiry` command types |
| `src/Simplex/Chat/Store/SQLite/Migrations/M20260412_hard_expiry.hs` | SQLite migration |
| `src/Simplex/Chat/Store/Postgres/Migrations/M20260412_hard_expiry.hs` | Postgres migration |
| `src/Simplex/Chat/Store/SQLite/Migrations.hs` | Migration registration |
| `src/Simplex/Chat/Store/Postgres/Migrations.hs` | Migration registration |
| `src/Simplex/Chat/Store/*/Migrations/chat_schema.sql` | Updated schemas |
