### PR TITLE
core, ui: tolerate unknown MsgContentTag in chatContentTypes

### DIFF
--- a/apps/ios/Shared/Model/SimpleXAPI.swift
+++ b/apps/ios/Shared/Model/SimpleXAPI.swift
@@ -458,7 +458,7 @@ func apiGetChat(chatId: ChatId, scope: GroupChatScope?, contentTag: MsgContentTa
 
 func apiGetChatContentTypes(chatId: ChatId, scope: GroupChatScope? = nil) async throws -> [MsgContentTag] {
     let r: ChatResponse0 = try await chatSendCmd(.apiGetChatContentTypes(chatId: chatId, scope: scope))
-    if case let .chatContentTypes(types) = r { return types }
+    if case let .chatContentTypes(types) = r { return types.filter { if case .unknown = $0 { return false }; return true } }
     throw r.unexpected
 }
 

--- a/apps/ios/SimpleXChat/ChatTypes.swift
+++ b/apps/ios/SimpleXChat/ChatTypes.swift
@@ -4773,7 +4773,7 @@ extension MsgContent: Encodable {
     }
 }
 
-public enum MsgContentTag: String, Decodable {
+public enum MsgContentTag: Codable, Hashable {
     case text
     case link
     case image
@@ -4781,6 +4781,43 @@ public enum MsgContentTag: String, Decodable {
     case voice
     case file
     case report
+    case chat
+    case unknown(type: String)
+
+    public var rawValue: String {
+        switch self {
+        case .text: return "text"
+        case .link: return "link"
+        case .image: return "image"
+        case .video: return "video"
+        case .voice: return "voice"
+        case .file: return "file"
+        case .report: return "report"
+        case .chat: return "chat"
+        case let .unknown(type): return type
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let s = try decoder.singleValueContainer().decode(String.self)
+        switch s {
+        case "text": self = .text
+        case "link": self = .link
+        case "image": self = .image
+        case "video": self = .video
+        case "voice": self = .voice
+        case "file": self = .file
+        case "report": self = .report
+        case "chat": self = .chat
+        case "liveText": self = .text
+        default: self = .unknown(type: s)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
 }
 
 public enum MsgChatLink: Codable, Equatable, Hashable {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
@@ -4492,16 +4492,51 @@ object MsgContentSerializer : KSerializer<MsgContent> {
   }
 }
 
-@Serializable
-enum class MsgContentTag {
-  @SerialName("text") Text,
-  @SerialName("link") Link,
-  @SerialName("image") Image,
-  @SerialName("video") Video,
-  @SerialName("voice") Voice,
-  @SerialName("file") File,
-  @SerialName("report") Report,
-  @SerialName("chat") Chat,
+@Serializable(with = MsgContentTagSerializer::class)
+sealed class MsgContentTag {
+  @Serializable @SerialName("text") object Text: MsgContentTag()
+  @Serializable @SerialName("link") object Link: MsgContentTag()
+  @Serializable @SerialName("image") object Image: MsgContentTag()
+  @Serializable @SerialName("video") object Video: MsgContentTag()
+  @Serializable @SerialName("voice") object Voice: MsgContentTag()
+  @Serializable @SerialName("file") object File: MsgContentTag()
+  @Serializable @SerialName("report") object Report: MsgContentTag()
+  @Serializable @SerialName("chat") object Chat: MsgContentTag()
+  @Serializable @SerialName("unknown") data class Unknown(val type: String): MsgContentTag()
+
+  val cmdString: String get() = when (this) {
+    is Text -> "text"
+    is Link -> "link"
+    is Image -> "image"
+    is Video -> "video"
+    is Voice -> "voice"
+    is File -> "file"
+    is Report -> "report"
+    is Chat -> "chat"
+    is Unknown -> type
+  }
+}
+
+object MsgContentTagSerializer : KSerializer<MsgContentTag> {
+  override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("MsgContentTag", PrimitiveKind.STRING)
+
+  override fun deserialize(decoder: Decoder): MsgContentTag =
+    when (val s = decoder.decodeString()) {
+      "text" -> MsgContentTag.Text
+      "link" -> MsgContentTag.Link
+      "image" -> MsgContentTag.Image
+      "video" -> MsgContentTag.Video
+      "voice" -> MsgContentTag.Voice
+      "file" -> MsgContentTag.File
+      "report" -> MsgContentTag.Report
+      "chat" -> MsgContentTag.Chat
+      "liveText" -> MsgContentTag.Text
+      else -> MsgContentTag.Unknown(s)
+    }
+
+  override fun serialize(encoder: Encoder, value: MsgContentTag) {
+    encoder.encodeString(value.cmdString)
+  }
 }
 
 @Serializable

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
@@ -1043,7 +1043,7 @@ object ChatController {
 
   suspend fun apiGetChatContentTypes(rh: Long?, type: ChatType, id: Long, scope: GroupChatScope?): List<MsgContentTag>? {
     val r = sendCmd(rh, CC.ApiGetChatContentTypes(type, id, scope))
-    if (r is API.Result && r.res is CR.ChatContentTypes) return r.res.contentTypes
+    if (r is API.Result && r.res is CR.ChatContentTypes) return r.res.contentTypes.filter { it !is MsgContentTag.Unknown }
     Log.e(TAG, "apiGetChatContentTypes bad response: ${r.responseType} ${r.details}")
     AlertManager.shared.showAlertMsg(generalGetString(MR.strings.error_loading_details), "${r.responseType}: ${r.details}")
     return null
@@ -3790,7 +3790,7 @@ sealed class CC {
       val tag = if (contentTag == null) {
         ""
       } else {
-        " content=${contentTag.name.lowercase()}"
+        " content=${contentTag.cmdString}"
       }
       "/_get chat ${chatRef(type, id, scope)}$tag ${pagination.cmdString}" + (if (search == "") "" else " search=$search")
     }


### PR DESCRIPTION
## Summary
- Fixes the error opening a group containing items with unknown or legacy `msg_content_tag` values (e.g. `"liveText"`). Strict enum decoding of `List<MsgContentTag>` in `apiGetChatContentTypes` was failing on the whole response; backend already round-trips unknowns via `MCUnknown_`, so the clients now do the same.
- Follows the open-union pattern used by `GroupType` / `ReportReason`: preserve the original type string in the `Unknown` variant so it round-trips instead of collapsing to a sentinel.
- Multiplatform (Kotlin): `MsgContentTag` becomes a `sealed class` with `object` cases for known tags and `data class Unknown(val type: String)`; custom `MsgContentTagSerializer` maps `"liveText"` → `Text` and wraps everything else in `Unknown(s)`. `apiGetChatContentTypes` filters out `Unknown`.
- iOS (Swift): `MsgContentTag` becomes a `Codable, Hashable` enum with `case unknown(type: String)`; `rawValue` retained as a computed property so existing call sites compile unchanged. `"liveText"` → `.text`; `.chat` case added for parity with backend/multiplatform. `apiGetChatContentTypes` filters out `.unknown`.

## Test plan
- [ ] Open a group that contains a message with an unknown/legacy `msg_content_tag` on Android — group opens without the "Error loading details: chatContentTypes" error.
- [ ] Repeat on iOS.
- [ ] Regression: open a normal group — content types load unchanged, no unknowns shown.