### PR TITLE
ui: fix 17 translation issues from PR #6881 review (es, zh, de, it, ar, ru)

### DIFF
--- a/apps/ios/SimpleX Localizations/de.xcloc/Localized Contents/de.xliff
+++ b/apps/ios/SimpleX Localizations/de.xcloc/Localized Contents/de.xliff
@@ -242,7 +242,7 @@ channel relay bar progress</note>
       </trans-unit>
       <trans-unit id="%d/%d relays active, %d failed" xml:space="preserve">
         <source>%1$d/%2$d relays active, %3$d failed</source>
-        <target>%1$d/%2$d Relais aktiv, %3$d Fehlgeschlagen</target>
+        <target>%1$d/%2$d Relais aktiv, %3$d fehlgeschlagen</target>
         <note>channel creation progress with errors
 channel relay bar</note>
       </trans-unit>
@@ -10339,7 +10339,7 @@ Verbindungsanfrage wiederholen?</target>
       <trans-unit id="Your profile **%@** will be shared with channel relays and subscribers.&#10;Relays can access channel messages." xml:space="preserve">
         <source>Your profile **%@** will be shared with channel relays and subscribers.
 Relays can access channel messages.</source>
-        <target>Ihr Profil %@ wird mit Kanal‑Relais und Abonnenten geteilt.
+        <target>Ihr Profil **%@** wird mit Kanal‑Relais und Abonnenten geteilt.
 Relais können auf Kanalnachrichten zugreifen.</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>

--- a/apps/ios/SimpleX Localizations/es.xcloc/Localized Contents/es.xliff
+++ b/apps/ios/SimpleX Localizations/es.xcloc/Localized Contents/es.xliff
@@ -232,7 +232,7 @@ channel subscriber relay bar</note>
       </trans-unit>
       <trans-unit id="%d/%d relays active" xml:space="preserve">
         <source>%1$d/%2$d relays active</source>
-        <target>%1$d%2$d servidores activos</target>
+        <target>%1$d/%2$d servidores activos</target>
         <note>channel creation progress
 channel relay bar progress</note>
       </trans-unit>
@@ -242,7 +242,7 @@ channel relay bar progress</note>
       </trans-unit>
       <trans-unit id="%d/%d relays active, %d failed" xml:space="preserve">
         <source>%1$d/%2$d relays active, %3$d failed</source>
-        <target>%1$d%2$d servidores activos, %3$d han fallado</target>
+        <target>%1$d/%2$d servidores activos, %3$d han fallado</target>
         <note>channel creation progress with errors
 channel relay bar</note>
       </trans-unit>
@@ -252,12 +252,12 @@ channel relay bar</note>
       </trans-unit>
       <trans-unit id="%d/%d relays connected" xml:space="preserve">
         <source>%1$d/%2$d relays connected</source>
-        <target>%1$d%2$d servidores conectados</target>
+        <target>%1$d/%2$d servidores conectados</target>
         <note>channel subscriber relay bar progress</note>
       </trans-unit>
       <trans-unit id="%d/%d relays connected, %d errors" xml:space="preserve">
         <source>%1$d/%2$d relays connected, %3$d errors</source>
-        <target>%1$d%2$d servidores conectados, %3$d errores</target>
+        <target>%1$d/%2$d servidores conectados, %3$d errores</target>
         <note>channel subscriber relay bar</note>
       </trans-unit>
       <trans-unit id="%d/%d relays connected, %d failed" xml:space="preserve">
@@ -1707,7 +1707,7 @@ alert subtitle</note>
       </trans-unit>
       <trans-unit id="Channel profile is stored on subscribers' devices and on the chat relays." xml:space="preserve">
         <source>Channel profile is stored on subscribers' devices and on the chat relays.</source>
-        <target>El perfil del canal se almacena en los dispositivos de los suscroptores y en los servidores de chat.</target>
+        <target>El perfil del canal se almacena en los dispositivos de los suscriptores y en los servidores de chat.</target>
         <note>No comment provided by engineer.</note>
       </trans-unit>
       <trans-unit id="Channel profile was changed. If you save it, the updated profile will be sent to channel subscribers." xml:space="preserve">
@@ -7982,7 +7982,7 @@ chat item action</note>
       </trans-unit>
       <trans-unit id="Server requires authorization to connect to relay, check password." xml:space="preserve">
         <source>Server requires authorization to connect to relay, check password.</source>
-        <target>El servidor requere autorización para conectar con el servidor, comprueba la contraseña.</target>
+        <target>El servidor requiere autorización para conectar con el servidor, comprueba la contraseña.</target>
         <note>relay test error</note>
       </trans-unit>
       <trans-unit id="Server requires authorization to create queues, check password." xml:space="preserve">

--- a/apps/ios/SimpleX Localizations/it.xcloc/Localized Contents/it.xliff
+++ b/apps/ios/SimpleX Localizations/it.xcloc/Localized Contents/it.xliff
@@ -3342,7 +3342,7 @@ chat item action</note>
       </trans-unit>
       <trans-unit id="Enable at least one chat relay in Network &amp; Servers." xml:space="preserve">
         <source>Enable at least one chat relay in Network &amp; Servers.</source>
-        <target>Attiva almeno un relayvdi chat in "Rete e server".</target>
+        <target>Attiva almeno un relay di chat in "Rete e server".</target>
         <note>channel creation warning</note>
       </trans-unit>
       <trans-unit id="Enable automatic message deletion?" xml:space="preserve">

--- a/apps/ios/de.lproj/Localizable.strings
+++ b/apps/ios/de.lproj/Localizable.strings
@@ -202,7 +202,7 @@ channel relay bar progress */
 
 /* channel creation progress with errors
 channel relay bar */
-"%d/%d relays active, %d failed" = "%1$d/%2$d Relais aktiv, %3$d Fehlgeschlagen";
+"%d/%d relays active, %d failed" = "%1$d/%2$d Relais aktiv, %3$d fehlgeschlagen";
 
 /* channel subscriber relay bar progress */
 "%d/%d relays connected" = "%1$d/%2$d Relais verbunden";
@@ -6696,7 +6696,7 @@ server test failure */
 "Your profile" = "Mein Profil";
 
 /* No comment provided by engineer. */
-"Your profile **%@** will be shared with channel relays and subscribers.\nRelays can access channel messages." = "Ihr Profil %@ wird mit Kanal‑Relais und Abonnenten geteilt.\nRelais können auf Kanalnachrichten zugreifen.";
+"Your profile **%@** will be shared with channel relays and subscribers.\nRelays can access channel messages." = "Ihr Profil **%@** wird mit Kanal‑Relais und Abonnenten geteilt.\nRelais können auf Kanalnachrichten zugreifen.";
 
 /* No comment provided by engineer. */
 "Your profile **%@** will be shared." = "Ihr Profil **%@** wird geteilt.";

--- a/apps/ios/es.lproj/Localizable.strings
+++ b/apps/ios/es.lproj/Localizable.strings
@@ -198,17 +198,17 @@
 
 /* channel creation progress
 channel relay bar progress */
-"%d/%d relays active" = "%1$d%2$d servidores activos";
+"%d/%d relays active" = "%1$d/%2$d servidores activos";
 
 /* channel creation progress with errors
 channel relay bar */
-"%d/%d relays active, %d failed" = "%1$d%2$d servidores activos, %3$d han fallado";
+"%d/%d relays active, %d failed" = "%1$d/%2$d servidores activos, %3$d han fallado";
 
 /* channel subscriber relay bar progress */
-"%d/%d relays connected" = "%1$d%2$d servidores conectados";
+"%d/%d relays connected" = "%1$d/%2$d servidores conectados";
 
 /* channel subscriber relay bar */
-"%d/%d relays connected, %d errors" = "%1$d%2$d servidores conectados, %3$d errores";
+"%d/%d relays connected, %d errors" = "%1$d/%2$d servidores conectados, %3$d errores";
 
 /* No comment provided by engineer. */
 "%lld" = "%lld";
@@ -1095,7 +1095,7 @@ set passcode view */
 "Channel profile" = "Perfil del canal";
 
 /* No comment provided by engineer. */
-"Channel profile is stored on subscribers' devices and on the chat relays." = "El perfil del canal se almacena en los dispositivos de los suscroptores y en los servidores de chat.";
+"Channel profile is stored on subscribers' devices and on the chat relays." = "El perfil del canal se almacena en los dispositivos de los suscriptores y en los servidores de chat.";
 
 /* snd group event chat item */
 "channel profile updated" = "perfil del canal actualizado";
@@ -5181,7 +5181,7 @@ chat item action */
 "server queue info: %@\n\nlast received msg: %@" = "información cola del servidor: %1$@\n\núltimo mensaje recibido: %2$@";
 
 /* relay test error */
-"Server requires authorization to connect to relay, check password." = "El servidor requere autorización para conectar con el servidor, comprueba la contraseña.";
+"Server requires authorization to connect to relay, check password." = "El servidor requiere autorización para conectar con el servidor, comprueba la contraseña.";
 
 /* server test error */
 "Server requires authorization to create queues, check password." = "El servidor requiere autorización para crear colas, comprueba la contraseña.";

--- a/apps/ios/it.lproj/Localizable.strings
+++ b/apps/ios/it.lproj/Localizable.strings
@@ -2159,7 +2159,7 @@ chat item action */
 "Enable (keep overrides)" = "Attiva (mantieni sostituzioni)";
 
 /* channel creation warning */
-"Enable at least one chat relay in Network & Servers." = "Attiva almeno un relayvdi chat in \"Rete e server\".";
+"Enable at least one chat relay in Network & Servers." = "Attiva almeno un relay di chat in \"Rete e server\".";
 
 /* alert title */
 "Enable automatic message deletion?" = "Attivare l'eliminazione automatica dei messaggi?";

--- a/apps/multiplatform/common/src/commonMain/resources/MR/ar/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/ar/strings.xml
@@ -2655,7 +2655,7 @@
     <string name="relay_section_footer_subscriber">لقد اتصلت بالقناة عبر رابط المُرحل هذا.</string>
     <string name="chat_banner_your_channel">قناتك</string>
     <string name="connect_plan_this_is_your_link_for_channel">قناتك</string>
-    <string name="your_profile_shared_with_channel_relays">سيتم مشاركة ملف تعريفك %1$s مع مُرحلات الفناة والمشتركين.\nيمكن للمُرحلات الوصول إلى رسائل القناة.</string>
+    <string name="your_profile_shared_with_channel_relays">سيتم مشاركة ملف تعريفك %1$s مع مُرحلات القناة والمشتركين.\nيمكن للمُرحلات الوصول إلى رسائل القناة.</string>
     <string name="your_relay_address">عنوان مُرحلك</string>
     <string name="your_relay_name">اسم مُرحلك</string>
     <string name="you_will_stop_receiving_messages_from_this_channel_chat_history_will_be_preserved">ستتوقف عن تلقي الرسائل من هذه القناة، وسيتم الاحتفاظ بسجل الدردشة.</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/de/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/de/strings.xml
@@ -176,7 +176,7 @@
     <string name="group_preview_you_are_invited">Sie sind zu der Gruppe eingeladen</string>
     <string name="group_preview_join_as">Beitreten als %s</string>
     <string name="group_connection_pending">verbinde …</string>
-    <string name="tap_to_start_new_chat">Tippen, um einen neuen Chats zu starten</string>
+    <string name="tap_to_start_new_chat">Tippen, um einen neuen Chat zu starten</string>
     <string name="chat_with_developers">Chatten Sie mit den Entwicklern</string>
     <string name="you_have_no_chats">Sie haben keine Chats</string>
     <!-- ShareListView.kt -->
@@ -2633,7 +2633,7 @@
     <string name="member_info_member_failed">Fehlgeschlagen</string>
     <string name="down_migration_warning_chat_relays">Kanäle, welche Sie erstellt haben oder denen Sie beigetreten sind, werden dauerhaft deaktiviert.</string>
     <string name="relay_bar_active">%1$d/%2$d Relais aktiv</string>
-    <string name="relay_bar_active_with_failures">%1$d/%2$d Relais aktiv, %3$d Fehlgeschlagen</string>
+    <string name="relay_bar_active_with_failures">%1$d/%2$d Relais aktiv, %3$d fehlgeschlagen</string>
     <string name="relay_bar_connected">%1$d/%2$d Relais verbunden</string>
     <string name="relay_bar_connected_with_errors">%1$d/%2$d Relais verbunden, %3$d Fehler</string>
     <string name="channel_subscriber_count_singular">%1$d Abonnent</string>
@@ -2798,12 +2798,12 @@
     <string name="a_link_for_one_person">Ein Link für eine einzelne Person zum Verbinden.</string>
     <string name="chat_list_channels">Kanäle</string>
     <string name="connect_via_link_or_qr_code">Über einen Link oder QR-Code verbinden</string>
-    <string name="connect_with_someone">Mit Jemandem verbinden</string>
+    <string name="connect_with_someone">Mit jemandem verbinden</string>
     <string name="create_your_public_address">Erstellen Sie Ihre öffentliche Adresse</string>
     <string name="v6_5_invite_friends">Freunde einladen – jetzt noch einfacher 👋</string>
     <string name="for_anyone_to_reach_you">Damit Sie jeder erreichen kann</string>
     <string name="invite_someone_privately">Jemanden privat einladen</string>
-    <string name="let_someone_connect_to_you">Damit sich Jemand mit Ihnen verbinden kann</string>
+    <string name="let_someone_connect_to_you">Damit sich jemand mit Ihnen verbinden kann</string>
     <string name="new_1_time_link">Neuer Einmal-Link</string>
     <string name="v6_5_non_profit_governance">Non‑Profit‑Governance</string>
     <string name="v6_5_safe_web_links_descr">- Opt‑in zum Senden von Linkvorschauen.\n- Hyperlink‑Phishing verhindern.\n- Link‑Tracking entfernen.</string>
@@ -2811,12 +2811,12 @@
     <string name="onboarding_or_use_qr_code">Oder diesen QR‑Code verwenden – ausgedruckt oder online.</string>
     <string name="v6_5_ownership">Volle Kontrolle: Sie können Ihre eigenen Relais betreiben.</string>
     <string name="v6_5_privacy">Privatsphäre: für Besitzer und Abonnenten.</string>
-    <string name="v6_5_public_channels">Öffentliche Kanäle – freies kommunizieren 🚀</string>
+    <string name="v6_5_public_channels">Öffentliche Kanäle – freies Kommunizieren 🚀</string>
     <string name="v6_5_reliability">Zuverlässigkeit: mehrere Relais pro Kanal.</string>
     <string name="v6_5_safe_web_links">Sichere Web-Links</string>
     <string name="v6_5_security">Sicherheit: Eigentümer besitzen die Kanalschlüssel.</string>
     <string name="onboarding_send_1_time_link">Den Link über einen beliebigen Messenger versenden – es ist sicher. Bitte in SimpleX einfügen.</string>
-    <string name="talk_to_someone">Mit Jemandem sprechen</string>
+    <string name="talk_to_someone">Mit jemandem sprechen</string>
     <string name="v6_5_non_profit_governance_descr">Für ein dauerhaftes SimpleX-Netzwerk.</string>
     <string name="onboarding_post_address">Diese Adresse in Ihrem Social‑Media‑Profil, auf Ihrer Webseite oder in Ihrer E‑Mail‑Signatur verwenden.</string>
     <string name="v6_5_invite_friends_descr">Wir haben das Verbinden für neue Nutzer vereinfacht.</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/es/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/es/strings.xml
@@ -2554,14 +2554,14 @@
     <string name="placeholder_search_voice_messages">Buscar mensajes de voz</string>
     <string name="content_filter_videos">Vídeos</string>
     <string name="content_filter_voice_messages">Mensajes de voz</string>
-    <string name="relay_bar_active">%1$d%2$d servidores activos</string>
-    <string name="relay_bar_active_with_failures">%1$d%2$d servidores activos, %3$d han fallado</string>
-    <string name="relay_bar_connected">%1$d%2$d servidores conectados</string>
-    <string name="relay_bar_connected_with_errors">%1$d%2$d servidores conectados, %3$d errores</string>
+    <string name="relay_bar_active">%1$d/%2$d servidores activos</string>
+    <string name="relay_bar_active_with_failures">%1$d/%2$d servidores activos, %3$d han fallado</string>
+    <string name="relay_bar_connected">%1$d/%2$d servidores conectados</string>
+    <string name="relay_bar_connected_with_errors">%1$d/%2$d servidores conectados, %3$d errores</string>
     <string name="relay_status_accepted">aceptado</string>
     <string name="relay_status_active">activo</string>
     <string name="test_relay_to_retrieve_name"><![CDATA[<b>Test del servidor</b> para recibir su nombre.]]></string>
-    <string name="channel_profile_is_stored_on_subscribers_devices">El perfil del canal se almacena en los dispositivos de los suscroptores y en los servidores de chat.</string>
+    <string name="channel_profile_is_stored_on_subscribers_devices">El perfil del canal se almacena en los dispositivos de los suscriptores y en los servidores de chat.</string>
     <string name="channel_will_start_with_relays">El canal comenzará a funcionar con %1$d de %2$d servidores. ¿Continuar?</string>
     <string name="chat_relay">Servidores de chat</string>
     <string name="button_channel_relays">Servidores de chat</string>
@@ -2590,7 +2590,7 @@
     <string name="compose_view_broadcast">Emisión</string>
     <string name="cancel_creating_channel_confirm">Cancelar</string>
     <string name="cancel_creating_channel_question">¿Cancelar la creación del canal?</string>
-    <string name="connect_plan_this_is_your_link_for_channel_vName"><![CDATA[This is your link for channel <b>%1$s</b>!]]></string>
+    <string name="connect_plan_this_is_your_link_for_channel_vName"><![CDATA[¡Este es tu enlace para el canal <b>%1$s</b>!]]></string>
     <string name="channel_role_label">canal</string>
     <string name="chat_banner_channel">Canal</string>
     <string name="info_row_channel">Canal</string>
@@ -2649,7 +2649,7 @@
     <string name="button_remove_subscriber_question">¿Eliminar suscriptor?</string>
     <string name="save_and_notify_channel_subscribers">Guardar y notificar suscriptores</string>
     <string name="save_channel_profile">Guardar perfil del canal</string>
-    <string name="error_relay_test_server_auth">El servidor requere autorización para conectar con el servidor, comprueba la contraseña.</string>
+    <string name="error_relay_test_server_auth">El servidor requiere autorización para conectar con el servidor, comprueba la contraseña.</string>
     <string name="server_warning">Alerta del servidor</string>
     <string name="share_relay_address">Compartir dirección del servidor</string>
     <string name="member_info_section_title_subscriber">SUSCRIPTOR</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/ru/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/ru/strings.xml
@@ -2645,7 +2645,7 @@
     <string name="snd_channel_event_channel_profile_updated">профиль канала обновлён</string>
     <string name="delete_channel_for_all_subscribers_cannot_undo_warning">Канал будет удалён для всех подписчиков — это действие нельзя отменить!</string>
     <string name="delete_channel_for_self_cannot_undo_warning">Канал будет удалён для вас — это действие нельзя отменить!</string>
-    <string name="configure_relays">Настроить ретранстляторы</string>
+    <string name="configure_relays">Настроить ретрансляторы</string>
     <string name="relay_test_step_connect">Соединиться</string>
     <string name="relay_conn_status_connected">соединено</string>
     <string name="relay_conn_status_connecting">соединяется</string>
@@ -2676,7 +2676,7 @@
     <string name="relay_bar_connected_with_errors">%1$d/%2$d ретрансляторов соединено, %3$d ошибок</string>
     <string name="relay_status_accepted">принят</string>
     <string name="relay_status_active">активен</string>
-    <string name="block_subscriber_for_all_question">Заблокировать подписчкика для всех?</string>
+    <string name="block_subscriber_for_all_question">Заблокировать подписчика для всех?</string>
     <string name="compose_view_broadcast">Вещание</string>
     <string name="cancel_creating_channel_confirm">Отмена</string>
     <string name="channel_will_start_with_relays">Канал начнёт работу с %1$d из %2$d ретрансляторов. Продолжить?</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/zh-rCN/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/zh-rCN/strings.xml
@@ -2666,7 +2666,7 @@
     <string name="alert_title_msg_error">消息错误</string>
     <string name="save_and_notify_channel_subscribers">保存并通知频道订阅者</string>
     <string name="save_channel_profile">保存频道资料</string>
-    <string name="alert_text_msg_reception_error">应用在尝试接受这条消息 %1$d 次后删除了这条消。</string>
+    <string name="alert_text_msg_reception_error">应用在尝试接收这条消息 %1$d 次后删除了它。</string>
     <string name="rcv_channel_event_updated_channel_profile">更新了频道资料</string>
     <string name="relay_bar_active_with_errors">%2$d 个中继中的 %1$d 个活跃， %3$d 个错误</string>
     <string name="relay_bar_active_with_removed">%2$d 个中继中的 %1$d 个活跃， %3$d 个被删除</string>
@@ -2679,7 +2679,7 @@
     <string name="relay_bar_all_relays_failed">所有中继均失灵</string>
     <string name="relay_bar_all_relays_removed">删除了所有中继</string>
     <string name="cant_broadcast_message">无法广播</string>
-    <string name="channel_no_active_relays_try_later">频道有不活跃的中继。请稍后尝试加入。</string>
+    <string name="channel_no_active_relays_try_later">频道无活跃中继。请稍后尝试加入。</string>
     <string name="channel_temporarily_unavailable">频道暂时不可用</string>
     <string name="relay_status_inactive">不活跃</string>
     <string name="relay_bar_no_active_relays">无活跃中继</string>
@@ -2691,12 +2691,12 @@
     <string name="error_sharing_channel">分享频道出错</string>
     <string name="chat_link_from_owner">（来自所有者）</string>
     <string name="chat_link_group">群链接</string>
-    <string name="owner_verification_passed">链接签名无效</string>
+    <string name="owner_verification_passed">链接签名已验证。</string>
     <string name="chat_link_one_time">一次性链接</string>
     <string name="share_channel">分享频道…</string>
     <string name="share_via_chat">经聊天分享</string>
     <string name="owner_verification_failed">⚠️ 签名验证失败：%s。</string>
-    <string name="chat_link_signed">(s已签名)</string>
+    <string name="chat_link_signed">（已签名）</string>
     <string name="tap_to_open">轻触打开</string>
     <string name="link_previews_alert_desc">发送链接预览可能会将你的 IP 地址暴露给网站。你可以稍后在“隐私”设置中更改此设置。</string>
     <string name="connection_reached_limit_of_undelivered_messages">连接达到了未送达消息的上限</string>
@@ -2720,7 +2720,7 @@
     <string name="new_1_time_link">新建一次性链接</string>
     <string name="v6_5_non_profit_governance">非盈利治理</string>
     <string name="v6_5_safe_web_links_descr">- 可选发送链接预览\n- 防止超链接钓鱼\n- 删除链接跟踪。</string>
-    <string name="onboarding_or_show_qr_code">面对面或通过视频通展示二维码。</string>
+    <string name="onboarding_or_show_qr_code">面对面或通过视频通话展示二维码。</string>
     <string name="onboarding_or_use_qr_code">或使用此二维码 — 打印或在线展示。</string>
     <string name="v6_5_ownership">所有权：你可以运行自己的中继。</string>
     <string name="v6_5_privacy">隐私：对所有者和订阅者。</string>


### PR DESCRIPTION
## Summary

Line-by-line review of PR #6881 surfaced 17 fixable issues in the new channel-feature translations. This PR applies all fixes to the same `weblate/translations` branch so they land together with #6881.

**Stats:** 11 files, 39 insertions, 39 deletions. No translations added or removed; only existing-string corrections.

## Merge-blockers fixed

- **Spanish `%1$d/%2$d` format specifier regression** (4 strings × 3 files: `apps/ios/es.lproj/Localizable.strings`, `es.xliff`, `MR/es/strings.xml`). Without the `/`, the relay-bar count rendered as e.g. `12 servidores activos` instead of `1/2 servidores activos`.
- **Chinese `owner_verification_passed`** was translated as `链接签名无效` (= `INVALID`). Both PASSED and FAILED branches looked like failure messages — users could not tell when a link signature was actually verified. Now: `链接签名已验证。`
- **Spanish `connect_plan_this_is_your_link_for_channel_vName`** was left in English. Now translated.

## Bugs / typos fixed

| Lang | Key / context | Fix |
|---|---|---|
| de | `tap_to_start_new_chat` | `einen neuen Chats` → `einen neuen Chat` (accusative grammar) |
| de | `connect_with_someone`, `let_someone_connect_to_you`, `talk_to_someone` | `Jemand(em)` → `jemand(em)` (indefinite pronoun, lowercase) |
| de | `v6_5_public_channels` | `freies kommunizieren` → `freies Kommunizieren` (nominalised infinitive, capitalised) |
| de | `relay_bar_active_with_failures` (Android + iOS .strings + xliff) | `%3$d Fehlgeschlagen` → `%3$d fehlgeschlagen` (parallels `%3$d Fehler`; participle not noun) |
| de iOS | "Your profile **%@** will be shared…" | restored dropped `**…**` markdown bold around `%@` |
| es | 3 files | `suscroptores` → `suscriptores` |
| es | 3 files | `requere` → `requiere` |
| it | 2 files | `relayvdi chat` → `relay di chat` |
| ru | `configure_relays` | `ретранстляторы` → `ретрансляторы` |
| ru | `block_subscriber_for_all_question` | `подписчкика` → `подписчика` |
| ar | `your_profile_shared_with_channel_relays` | `الفناة` → `القناة` |
| zh-rCN | `alert_text_msg_reception_error` | fixed truncation `这条消` and `接受` (accept) → `接收` (receive) |
| zh-rCN | `channel_no_active_relays_try_later` | inverted meaning `频道有不活跃的中继` (HAS inactive relays) → `频道无活跃中继` (no active relays) |
| zh-rCN | `chat_link_signed` | removed stray `s`: `(s已签名)` → `（已签名）` |
| zh-rCN | `onboarding_or_show_qr_code` | fixed truncation `视频通` → `视频通话` |

## Reviewed but intentionally **not** changed

- `hu copy_error` — flagged in review as "reversed", but verified usage in `apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt:2085` shows it's the action button "Copy [the] error [to clipboard]"; the new `Hiba másolása` is correct for that semantics.
- Stylistic inconsistencies (de hyphenation `Kanallink` vs `Kanal-Link`, "Eigentümer" vs "Besitzer", hu `feliratkozó` vs `előfizető`, ru ё/е, ru "Вы"/"вы") — these need an editorial decision and were left for the maintainer.

## Audit summary

The full review of #6881 covered 1,290+ changed translation entries across 21 languages. **No malicious content was found** in any language — no inserted URLs, slurs, propaganda, or out-of-source claims. The review was based on the English source (`MR/base/strings.xml` / iOS .strings keys) at the PR head SHA.

## Test plan

- [ ] Verify Spanish relay-bar strings render `1/2 servidores activos` (not `12 servidores`) in both iOS and Android builds.
- [ ] Verify Chinese `owner_verification_passed` shows a successful state (not "INVALID") when link signature is valid.
- [ ] Verify German `tap_to_start_new_chat` reads `Tippen, um einen neuen Chat zu starten`.
- [ ] Verify the German iOS profile-share string renders the profile name in **bold**.
- [ ] Quick eyeball pass on the other typo fixes (es, it, ru, ar, zh-rCN) in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)