### PR TITLE
android: fix system nav bar overlapping call buttons during call

### DIFF
--- a/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/views/call/CallView.android.kt
+++ b/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/views/call/CallView.android.kt
@@ -394,7 +394,7 @@ private fun ActiveCallOverlayLayout(
         DisabledBackgroundCallsButton()
       }
 
-      BoxWithConstraints(Modifier.padding(start = 6.dp, end = 6.dp, bottom = DEFAULT_PADDING).align(Alignment.CenterHorizontally)) {
+      BoxWithConstraints(Modifier.navigationBarsPadding().padding(start = 6.dp, end = 6.dp, bottom = DEFAULT_PADDING).align(Alignment.CenterHorizontally)) {
         val size = ((maxWidth - DEFAULT_PADDING_HALF * 4) / 5).coerceIn(0.dp, 60.dp)
         // limiting max width for tablets/wide screens, will be displayed in the center
         val padding = ((min(420.dp, maxWidth) - size * 5) / 4).coerceAtLeast(0.dp)


### PR DESCRIPTION
## Summary

- The active-call action button row (mute, speaker, hang up, flip/toggle camera) had only a fixed `20.dp` bottom padding. Under edge-to-edge layout on devices with 3-button system navigation, the system nav bar (~48.dp) drew on top of these buttons, hiding part of them — the hang-up button in particular could be partially obscured.
- Adds `.navigationBarsPadding()` to the `BoxWithConstraints` containing the button row so it floats above the system nav bar inset. No effect on devices using gesture navigation (the inset there collapses to a small handle and does not collide with the existing `20.dp` padding).
- Single-line change in `apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/views/call/CallView.android.kt`. The `navigationBarsPadding` symbol is already in scope via the existing `androidx.compose.foundation.layout.*` import — no new imports needed.

## Test plan

- [x] On an Android device with **3-button navigation** enabled (Settings → System → Gestures → 3-button), start an audio call. Confirm hang-up / mute / speaker buttons are fully visible above the system nav bar.
- [x] Repeat for a video call. Confirm the same plus the flip-camera and video-toggle buttons.
- [x] On a device with **gesture navigation** enabled, confirm the layout is unchanged — the buttons should not appear to have moved.
- [ ] Confirm the lock-screen incoming-call layout and the in-app incoming-call banner are unchanged (this PR does not touch those).