### PR TITLE
desktop: fix saving files with '[', '*', or '?' in name on Linux

### DIFF
--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/views/helpers/DefaultDialog.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/views/helpers/DefaultDialog.desktop.kt
@@ -13,11 +13,15 @@ import chat.simplex.common.platform.desktopPlatform
 import chat.simplex.res.MR
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.awt.Container
 import java.awt.FileDialog
+import java.awt.event.ActionListener
 import java.io.File
+import javax.swing.JButton
 import javax.swing.JFileChooser
 import javax.swing.filechooser.FileFilter
 import javax.swing.filechooser.FileNameExtensionFilter
+import javax.swing.plaf.basic.BasicFileChooserUI
 
 @Composable
 actual fun DefaultDialog(
@@ -77,6 +81,9 @@ fun FrameWindowScope.FileDialogChooserMultiple(
       fileChooser.dialogTitle = title
       fileChooser.isMultiSelectionEnabled = allowMultiple && isLoad
       fileChooser.isAcceptAllFileFilterUsed = fileFilter == null
+      if (!isLoad && desktopPlatform.isLinux()) {
+        installUnixSaveGlobBypass(fileChooser)
+      }
       if (fileFilter != null && fileFilterDescription != null) {
         fileChooser.addChoosableFileFilter(object: FileFilter() {
           override fun accept(file: File?): Boolean = fileFilter(file)
@@ -118,6 +125,38 @@ fun FrameWindowScope.FileDialogChooserMultiple(
       job.cancel()
     }
   }
+}
+
+// Wrap the Save button's ApproveSelectionAction to bypass the BasicFileChooserUI glob branch
+// that rejects '[', '*', '?' in filenames on Unix; non-glob names delegate to the original action.
+private fun installUnixSaveGlobBypass(fc: JFileChooser) {
+  val ui = fc.ui as? BasicFileChooserUI ?: return
+  val original: ActionListener = ui.approveSelectionAction
+  val btn = findButtonWithListener(fc, original) ?: return
+  btn.removeActionListener(original)
+  btn.addActionListener { e ->
+    val name = ui.fileName.orEmpty()
+    if (name.none { it == '[' || it == '*' || it == '?' }) {
+      original.actionPerformed(e)
+      return@addActionListener
+    }
+    val typed = File(name)
+    val target = if (typed.isAbsolute) typed else File(fc.currentDirectory, name)
+    if (target.isDirectory && fc.isTraversable(target)) {
+      fc.currentDirectory = target
+    } else {
+      fc.selectedFile = target
+      fc.approveSelection()
+    }
+  }
+}
+
+private fun findButtonWithListener(c: Container, listener: ActionListener): JButton? {
+  for (comp in c.components) {
+    if (comp is JButton && comp.actionListeners.any { it === listener }) return comp
+    if (comp is Container) findButtonWithListener(comp, listener)?.let { return it }
+  }
+  return null
 }
 
 /*

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/views/helpers/DefaultDialog.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/views/helpers/DefaultDialog.desktop.kt
@@ -127,19 +127,17 @@ fun FrameWindowScope.FileDialogChooserMultiple(
   }
 }
 
-// Wrap the Save button's ApproveSelectionAction to bypass the BasicFileChooserUI glob branch
-// that rejects '[', '*', '?' in filenames on Unix; non-glob names delegate to the original action.
+// Replace the Save button's action with a literal-filename handler. This bypasses JFileChooser's
+// glob-on-save behaviour, which mis-handles '[' as a glob char on Unix (breaking filenames like
+// '[1].pdf') and is not a feature of any native OS save dialog — macOS NSSavePanel and native
+// Windows / Linux GTK / KDE save dialogs all treat the typed filename as a literal name.
 private fun installUnixSaveGlobBypass(fc: JFileChooser) {
   val ui = fc.ui as? BasicFileChooserUI ?: return
   val original: ActionListener = ui.approveSelectionAction
   val btn = findButtonWithListener(fc, original) ?: return
   btn.removeActionListener(original)
-  btn.addActionListener { e ->
-    val name = ui.fileName.orEmpty()
-    if (name.none { it == '[' || it == '*' || it == '?' }) {
-      original.actionPerformed(e)
-      return@addActionListener
-    }
+  btn.addActionListener {
+    val name = ui.fileName?.takeIf { it.isNotEmpty() } ?: return@addActionListener
     val typed = File(name)
     val target = if (typed.isAbsolute) typed else File(fc.currentDirectory, name)
     if (target.isDirectory && fc.isTraversable(target)) {


### PR DESCRIPTION
## Summary

On Linux, you cannot save a received file whose name contains `[`, `*`, or `?` — the Save dialog stays open and nothing is written to disk. Reproduced with `[test].txt`; common in practice with browser-style downloads like `report[1].pdf`.

## Root cause

`javax.swing.plaf.basic.BasicFileChooserUI.ApproveSelectionAction.actionPerformed()` does this when the user clicks Save:

1. reads the typed filename via `getFileName()`
2. resolves it via `FileSystemView.createFileObject(name)`
3. if **the file does not exist** AND `isGlobPattern(name)` is `true`, it interprets the name as a glob: it calls `changeDirectory(parent)`, sets a `GlobFilter` on the chooser, and returns — **without ever calling `approveSelection()`**.

`BasicFileChooserUI.isGlobPattern()` (verified by reflection on JDK 17.0.18):

| separator | glob chars |
|---|---|
| `/` (Linux/macOS) | `*`, `?`, **`[`** |
| `\` (Windows) | `*`, `?` |

So `file[1].pdf` → `isGlobPattern` true → glob branch taken → save never happens. On Windows `[` is not a glob char per the JDK; on macOS this code base uses `java.awt.FileDialog`, not `JFileChooser`, so neither is affected by the `[` case. (`*` and `?` are also intercepted as glob in the JFileChooser save dialog on Windows, but they are illegal NTFS filename chars anyway.)

## When this regressed

Introduced by 02d00944f / #2789 (2023-07-28, "desktop: fix creating tmpDir and providing name for file to save"). That commit started pre-populating the filename via:

```kotlin
fileChooser.selectedFile = File(filename)
```

Before then, the save dialog ran in `DIRECTORIES_ONLY` mode — the user picked a folder and the file was written with its original name; `JFileChooser` never saw the filename, so the glob branch never ran.

## Fix approach

`BasicFileChooserUI.getApproveSelectionAction()` is a public method that returns **the exact `ActionListener` instance** wired onto the Save button. Using that we:

- locate the Save button by **identity** (`it === listener`) — no class-name string match;
- replace it with a small handler that resolves the typed text as a **literal filename**, traverses on directory paths, and calls `approveSelection()` directly — bypassing the glob branch entirely.

The handler is installed only when `!isLoad && desktopPlatform.isLinux()`:

- Windows save dialog: untouched.
- macOS save dialog: untouched (uses `java.awt.FileDialog`, different code path).
- Open dialog on every platform: untouched (the fix is gated on `!isLoad`).

### Why bypass glob-on-save entirely (instead of only for `[`)

JFileChooser's glob-on-save behaviour is a Swing-only eccentricity that no native OS save dialog implements:

- **macOS NSSavePanel** — no glob-on-save (and this app already uses it on macOS via AWT FileDialog).
- **Native Windows save dialog** — no glob-on-save.
- **Native Linux GTK / KDE save dialogs** — no glob-on-save.

It also blocks legitimate POSIX filenames containing `*` or `?` from being saved (those are legal on POSIX filesystems even though Windows forbids them).

So the user-facing change on Linux is: the Save button always treats the typed text as a literal filename — matching what users get on macOS in this same app and what they get from every native OS save dialog.

### Alternatives considered and rejected

| Option | Why rejected |
|---|---|
| Sanitize/escape the filename | Destructive and user-visible — rewrites the proposed name. |
| Use `java.awt.FileDialog` on Linux for save | Existing comment in `DefaultDialog.desktop.kt` warns of "graphic glitches on many Linux distributions" — that is why JFileChooser was chosen for Linux in the first place. |
| Reflection on `BasicFileChooserUI.getApproveButton(JFileChooser)` | Method is `protected`; `setAccessible(true)` fails under JPMS without `--add-opens java.desktop/javax.swing.plaf.basic=ALL-UNNAMED`. Verified on JDK 17. |
| Override `JFileChooser.approveSelection()` in a subclass | The glob branch returns *before* `approveSelection()` is called, so an override never sees the click. |
| Replace the `actionMap["approveSelection"]` entry | The Save button has the action wired as a **direct ActionListener**, not via the action map — verified by walking the component tree. The action map binding only matters for keyboard shortcuts, which are not on the broken path. |
| Bypass only when filename contains `[` (and delegate for `*`/`?`) | Preserves Swing's glob-on-save for `*`/`?`, but no native OS save dialog has this feature, and it still blocks saving legitimate POSIX filenames containing `*` or `?`. |
| Custom `FileSystemView` that returns a `File` whose `exists()` lies | Would silently affect every other consumer of the FSV; high blast radius for a narrow workaround. |

## Test plan

- [x] Build Linux AppImage; receive `[test].txt`, click Save → saves correctly.
- [x] Save filenames containing `*` and `?` on Linux → save correctly.
- [x] Save normal filename `hello.txt` → unchanged behaviour.
- [x] Save into a directory by typing its path in the filename field → traverses into it.
- [ ] Confirm Windows save dialog unaffected (no code path change for Windows).
- [ ] Confirm macOS save dialog unaffected (no code path change for macOS).
- [ ] Confirm open dialog unchanged on every platform.