### PR TITLE
website: fix horizontal scrollbar on Windows

### DIFF
--- a/website/src/css/design3.css
+++ b/website/src/css/design3.css
@@ -216,6 +216,9 @@ html {
     font-family: GT-Walsheim, Gilroy, Helvetica, sans-serif;
 }
 
+body {
+    overflow-x: hidden;
+}
 
 .dark html,
 .dark body {


### PR DESCRIPTION
Fix horizontal scrollbar on Windows desktop browsers. The CSS variable `--sec-w` uses `100vw` which on Windows includes the vertical scrollbar width, making `.area` a few pixels wider than the body. Added `overflow-x: hidden` on `body` in `design3.css` (only affects the homepage).