### PR TITLE
android, desktop: fix several RTL layout issues

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatItemInfoView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatItemInfoView.kt
@@ -359,6 +359,7 @@ fun ChatItemInfoView(chatRh: Long?, ci: ChatItem, ciInfo: ChatItemInfo, devTools
           Icon(
             painterResource(MR.images.ic_arrow_forward),
             contentDescription = null,
+            modifier = Modifier.mirrorIfRtl(),
             tint = CurrentColors.value.colors.secondary
           )
         }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/CommandsMenuView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/CommandsMenuView.kt
@@ -25,6 +25,7 @@ import chat.simplex.common.ui.theme.DEFAULT_PADDING_HALF
 import chat.simplex.common.views.chat.group.*
 import chat.simplex.common.views.chat.item.sendCommandMsg
 import chat.simplex.common.views.helpers.commandMenuAnimSpec
+import chat.simplex.common.views.helpers.mirrorIfRtl
 import chat.simplex.res.MR
 import dev.icerock.moko.resources.compose.painterResource
 import kotlinx.coroutines.launch
@@ -126,6 +127,7 @@ fun CommandsMenuView(
         Icon(
           painterResource(MR.images.ic_arrow_back_ios_new),
           contentDescription = null,
+          modifier = Modifier.mirrorIfRtl(),
           tint = MaterialTheme.colors.secondary
         )
         Spacer(Modifier.width(DEFAULT_PADDING_HALF))
@@ -205,6 +207,7 @@ fun CommandsMenuView(
             Icon(
               painterResource(MR.images.ic_chevron_right),
               contentDescription = null,
+              modifier = Modifier.mirrorIfRtl(),
               tint = MaterialTheme.colors.secondary
             )
           }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/CIMetaView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/CIMetaView.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import chat.simplex.common.model.*
 import chat.simplex.common.ui.theme.isInDarkTheme
+import chat.simplex.common.views.helpers.mirrorIfRtl
 import chat.simplex.res.MR
 import kotlinx.datetime.Clock
 
@@ -87,7 +88,7 @@ private fun CIMetaText(
   }
   if (showViaProxy && meta.sentViaProxy == true) {
     Spacer(Modifier.width(4.dp))
-    Icon(painterResource(MR.images.ic_arrow_forward), null, Modifier.height(17.dp), tint = MaterialTheme.colors.secondary)
+    Icon(painterResource(MR.images.ic_arrow_forward), null, Modifier.height(17.dp).mirrorIfRtl(), tint = MaterialTheme.colors.secondary)
   }
   if (showStatus) {
     Spacer(Modifier.width(4.dp))

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/ChatItemView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/ChatItemView.kt
@@ -238,7 +238,7 @@ fun ChatItemView(
     }
 
     @Composable
-    fun GoToItemInnerButton(alignStart: Boolean, icon: ImageResource, iconSize: Dp = 22.dp, parentActivated: State<Boolean>, onClick: () -> Unit) {
+    fun GoToItemInnerButton(alignStart: Boolean, icon: ImageResource, iconSize: Dp = 22.dp, parentActivated: State<Boolean>, mirror: Boolean = false, onClick: () -> Unit) {
       val buttonInteractionSource = remember { MutableInteractionSource() }
       val buttonHovered = buttonInteractionSource.collectIsHoveredAsState()
       val buttonPressed = buttonInteractionSource.collectIsPressedAsState()
@@ -273,7 +273,7 @@ fun ChatItemView(
           .size(22.dp),
         interactionSource = buttonInteractionSource
       ) {
-        Icon(painterResource(icon), null, Modifier.size(iconSize), tint = iconTint)
+        Icon(painterResource(icon), null, Modifier.size(iconSize).then(if (mirror) Modifier.mirrorIfRtl() else Modifier), tint = iconTint)
       }
     }
 
@@ -289,7 +289,7 @@ fun ChatItemView(
           }
         }
       } else if (chatTypeApiIdMsgId != null) {
-        GoToItemInnerButton(alignStart, MR.images.ic_arrow_forward, 22.dp, parentActivated) {
+        GoToItemInnerButton(alignStart, MR.images.ic_arrow_forward, 22.dp, parentActivated, mirror = true) {
           val (chatType, apiId, msgId) = chatTypeApiIdMsgId
           withBGApi {
             openChat(secondaryChatsCtx = null, rhId, chatType, apiId, msgId)
@@ -1283,10 +1283,9 @@ private fun chatItemShape(roundness: Float, density: Density, tailVisible: Boole
     quadraticBezierTo(bubbleInitialX, 0f, bubbleInitialX + rx, 0f) // Top-left corner
   }
 
-  // The default path draws the tail at the bottom-left corner. We mirror the path so the tail
-  // ends up on the side closer to the message author's profile in chat: right for sent in LTR,
-  // left for received in LTR — and the opposite under RTL where chat sides are mirrored.
-  if (sent != (layoutDirection == LayoutDirection.Rtl)) {
+  // Default path draws the tail at the bottom-left corner.
+  val tailOnRight = sent != (layoutDirection == LayoutDirection.Rtl)
+  if (tailOnRight) {
     val matrix = Matrix()
     matrix.scale(-1f, 1f)
     this.transform(matrix)

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/ChatItemView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/ChatItemView.kt
@@ -1231,7 +1231,7 @@ fun Modifier.clipChatItem(chatItem: ChatItem? = null, tailVisible: Boolean = fal
   return this.clip(shape)
 }
 
-private fun chatItemShape(roundness: Float, density: Density, tailVisible: Boolean, sent: Boolean = false): GenericShape = GenericShape { size, _ ->
+private fun chatItemShape(roundness: Float, density: Density, tailVisible: Boolean, sent: Boolean = false): GenericShape = GenericShape { size, layoutDirection ->
   val (msgTailWidth, msgBubbleMaxRadius) = with(density) { Pair(msgTailWidthDp.toPx(), msgBubbleMaxRadius.toPx()) }
   val width = size.width
   val height = size.height
@@ -1283,7 +1283,10 @@ private fun chatItemShape(roundness: Float, density: Density, tailVisible: Boole
     quadraticBezierTo(bubbleInitialX, 0f, bubbleInitialX + rx, 0f) // Top-left corner
   }
 
-  if (sent) {
+  // The default path draws the tail at the bottom-left corner. We mirror the path so the tail
+  // ends up on the side closer to the message author's profile in chat: right for sent in LTR,
+  // left for received in LTR — and the opposite under RTL where chat sides are mirrored.
+  if (sent != (layoutDirection == LayoutDirection.Rtl)) {
     val matrix = Matrix()
     matrix.scale(-1f, 1f)
     this.transform(matrix)

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/FramedItemView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/FramedItemView.kt
@@ -592,8 +592,6 @@ fun CenteredRowLayout(
     val second = measureable[1].measure(constraints.copy(minWidth = 0, minHeight = 0, maxWidth = (constraints.maxWidth - first.measuredWidth - third.measuredWidth).coerceAtLeast(0)))
     // Limit width for every other element to width of important element and height for a sum of all elements.
     layout(constraints.maxWidth, constraints.maxHeight) {
-      // placeRelative mirrors x under RTL so the leading slot (first) and trailing slot (third)
-      // swap visual sides automatically when the locale flips.
       first.placeRelative(0, ((constraints.maxHeight - first.measuredHeight) / 2).coerceAtLeast(0))
       second.placeRelative((constraints.maxWidth - second.measuredWidth) / 2, ((constraints.maxHeight - second.measuredHeight) / 2).coerceAtLeast(0))
       third.placeRelative(constraints.maxWidth - third.measuredWidth, ((constraints.maxHeight - third.measuredHeight) / 2).coerceAtLeast(0))

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/FramedItemView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/FramedItemView.kt
@@ -592,9 +592,11 @@ fun CenteredRowLayout(
     val second = measureable[1].measure(constraints.copy(minWidth = 0, minHeight = 0, maxWidth = (constraints.maxWidth - first.measuredWidth - third.measuredWidth).coerceAtLeast(0)))
     // Limit width for every other element to width of important element and height for a sum of all elements.
     layout(constraints.maxWidth, constraints.maxHeight) {
-      first.place(0, ((constraints.maxHeight - first.measuredHeight) / 2).coerceAtLeast(0))
-      second.place((constraints.maxWidth - second.measuredWidth) / 2, ((constraints.maxHeight - second.measuredHeight) / 2).coerceAtLeast(0))
-      third.place(constraints.maxWidth - third.measuredWidth, ((constraints.maxHeight - third.measuredHeight) / 2).coerceAtLeast(0))
+      // placeRelative mirrors x under RTL so the leading slot (first) and trailing slot (third)
+      // swap visual sides automatically when the locale flips.
+      first.placeRelative(0, ((constraints.maxHeight - first.measuredHeight) / 2).coerceAtLeast(0))
+      second.placeRelative((constraints.maxWidth - second.measuredWidth) / 2, ((constraints.maxHeight - second.measuredHeight) / 2).coerceAtLeast(0))
+      third.placeRelative(constraints.maxWidth - third.measuredWidth, ((constraints.maxHeight - third.measuredHeight) / 2).coerceAtLeast(0))
     }
   }
 }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/DefaultTopAppBar.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/DefaultTopAppBar.kt
@@ -128,7 +128,7 @@ fun CallAppBar(
 fun NavigationButtonBack(onButtonClicked: (() -> Unit)?, tintColor: Color = if (onButtonClicked != null) MaterialTheme.colors.primary else MaterialTheme.colors.secondary, height: Dp = 24.dp) {
   IconButton(onButtonClicked ?: {}, enabled = onButtonClicked != null) {
     Icon(
-      painterResource(MR.images.ic_arrow_back_ios_new), stringResource(MR.strings.back), Modifier.height(height), tint = tintColor
+      painterResource(MR.images.ic_arrow_back_ios_new), stringResource(MR.strings.back), Modifier.height(height).mirrorIfRtl(), tint = tintColor
     )
   }
 }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/Modifiers.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/Modifiers.kt
@@ -12,8 +12,6 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.LayoutDirection
 import kotlin.math.roundToInt
 
-// Horizontally flips an asymmetric directional drawable (back/forward arrows, chevrons, signal
-// waves) when the layout direction is RTL. Apply to the Icon's modifier at each call site.
 @Composable
 fun Modifier.mirrorIfRtl(): Modifier =
   if (LocalLayoutDirection.current == LayoutDirection.Rtl) this.scale(scaleX = -1f, scaleY = 1f) else this

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/Modifiers.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/Modifiers.kt
@@ -5,11 +5,18 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.LayoutDirection
 import kotlin.math.roundToInt
+
+// Horizontally flips an asymmetric directional drawable (back/forward arrows, chevrons, signal
+// waves) when the layout direction is RTL. Apply to the Icon's modifier at each call site.
+@Composable
+fun Modifier.mirrorIfRtl(): Modifier =
+  if (LocalLayoutDirection.current == LayoutDirection.Rtl) this.scale(scaleX = -1f, scaleY = 1f) else this
 
 fun Modifier.badgeLayout() =
   layout { measurable, constraints ->

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/SubscriptionStatusIcon.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/SubscriptionStatusIcon.kt
@@ -16,26 +16,26 @@ fun SubscriptionStatusIcon(
 ) {
   @Composable
   fun ZeroIcon() {
-    Icon(painterResource(MR.images.ic_radiowaves_up_forward_4_bar), null, tint = color.copy(alpha = 0.33f), modifier = modifier)
+    Icon(painterResource(MR.images.ic_radiowaves_up_forward_4_bar), null, tint = color.copy(alpha = 0.33f), modifier = modifier.mirrorIfRtl())
   }
 
   when {
     variableValue <= 0f -> ZeroIcon()
     variableValue > 0f && variableValue <= 0.25f -> Box {
       ZeroIcon()
-      Icon(painterResource(MR.images.ic_radiowaves_up_forward_1_bar), null, tint = color, modifier = modifier)
+      Icon(painterResource(MR.images.ic_radiowaves_up_forward_1_bar), null, tint = color, modifier = modifier.mirrorIfRtl())
     }
 
     variableValue > 0.25f && variableValue <= 0.5f -> Box {
       ZeroIcon()
-      Icon(painterResource(MR.images.ic_radiowaves_up_forward_2_bar), null, tint = color, modifier = modifier)
+      Icon(painterResource(MR.images.ic_radiowaves_up_forward_2_bar), null, tint = color, modifier = modifier.mirrorIfRtl())
     }
 
     variableValue > 0.5f && variableValue <= 0.75f -> Box {
       ZeroIcon()
-      Icon(painterResource(MR.images.ic_radiowaves_up_forward_3_bar), null, tint = color, modifier = modifier)
+      Icon(painterResource(MR.images.ic_radiowaves_up_forward_3_bar), null, tint = color, modifier = modifier.mirrorIfRtl())
     }
 
-    else -> Icon(painterResource(MR.images.ic_radiowaves_up_forward_4_bar), null, tint = color, modifier = modifier)
+    else -> Icon(painterResource(MR.images.ic_radiowaves_up_forward_4_bar), null, tint = color, modifier = modifier.mirrorIfRtl())
   }
 }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/SubscriptionStatusIcon.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/SubscriptionStatusIcon.kt
@@ -14,28 +14,29 @@ fun SubscriptionStatusIcon(
   variableValue: Float,
   modifier: Modifier = Modifier
 ) {
+  val iconModifier = modifier.mirrorIfRtl()
   @Composable
   fun ZeroIcon() {
-    Icon(painterResource(MR.images.ic_radiowaves_up_forward_4_bar), null, tint = color.copy(alpha = 0.33f), modifier = modifier.mirrorIfRtl())
+    Icon(painterResource(MR.images.ic_radiowaves_up_forward_4_bar), null, tint = color.copy(alpha = 0.33f), modifier = iconModifier)
   }
 
   when {
     variableValue <= 0f -> ZeroIcon()
     variableValue > 0f && variableValue <= 0.25f -> Box {
       ZeroIcon()
-      Icon(painterResource(MR.images.ic_radiowaves_up_forward_1_bar), null, tint = color, modifier = modifier.mirrorIfRtl())
+      Icon(painterResource(MR.images.ic_radiowaves_up_forward_1_bar), null, tint = color, modifier = iconModifier)
     }
 
     variableValue > 0.25f && variableValue <= 0.5f -> Box {
       ZeroIcon()
-      Icon(painterResource(MR.images.ic_radiowaves_up_forward_2_bar), null, tint = color, modifier = modifier.mirrorIfRtl())
+      Icon(painterResource(MR.images.ic_radiowaves_up_forward_2_bar), null, tint = color, modifier = iconModifier)
     }
 
     variableValue > 0.5f && variableValue <= 0.75f -> Box {
       ZeroIcon()
-      Icon(painterResource(MR.images.ic_radiowaves_up_forward_3_bar), null, tint = color, modifier = modifier.mirrorIfRtl())
+      Icon(painterResource(MR.images.ic_radiowaves_up_forward_3_bar), null, tint = color, modifier = iconModifier)
     }
 
-    else -> Icon(painterResource(MR.images.ic_radiowaves_up_forward_4_bar), null, tint = color, modifier = modifier.mirrorIfRtl())
+    else -> Icon(painterResource(MR.images.ic_radiowaves_up_forward_4_bar), null, tint = color, modifier = iconModifier)
   }
 }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatView.kt
@@ -568,6 +568,7 @@ private fun InviteView(rhId: Long?, connLinkInvitation: CreatedConnLink, contact
             painter = painterResource(MR.images.ic_arrow_forward_ios),
             contentDescription = stringResource(MR.strings.new_chat_share_profile),
             tint = MaterialTheme.colors.secondary,
+            modifier = Modifier.mirrorIfRtl(),
           )
         }
       }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/OnboardingCards.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/OnboardingCards.kt
@@ -263,7 +263,7 @@ private fun BackButton(modifier: Modifier = Modifier, color: Color = MaterialThe
       painterResource(MR.images.ic_arrow_back_ios_new),
       contentDescription = stringResource(MR.strings.back),
       tint = color,
-      modifier = Modifier.height(24.dp)
+      modifier = Modifier.height(24.dp).mirrorIfRtl()
     )
     Text(stringResource(MR.strings.back), color = color)
   }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/onboarding/WhatsNewView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/onboarding/WhatsNewView.kt
@@ -112,7 +112,7 @@ fun ModalData.WhatsNewView(updatedConditions: Boolean = false, viaSettings: Bool
               .clickable { currentVersion.value = prev }
               .padding(8.dp)
           ) {
-            Icon(painterResource(MR.images.ic_arrow_back_ios_new), "previous", tint = MaterialTheme.colors.primary)
+            Icon(painterResource(MR.images.ic_arrow_back_ios_new), "previous", Modifier.mirrorIfRtl(), tint = MaterialTheme.colors.primary)
             Text(versionDescriptions[prev].version, color = MaterialTheme.colors.primary)
           }
         }
@@ -129,7 +129,7 @@ fun ModalData.WhatsNewView(updatedConditions: Boolean = false, viaSettings: Bool
               .padding(8.dp)
           ) {
             Text(versionDescriptions[next].version, color = MaterialTheme.colors.primary)
-            Icon(painterResource(MR.images.ic_arrow_forward_ios), "next", tint = MaterialTheme.colors.primary)
+            Icon(painterResource(MR.images.ic_arrow_forward_ios), "next", Modifier.mirrorIfRtl(), tint = MaterialTheme.colors.primary)
           }
         }
       }

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/views/chat/item/ImageFullScreenView.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/views/chat/item/ImageFullScreenView.desktop.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import chat.simplex.common.platform.*
 import chat.simplex.common.views.helpers.getBitmapFromByteArray
+import chat.simplex.common.views.helpers.mirrorIfRtl
 import chat.simplex.res.MR
 import dev.icerock.moko.resources.compose.painterResource
 import dev.icerock.moko.resources.compose.stringResource
@@ -33,7 +34,7 @@ actual fun FullScreenVideoView(player: VideoPlayer, modifier: Modifier, close: (
     Box(Modifier.fillMaxSize().padding(bottom = 50.dp)) {
       SurfaceFromPlayer(player, modifier)
       IconButton(onClick = close, Modifier.padding(top = 5.dp)) {
-        Icon(painterResource(MR.images.ic_arrow_back_ios_new), null, Modifier.size(30.dp), tint = MaterialTheme.colors.primary)
+        Icon(painterResource(MR.images.ic_arrow_back_ios_new), null, Modifier.size(30.dp).mirrorIfRtl(), tint = MaterialTheme.colors.primary)
       }
     }
     Controls(player)

--- a/plans/2026-05-13-rtl-layout-issues.md
+++ b/plans/2026-05-13-rtl-layout-issues.md
@@ -1,0 +1,220 @@
+# RTL layout regressions (chat bubble tail, app bar, directional icons)
+
+Design doc for the fix shipped in PR #6908 (Fixes #5448).
+
+## Problem
+
+Under an RTL locale (Arabic, Persian, Hebrew) on Android and desktop:
+
+- Chat bubble tail points away from the message author's profile, with
+  the tail overflowing onto the avatar.
+- Chat header places the call + 3-dot menu on the visual right and the
+  back chevron on the visual left, opposite of platform convention; the
+  3-dot dropdown opens off-screen.
+- Chat list header has the profile avatar on the visual left and the
+  signal/wifi icon + "Chats" title on the right.
+- Asymmetric directional drawables — back/forward arrows, chevrons,
+  signal-strength waves, sent-via-proxy arrow — keep their LTR
+  orientation everywhere they appear.
+
+iOS is unaffected — UIKit's RTL support and SwiftUI's semantic edges
+already handle these cases.
+
+## Background — three independent mechanisms
+
+The user-visible regressions all come from one of three roots, each
+fixed at the root rather than per call site:
+
+1. **Bubble shape mirroring** — `chatItemShape` in
+   `apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/ChatItemView.kt`.
+2. **App-bar slot placement** — `CenteredRowLayout` in
+   `apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/FramedItemView.kt`,
+   reached by every `DefaultAppBar` caller via `AppBarCenterAligned`
+   (≈ 11 sites: `ChatView`, `ChatListView`, `NewChatSheet` ×2,
+   `MemberSupportChatView` ×2, `GroupReportsView`, `ModalView`,
+   `ShareListView`, `SelectableChatItemToolbars`).
+3. **Asymmetric directional drawables** — applied at each Icon call
+   site whose vector resource is intrinsically directional.
+
+## Fix
+
+### 1. Bubble tail direction
+
+`chatItemShape` is a `GenericShape`. Compose already passes
+`LayoutDirection` into the shape's lambda; the original signature
+discarded it (`{ size, _ ->`). Capture it (`{ size, layoutDirection ->`)
+and flip the mirror predicate from `sent` to
+`sent != (layoutDirection == LayoutDirection.Rtl)`.
+
+```kotlin
+// Default path draws the tail at the bottom-left corner.
+val tailOnRight = sent != (layoutDirection == LayoutDirection.Rtl)
+if (tailOnRight) {
+  val matrix = Matrix()
+  matrix.scale(-1f, 1f)
+  this.transform(matrix)
+  this.translate(Offset(size.width, 0f))
+}
+```
+
+The bubble-tail `padding(start, end)` in `FramedItemView.kt` and
+`ChatView.kt` is already direction-aware, so the corrected shape falls
+into place against the existing padding under both directions
+automatically.
+
+### 2. App-bar slot placement
+
+`CenteredRowLayout` is a custom `Layout` with three slots
+(leading / center / trailing). It placed slots with absolute `place(x, y)`,
+which doesn't react to layout direction. Switch all three calls to
+`placeRelative(x, y)` — the standard Compose primitive that mirrors the
+x coordinate under RTL.
+
+```kotlin
+first.placeRelative(0, ...)
+second.placeRelative((maxWidth - second.width) / 2, ...)
+third.placeRelative(maxWidth - third.width, ...)
+```
+
+One source of truth, ≈ 11 call sites covered. `placeRelative` is
+identical to `place` under LTR — bit-exact LTR preservation.
+
+`DropdownMenu` `DpOffset(-width.value, ...)` calls in `ChatView.kt`
+are intentionally untouched: `DropdownMenuPositionProvider` already
+negates the content offset under RTL, so once `CenteredRowLayout` is
+fixed the chat-header menus anchor correctly without a call-site change.
+
+### 3. Asymmetric directional drawables
+
+Add `Modifier.mirrorIfRtl()` in
+`apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/Modifiers.kt`:
+
+```kotlin
+@Composable
+fun Modifier.mirrorIfRtl(): Modifier =
+  if (LocalLayoutDirection.current == LayoutDirection.Rtl)
+    this.scale(scaleX = -1f, scaleY = 1f)
+  else this
+```
+
+`Modifier.scale` is a draw-time transform: it does not change measured
+size or hit-test bounds. For the icons in question (square or
+near-square) it is visually identical to a mirrored asset and click
+areas remain correct.
+
+Apply at each call site whose drawable is intrinsically directional:
+
+- back chevron (`NavigationButtonBack`, `OnboardingCards`'s `BackButton`,
+  `ImageFullScreenView.desktop`, `WhatsNewView`'s "previous" pager,
+  `CommandsMenuView`)
+- forward chevron / arrow (`NewChatView`'s share-profile chevron,
+  `WhatsNewView`'s "next" pager, `CommandsMenuView`'s submenu chevron,
+  `GoToItemInnerButton`'s forward variant)
+- subscription-status waves (5 variants in `SubscriptionStatusIcon`)
+- sent-via-proxy arrow (`CIMetaView`, `ChatItemInfoView`)
+
+Two structural details for site-level callers:
+
+- **`SubscriptionStatusIcon`** renders the same `modifier` parameter at
+  five Icon callsites within a single composable. Hoist the mirror once
+  (`val iconModifier = modifier.mirrorIfRtl()`) and reuse — calling
+  `mirrorIfRtl()` once or five times yields the same `Modifier` value
+  inside one composition.
+- **`GoToItemInnerButton`** is a private helper that renders both a
+  directional icon (`ic_arrow_forward`, "go to forwarded source") and a
+  non-directional icon (`ic_search`, search-result indicator) through
+  the same `Icon(painterResource(icon), ...)` call. Add a
+  `mirror: Boolean = false` parameter and pass `mirror = true` only at
+  the directional callsite. The `ic_search` callsite keeps its default
+  and is unchanged.
+
+## Why this is correct under both layout directions
+
+| direction | sent | mirror? | tail position | profile side | OK |
+|---|---|---|---|---|---|
+| LTR | true  | yes | bottom-right | sender right | ✓ |
+| LTR | false | no  | bottom-left  | contact left | ✓ |
+| RTL | true  | no  | bottom-left  | sender left  | ✓ |
+| RTL | false | yes | bottom-right | contact right | ✓ |
+
+The XOR predicate `sent != isRtl` collapses to `sent` under LTR — bit-
+exact LTR preservation.
+
+`placeRelative` is identical to `place` under LTR. `mirrorIfRtl()`
+returns the receiver unchanged under LTR. No LTR location regresses.
+
+## Why a wider structural change is not in scope here
+
+These are deliberately deferred:
+
+1. **`GroupSndStatus.Forwarded`'s `ic_chevron_right_2`** in member
+   delivery status (long-press → Info → Delivery). Cleanly mirroring it
+   requires extending `GroupSndStatus.statusIcon()`'s return type so a
+   single `when (this)` produces `(icon, color, mirror)` — a
+   consumer-side `is Forwarded` check would dispatch on `status` a
+   second time and couple the consumer to status sub-types. The proper
+   fix is a model API change, deserving its own commit.
+
+2. **Two settings rows** route their icon through
+   `SimpleButtonIconEnded` and `SettingsPreferenceItem`, which don't
+   accept a per-icon `Modifier`. Fixing them requires extending those
+   helper signatures.
+
+3. **iOS-side**: not addressed because UIKit's RTL support and SwiftUI's
+   semantic edges already handle these cases.
+
+The PR aims at the user-visible regressions called out in the issue;
+deferring the above keeps the diff focused (+35/−16 across 12 files)
+and the regression risk low.
+
+## Verification
+
+Manual (Android + desktop) — switch in-app language to Arabic / Persian /
+Hebrew (or system locale to RTL) and walk through the screens called
+out in the issue:
+
+- Open any chat — sent-message tails point to your profile (visual side
+  closest to your avatar in 2-pane mode); received-message tails point
+  to the contact's avatar.
+- Chat header — call + 3-dot menu on the visual left, back chevron on
+  the visual right and pointing right (`>`). Tapping the 3-dot menu
+  opens a dropdown that anchors on the left and stays on-screen.
+- Settings → Your settings — back chevron points `>` and is on the right
+  edge of the navigation header.
+- Chat list header — profile avatar on the right; "Chats" title and
+  signal/wifi icon on the left, with the signal icon's "waves" mirrored.
+- Settings → About → What's new — pagination chevrons mirror.
+- Sent-via-proxy badge in chat-item meta and message info — arrow
+  mirrors.
+- Switch back to English — every above location matches pre-PR behavior;
+  no LTR regression.
+
+## Alternatives considered and rejected
+
+- **`android:autoMirrored="true"` on the vector drawables.** Would set
+  the mirror policy once per asset instead of once per call site. The
+  project's vector drawables are generated by moko-resources from SVGs,
+  and the SVG → vector XML pipeline doesn't currently propagate that
+  flag. Per-call-site `mirrorIfRtl()` is the available alternative; if
+  moko-resources adds the flag, the per-asset approach becomes cleaner
+  and the modifier calls can be removed.
+
+- **A `MirroredIcon` wrapper composable.** Each call site has different
+  surrounding modifiers (`size`, `height`, `padding`), tints, and
+  content descriptions. A wrapper would have to forward many parameters
+  and produce a worse interface than direct `.mirrorIfRtl()` in the
+  modifier chain.
+
+- **Mirror `ic_search` inside `GoToItemInnerButton`.** Material Design
+  recommends mirroring magnifying-glass icons under RTL (handle to
+  bottom-left), but the original PR doesn't mirror search icons
+  elsewhere and the issue doesn't call them out. Out of scope; revisit
+  in a focused pass over search-icon directionality if reported.
+
+- **Fix Forwarded delivery status icon by gating on
+  `status is GroupSndStatus.Forwarded` at the consumer.** Considered
+  during review and rejected: it dispatches on `status` a second time
+  (after `statusIcon()` already did), couples the consumer to specific
+  sub-types, and risks drift if a future status sub-type adopts a
+  directional icon. The proper fix is to fuse the dispatch by extending
+  `statusIcon()`'s return — deferred to its own commit.


### PR DESCRIPTION
Fixes #5448.

The issue documents four user-visible regressions under an RTL locale
(Arabic, Persian, Hebrew). This PR addresses all of them and a handful
of related directional-icon mirroring sites discovered while auditing.

## Changes

- **Chat bubble tail direction (`chatItemShape` in `ChatItemView.kt`).** The
  shape's `GenericShape` block now uses the `layoutDirection` parameter that
  Compose already passes in. The matrix-mirror predicate flips from `sent`
  to `sent != isRtl`, so sent-bubble tails point toward the user's profile
  and received-bubble tails toward the contact's profile under both LTR and
  RTL. The bubble-tail `padding(start, end)` in `FramedItemView.kt` and
  `ChatView.kt` is already direction-aware, so it falls into place against
  the corrected shape automatically.

- **App-bar slot mirroring (`CenteredRowLayout` in `FramedItemView.kt`).**
  Switched the three placements from `place(...)` to `placeRelative(...)`.
  Both the chat header (call + 3-dot-menu buttons, back arrow) and the chat
  list header (profile avatar, signal icon, "Chats" title) route through
  this layout, so one edit covers both panes.

- **Asymmetric directional drawables.** Added `Modifier.mirrorIfRtl()`
  (`Modifier.scale(-1f, 1f)` when `LocalLayoutDirection.current` is `Rtl`)
  in `views/helpers/Modifiers.kt` and applied it to:
  - the back arrow in `NavigationButtonBack`
  - all five variants of the `SubscriptionStatusIcon` waves
  - the pagination chevrons in `WhatsNewView`
  - the back arrow + submenu chevron in `CommandsMenuView`
  - the back arrow in `OnboardingCards`
  - the back arrow in `ImageFullScreenView.desktop`
  - the share-profile chevron in `NewChatView`
  - the sent-via-proxy arrow in `CIMetaView` and `ChatItemInfoView`

## Notes

- `DropdownMenu` `DpOffset(-width.value, ...)` calls in `ChatView.kt` are
  intentionally left as-is. `DropdownMenuPositionProvider` already negates
  the content offset under RTL, so once `CenteredRowLayout` is fixed the
  chat-header menus anchor correctly and open in the right direction
  without any code change at the call sites.
- Two settings rows route their icon through helpers
  (`SimpleButtonIconEnded`, `SettingsPreferenceItem`) that don't accept a
  per-icon `Modifier`. They are not addressed in this PR — fixing them
  would require extending those helper signatures and is out of scope for
  the user-visible bugs reported in the issue.
- No iOS-side changes — the iOS message composer architecture handles all
  these cases via UIKit's RTL support and SwiftUI's semantic edges.

## Test plan

Switch the in-app language to Arabic / Persian / Hebrew (or system locale
to RTL) and walk through the screens called out in the issue:

- [ ] Open any chat — sent-message tails point to your profile (visual
      side closest to your avatar in 2-pane mode); received-message tails
      point to the contact's avatar.
- [ ] Chat header — call + 3-dot menu on the visual left, back chevron on
      the visual right and pointing right (`>`). Tapping the 3-dot menu
      opens a dropdown that anchors on the left and stays on-screen.
- [ ] Settings → Your settings — back chevron points `>` and is on the
      right edge of the navigation header.
- [ ] Chat list header — profile avatar on the right; "Chats" title and
      signal/wifi icon on the left, with the signal icon's "waves"
      mirrored.
- [ ] Settings → About → What's new — pagination chevrons mirror.
- [ ] Sent-via-proxy badge in chat-item meta and message info — arrow
      mirrors.
- [ ] Switch back to English — every above location matches pre-PR
      behavior; no LTR regression.