### PR TITLE
ui: fix crash opening About SimpleX Chat

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/onboarding/SimpleXInfo.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/onboarding/SimpleXInfo.kt
@@ -105,9 +105,9 @@ fun SimpleXInfoLayout(
   user: User?,
   onboardingStage: SharedPreference<OnboardingStage>?
 ) {
-  val oneHandUI = remember { appPrefs.oneHandUI.state }
-  val topAppBarInset = if (onboardingStage == null && !oneHandUI.value) AppBarHeight * fontSizeSqrtMultiplier else 0.dp
-  Column(Modifier.fillMaxSize().systemBarsPadding().padding(top = topAppBarInset).padding(horizontal = DEFAULT_ONBOARDING_HORIZONTAL_PADDING), horizontalAlignment = Alignment.CenterHorizontally) {
+  val topBar = onboardingStage == null && !appPrefs.oneHandUI.state.value
+  val modifier = Modifier.fillMaxSize().systemBarsPadding().padding(horizontal = DEFAULT_ONBOARDING_HORIZONTAL_PADDING)
+  Column(if (topBar) modifier.padding(top = AppBarHeight * fontSizeSqrtMultiplier) else modifier, horizontalAlignment = Alignment.CenterHorizontally) {
     Box(Modifier.padding(top = DEFAULT_PADDING * 2).widthIn(max = if (appPlatform.isAndroid) 185.dp else 160.dp), contentAlignment = Alignment.Center) {
       SimpleXLogo()
     }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/onboarding/SimpleXInfo.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/onboarding/SimpleXInfo.kt
@@ -105,7 +105,9 @@ fun SimpleXInfoLayout(
   user: User?,
   onboardingStage: SharedPreference<OnboardingStage>?
 ) {
-  Column(Modifier.fillMaxSize().systemBarsPadding().padding(horizontal = DEFAULT_ONBOARDING_HORIZONTAL_PADDING), horizontalAlignment = Alignment.CenterHorizontally) {
+  val oneHandUI = remember { appPrefs.oneHandUI.state }
+  val topAppBarInset = if (onboardingStage == null && !oneHandUI.value) AppBarHeight * fontSizeSqrtMultiplier else 0.dp
+  Column(Modifier.fillMaxSize().systemBarsPadding().padding(top = topAppBarInset).padding(horizontal = DEFAULT_ONBOARDING_HORIZONTAL_PADDING), horizontalAlignment = Alignment.CenterHorizontally) {
     Box(Modifier.padding(top = DEFAULT_PADDING * 2).widthIn(max = if (appPlatform.isAndroid) 185.dp else 160.dp), contentAlignment = Alignment.Center) {
       SimpleXLogo()
     }
@@ -156,7 +158,7 @@ fun SimpleXInfoLayout(
             ModalManager.fullscreen.showModal { HowItWorks(user, onboardingStage) }
           })
         }
-      }
+      } else Spacer(Modifier)
     }
   )
   }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/onboarding/SimpleXInfo.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/onboarding/SimpleXInfo.kt
@@ -158,7 +158,9 @@ fun SimpleXInfoLayout(
             ModalManager.fullscreen.showModal { HowItWorks(user, onboardingStage) }
           })
         }
-      } else Spacer(Modifier)
+      } else {
+        Spacer(Modifier)
+      }
     }
   )
   }


### PR DESCRIPTION
## Summary
- Fixes a crash on Settings → About SimpleX Chat introduced in #6888 (visible in 6.5-beta.11): `java.util.NoSuchElementException: List is empty.` at `OnboardingLayout.kt:57`.
- Root cause: `OnboardingShrinkingLayout` called `.first()` on each slot's measurables. `SimpleXInfoLayout` passes `onboardingStage = null` when reached from About, and the `button` slot emits no children in that case → `.first()` throws.
- Fix: treat each slot's measurables as 0-or-1 children — use `firstOrNull()` and skip placement / contribute zero height when absent. The fix lives in the layout primitive, so any caller is safe.