### PR TITLE
desktop: fix sending files with + in file name

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/platform/Files.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/platform/Files.kt
@@ -9,6 +9,8 @@ import com.charleskorn.kaml.*
 import kotlinx.serialization.encodeToString
 import java.io.*
 import java.net.URI
+import java.net.URLDecoder
+import java.net.URLEncoder
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 
@@ -38,9 +40,11 @@ expect fun desktopOpenDatabaseDir()
 
 expect fun desktopOpenDir(dir: File)
 
-fun createURIFromPath(absolutePath: String): URI = File(absolutePath).toURI()
+fun createURIFromPath(absolutePath: String): URI = URI.create(URLEncoder.encode(absolutePath, "UTF-8"))
 
-fun URI.toFile(): File = File(path)
+fun URI.toFile(): File =
+  if (scheme == "file") File(this)
+  else File(URLDecoder.decode(rawPath, "UTF-8").removePrefix("file:"))
 
 fun copyFileToFile(from: File, to: URI, finally: () -> Unit) {
   try {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/platform/Files.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/platform/Files.kt
@@ -9,8 +9,6 @@ import com.charleskorn.kaml.*
 import kotlinx.serialization.encodeToString
 import java.io.*
 import java.net.URI
-import java.net.URLDecoder
-import java.net.URLEncoder
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 
@@ -40,9 +38,9 @@ expect fun desktopOpenDatabaseDir()
 
 expect fun desktopOpenDir(dir: File)
 
-fun createURIFromPath(absolutePath: String): URI = URI.create(URLEncoder.encode(absolutePath, "UTF-8"))
+fun createURIFromPath(absolutePath: String): URI = File(absolutePath).toURI()
 
-fun URI.toFile(): File = File(URLDecoder.decode(rawPath, "UTF-8").removePrefix("file:"))
+fun URI.toFile(): File = File(path)
 
 fun copyFileToFile(from: File, to: URI, finally: () -> Unit) {
   try {


### PR DESCRIPTION
Use RFC 3986 URI encoding (File.toURI()) instead of application/x-www-form-urlencoded (URLEncoder/URLDecoder) for file path URIs. URLDecoder treated literal + as space, corrupting filenames containing + on desktop.