### PR TITLE
website: oklch gradients with two-layer cyan-yellow transition

### DIFF
--- a/website/src/css/design3.css
+++ b/website/src/css/design3.css
@@ -136,11 +136,9 @@
 }
 
 :root {
-    --bg-grad: linear-gradient(10deg,
-            #e8f3ff 0%,
-            #c0e2ff 40%,
-            #e9ffff 80%,
-            #ffefd6 90%);
+    --bg-grad:
+            linear-gradient(10deg, transparent 83%, #ffefd6 90%),
+            linear-gradient(in oklch 10deg, #e8f3ff 0%, #c0e2ff 40%, #e9ffff 82%, #e0fff0 92%);
 
     /* Compute cover drawn size and inner safe frame (60% of full image on each axis) */
     /* --cover-bg-w: calc(min((3200 / 1920) * 100vw, (3200 / 1080) * 100vh));
@@ -163,21 +161,16 @@
 }
 
 :root.dark {
-    --bg-grad: linear-gradient(9.2deg,
-            #000000 0%,
-            #131d49 52%,
-            #3f5598 65%,
-            #c3faff 85%,
-            #fff6e0 90%);
+    --bg-grad:
+            linear-gradient(9.2deg, transparent 87%, #fff6e0 92%),
+            linear-gradient(in oklch 9.2deg, #000000 0%, #131d49 52%, #3f5598 65%, #c3faff 85%, #e0fff0 92%);
 }
 
 @media screen and (max-width: 959px) {
     :root {
-        --bg-grad: linear-gradient(30deg,
-                #e8f3ff 0%,
-                #c0e2ff 40%,
-                #e9ffff 80%,
-                #ffefd6 90%);
+        --bg-grad:
+                linear-gradient(30deg, transparent 83%, #ffefd6 90%),
+                linear-gradient(in oklch 30deg, #e8f3ff 0%, #c0e2ff 40%, #e9ffff 82%, #e0fff0 92%);
 
         /* Cover background for mobile */
         --cover-bg-w: calc(min((3200 / 620) * 100vw, (3200 / 1080) * 100vh));
@@ -191,12 +184,9 @@
     }
 
     :root.dark {
-        --bg-grad: linear-gradient(30deg,
-                #000000 0%,
-                #131d49 52%,
-                #3f5598 65%,
-                #c3faff 85%,
-                #fff6e0 90%);
+        --bg-grad:
+                linear-gradient(30deg, transparent 87%, #fff6e0 92%),
+                linear-gradient(in oklch 30deg, #000000 0%, #131d49 52%, #3f5598 65%, #c3faff 85%, #e0fff0 92%);
     }
 }
 


### PR DESCRIPTION
Background gradients switched to oklch interpolation for smoother blue-cyan transitions. The cyan-to-yellow segment uses two stacked gradients — sRGB yellow overlay on top of oklch blue-cyan base — to avoid the green hue shift that oklch produces when interpolating between distant hues.