### PR TITLE
android: handle screen-size config changes in MainActivity

### DIFF
--- a/apps/multiplatform/android/src/main/AndroidManifest.xml
+++ b/apps/multiplatform/android/src/main/AndroidManifest.xml
@@ -55,7 +55,7 @@
         android:exported="true"
         android:label="${app_name}"
         android:windowSoftInputMode="adjustResize"
-        android:configChanges="uiMode"
+        android:configChanges="uiMode|orientation|screenSize|screenLayout|smallestScreenSize"
         android:theme="@style/Theme.SimpleX">
       <intent-filter>
         <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
## Summary

Fix two flows on Android that, on Waydroid specifically, recreated `MainActivity` whenever app code wrote `requestedOrientation`:

1. **Voice recording in tap-to-stop mode.** Tap record button → screen flashed black → reopened with the recording shown stopped at ~1 second. (The recreate disposed `RecordVoiceView`'s `DisposableEffect`, which calls `rec.stop()`; the elapsed wall-clock time became the recording duration; `composeState` was preserved across the recreate so the user landed on a `VoicePreview` attachment.)
2. **Settings → Migrate to another device.** Tap the button → migrate UI never opened; the activity got stuck looping on a black-screen recreate, never reaching the modal.

## Root cause

Two callsites set `requestedOrientation` to a specific value:
- `LockToCurrentOrientationUntilDispose()` in `UI.android.kt:26-41`, used by `SendMsgView.kt:312` when entering tap-to-stop recording mode.
- `androidLockPortraitOrientation()` in `SimplexApp.kt:344-357`, used by `MigrateFromDevice.kt:157` and `MigrateToDevice.kt:172`.

`MainActivity` declared `android:configChanges="uiMode"` only, so Android destroyed and recreated the activity on every `requestedOrientation` write that resulted in a config change. Real Android devices and the AVD typically optimize the recreate away when the requested orientation already matches current; Waydroid's Wayland-to-Android display bridge does not, and additionally reports `screenSize`, `screenLayout`, and `smallestScreenSize` changes whenever the window is resized — which is also why the bug intermittently came back after the Waydroid window grew.

## Fix

Match `CallActivity`'s configChanges set (which doesn't exhibit the bug on the same platform):

```diff
- android:configChanges="uiMode"
+ android:configChanges="uiMode|orientation|screenSize|screenLayout|smallestScreenSize"
```

The two `requestedOrientation` callsites and all surrounding logic are unchanged — only the framework's response to those writes changes. Compose tracks `LocalConfiguration` and recomposes on configuration changes without needing the activity to be recreated.

## Resulting behavior on Waydroid

After the fix, both flows complete successfully without the activity being torn down. Because the `requestedOrientation` writes still happen, Waydroid honors them and resizes its window to a portrait aspect ratio when the recording UI / migrate UI is active.

- **Migrate flow:** the Waydroid resize matches what real Android does — `setRequestedOrientation(SCREEN_ORIENTATION_PORTRAIT)` constrains the activity to a portrait aspect on every Android target. No behavioral difference between Waydroid and a real phone here.
- **Voice recording:** Waydroid still resizes (because the activity declares a specific orientation), whereas on a real phone the same call typically has no visible effect because the device is already in the requested orientation. This is a Waydroid-specific cosmetic side-effect of the existing orientation lock; it is not introduced by this PR — it was already present pre-fix, just hidden behind the recreate-loop bug. Removing the resize would require changing the lock implementation itself (e.g. switching to `SCREEN_ORIENTATION_LOCKED`), which is out of scope here.

## Adversarial review

- **Resource selection by orientation/screen-size.** No `-land`, `-port`, `-sw*dp` directories in the project; only `-night` (handled by `uiMode`).
- **Compose configuration reads.** `Resources.android.kt` `windowWidth()` / `windowHeight()` use `LocalConfiguration.current` — updates correctly without recreate. `ImageFullScreenView.android.kt` reads `ctx.resources.configuration.screenWidthDp` inside a composable that recomposes on config change.
- **`MainActivity.onCreate` side effects.** `mainActivity = WeakReference(this)`, `enableEdgeToEdge()`, `window.setFlags(...)` all persist on the existing window. `setContent { AppScreen() }` runs once and Compose's recomposition handles config changes inside the existing tree. `schedulePeriodicServiceRestartWorker()` and `schedulePeriodicWakeUp()` use `enqueueUniquePeriodicWork(KEEP)` and `MessagesFetcherWorker.scheduleWork()` — idempotent. The `if (savedInstanceState == null)` guard at line 47 still correctly handles real `savedInstanceState` restore (process kill).
- **`onConfigurationChanged` overrides.** Zero in the codebase; default Activity behavior is sufficient because Compose observes configuration via `LocalConfiguration`.
- **CallActivity precedent.** Already declares `screenSize|smallestScreenSize|screenLayout|orientation` (`AndroidManifest.xml:153`) and is unaffected on Waydroid — direct evidence the set is correct.
- **`Locale` mutations** in `helpers/Locale.kt` still call `recreate()` explicitly; locale isn't in `configChanges`, so the framework would also recreate. No conflict.

## Test plan

- [x] Type-check Android.
- [x] APK builds clean.
- [x] Tested on Waydroid: voice recording (tap-to-stop) no longer flashes black; migrate flow now opens normally instead of looping on recreate; window resizing the Waydroid host no longer reintroduces the bug.
- [ ] AVD / real device: rotate while recording — orientation should stay locked, recording continues uninterrupted.
- [ ] Locale change (Settings → Language) still recreates the activity (orthogonal path).
- [ ] Calls (`CallActivity`) unaffected.
