### PR TITLE
android, desktop: stop voice recording on first play tap

### DIFF
--- a/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/platform/RecAndPlay.android.kt
+++ b/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/platform/RecAndPlay.android.kt
@@ -78,15 +78,12 @@ actual class RecorderNative: RecorderInterface {
     runCatching {
       recorder?.release()
     }
-    // Await coroutine finishes in order to send real duration to it's listener
-    runBlocking {
-      progressJob?.cancelAndJoin()
-    }
+    progressJob?.cancel()
     progressJob = null
     filePath = null
     recorder = null
     keepScreenOn(false)
-    return (realDuration(path) ?: 0).also { recStartedAt = null }
+    return (progress() ?: 0).also { recStartedAt = null }
   }
 
   private fun progress(): Int? = recStartedAt?.let { (System.currentTimeMillis() - it).toInt() }

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/RecAndPlay.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/RecAndPlay.desktop.kt
@@ -70,11 +70,11 @@ actual class RecorderNative: RecorderInterface {
     RecorderInterface.stopRecording = null
     runCatching { player?.controls()?.stop() }
     runCatching { player?.release() }
-    runBlocking { progressJob?.cancelAndJoin() }
+    progressJob?.cancel()
     progressJob = null
     filePath = null
     player = null
-    return (realDuration(path) ?: 0).also { recStartedAt = null }
+    return (progress() ?: 0).also { recStartedAt = null }
   }
 
   private fun progress(): Int? = recStartedAt?.let { (System.currentTimeMillis() - it).toInt() }


### PR DESCRIPTION
## Summary

Fix: while a voice recording is in progress, tapping play on another voice message did nothing on the first attempt — only spam-clicking eventually stopped the recording (and on Desktop the UI could wedge entirely).

## Root cause

`AudioPlayer.start()` synchronously calls `RecorderInterface.stopRecording?.invoke()`, which lands in `RecorderNative.stop()`. Two costs there compounded:

- `runBlocking { progressJob?.cancelAndJoin() }` — blocks the calling thread until the progress coroutine's `invokeOnCompletion { onProgressUpdate(realDuration(path), true) }` handler has finished. `realDuration` falls through to `AudioPlayer.duration(path)`. On Desktop that constructs a fresh `AudioPlayerComponent` and runs `media().startPaused()` on the recording file VLC just released — slow at best, sometimes never returns.
- A second `realDuration(path)` at the very end of `stop()` for the return value — duplicating the same probe on the calling thread.

On Desktop this could wedge the calling thread for several seconds or indefinitely, blocking subsequent clicks from registering.

## Fix

Two minimal edits in each of `RecAndPlay.android.kt` and `RecAndPlay.desktop.kt`:

1. Replace `runBlocking { progressJob?.cancelAndJoin() }` with `progressJob?.cancel()` — fire-and-forget cancellation; the caller no longer waits for `invokeOnCompletion`.
2. Replace `realDuration(path) ?: 0` with `progress() ?: 0` in `stop()`'s return — wall-clock elapsed time instead of probing the file.

`invokeOnCompletion` still fires (now async, on `Dispatchers.Default`, after `stop()` has returned) and still calls `realDuration` to update `recState` via the existing listener path. The bug-fix path no longer pays for that probe.

`durationMs` reported to `RecordingState.Finished` by `stopRecordingAndAddAudio` (which uses `stop()`'s return) is now wall-clock elapsed rather than container-probed — typically tens of ms looser, well below any user-visible threshold for a voice message.

## Test plan

- [x] Type-check Android (`./gradlew :common:compileDebugKotlinAndroid`).
- [x] Type-check Desktop (`./gradlew :common:compileKotlinDesktop`).
- [x] Desktop manual: tap (don't hold) record, then single-click play on an existing voice — playback starts on the first click instead of requiring spam-clicks.
- [ ] Android manual on device/emulator.
- [ ] Press-and-hold recording still produces a voice attachment with sensible duration (`onRelease = stopRecordingAndAddAudio`).
- [ ] Cancel button still discards the recording cleanly (`cancelVoice`).
- [ ] Switching chats while recording still stops the recording (`KeyChangeEffect`).
