### PR TITLE
android: fix tap outside retry connection error in QR scan

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
@@ -58,6 +58,7 @@ import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.*
+import java.util.concurrent.atomic.AtomicBoolean
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.util.Date
@@ -723,14 +724,20 @@ object ChatController {
     val alert = if (r is API.Error) retryableNetworkErrorAlert(r.err) else null
     if ((inProgress == null || inProgress.value) && alert != null) {
       return suspendCancellableCoroutine { cont ->
+        val resumed = AtomicBoolean(false)
+        fun safeResume(result: Result<API?>) {
+          if (resumed.compareAndSet(false, true)) {
+            cont.resumeWith(result)
+          }
+        }
         showRetryAlert(
           alert,
           onCancel = {
-            cont.resumeWith(Result.success(null))
+            safeResume(Result.success(null))
           },
           onRetry = {
             withLongRunningApi {
-              cont.resumeWith(
+              safeResume(
                 runCatching {
                   coroutineScope {
                     sendCmdWithRetry(rhId, cmd, inProgress = inProgress, retryNum = retryNum + 1)
@@ -742,7 +749,7 @@ object ChatController {
         )
 
         cont.invokeOnCancellation {
-          cont.resumeWith(Result.success(null))
+          safeResume(Result.success(null))
         }
       }
     } else {


### PR DESCRIPTION
Tapping outside of connection error alert produces error

1. Scan 1-time link on Android with internet off:
2. Server connection error shows correctly
3. Tap outside error popup (May need to spam click retry on error multiple times in some cases and may not reproduce on some older Android versions)
4. Get new error popup:

java.lang.IllegalStateException: Already resumed, but proposed with update null
  at kotlinx.coroutines.CancellableContinuationImpl.alreadyResumedError(CancellableContinuationImpl.kt:551)
..... (line 64 in tests)

Same issue on group link QR scan