### PR TITLE
simplex-chat-nodejs: mute benign group-member teardown errors

### DIFF
--- a/packages/simplex-chat-nodejs/src/api.ts
+++ b/packages/simplex-chat-nodejs/src/api.ts
@@ -56,6 +56,32 @@ interface EventSubscriber<K extends CEvt.Tag> {
   once: boolean
 }
 
+// Mirrors src/Simplex/Chat/View.hs:2632 ("-- mutes delete group error"): the
+// Haskell CLI hides SEConnectionNotFound at default log level because it fires
+// benignly during group-member teardown. The Node SDK has no log-level knob,
+// so we mute the two exact error shapes that originate from that teardown path:
+//   1. ChatError.ErrorStore { storeError: { type: "connectionNotFound", ... } }
+//      Emitted via getChatLockEntity (Connections.hs:54) / getConnectionEntity
+//      (Connections.hs:93) when an async agent event references a connection
+//      whose row was just deleted by deleteMembersConnections'.
+//   2. ChatError.ErrorAgent with empty agentConnId + CONN NOT_FOUND.
+//      Emitted at Subscriber.hs:112 (processAgentMessage _ _ "" (ERR e)) when
+//      the SMP agent sends a bulk ERR after teardown.
+function isMutedChatError(err: T.ChatError): boolean {
+  if (err.type === "errorStore" && err.storeError.type === "connectionNotFound") {
+    return true
+  }
+  if (
+    err.type === "errorAgent" &&
+    err.agentConnId === "" &&
+    err.agentError.type === "CONN" &&
+    err.agentError.connErr.type === "NOT_FOUND"
+  ) {
+    return true
+  }
+  return false
+}
+
 /**
  * Main API class for interacting with the chat core library.
  */
@@ -147,6 +173,7 @@ export class ChatApi {
       } catch(err) {
         const e = err as core.ChatAPIError
         if ("chatError" in e) {
+          if (e.chatError && isMutedChatError(e.chatError)) continue
           console.log("Chat error", e.chatError)
         } else {
           console.log("Invalid event", e)


### PR DESCRIPTION
## Summary

- The Haskell CLI already mutes `SEConnectionNotFound` at default log level (`View.hs:2632`, comment: `-- mutes delete group error`). The Node SDK had no equivalent filter, so `apiRemoveMembers` / `apiLeaveGroup` calls logged two noisy but harmless errors:
  - `ErrorStore { storeError: { type: "connectionNotFound" } }` — DB row deleted by `deleteMembersConnections'` before an async agent event references it
  - `ErrorAgent { agentConnId: "", agentError: { type: "CONN", connErr: { type: "NOT_FOUND" } } }` — bulk SMP agent ERR after teardown (`Subscriber.hs:112`)
- Adds `isMutedChatError()` helper that skips these two exact error shapes in the event loop `catch` block, matching the CLI's default behavior
- All other `ChatError` shapes continue to log normally

## Changes

`packages/simplex-chat-nodejs/src/api.ts` only:
1. New `isMutedChatError(err: T.ChatError): boolean` function after the `EventSubscriber` interface
2. One-line guard `if (e.chatError && isMutedChatError(e.chatError)) continue` in `runEventsLoop` catch block

## Test plan

- [ ] `npx tsc --noEmit` passes in `packages/simplex-chat-nodejs`
- [ ] Existing SDK tests pass (`packages/simplex-chat-nodejs/tests/api.test.ts`)
- [ ] Live bot run: trigger Grok removal → confirm no `Chat error` lines for the two muted shapes
- [ ] Live bot run: confirm other chat errors still log normally