### PR TITLE
desktop: keep text selection on the originally selected message when a new message arrives

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/TextSelection.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/TextSelection.kt
@@ -50,10 +50,13 @@ data class ItemContext(
 
 val LocalItemContext = compositionLocalOf { ItemContext() }
 
+// Selection is anchored to ChatItem IDs, not list positions, so it survives list mutations
+// (new message arrives, item deleted, etc.). Positional indices are derived from the current
+// items list on read — see SelectionManager.startIndex / endIndex.
 data class SelectionRange(
-    val startIndex: Int,
+    val startItemId: Long,
     val startOffset: Int,
-    val endIndex: Int,
+    val endItemId: Long,
     val endOffset: Int
 )
 
@@ -65,6 +68,10 @@ class SelectionManager {
 
     var range by mutableStateOf<SelectionRange?>(null)
         private set
+
+    // Current merged-items list, kept in sync by SelectionHandler so the manager can resolve
+    // item-id-anchored positions without callers threading the list through every call site.
+    var items by mutableStateOf<List<MergedItem>>(emptyList())
 
     var anchorWindowY by mutableStateOf(0f)
         private set
@@ -82,8 +89,17 @@ class SelectionManager {
     var onCopySelection: (() -> Unit)? = null
     private var autoScrollJob: Job? = null
 
+    // Positional indices derived from anchored item IDs against the current list.
+    // Cached via derivedStateOf so the O(n) scan runs once per items/range change, not once per
+    // per-item composable read (which would be O(n²)). Returns -1 if the anchored item is gone.
+    private val startIndexState = derivedStateOf { items.indexOfItemId(range?.startItemId) }
+    private val endIndexState = derivedStateOf { items.indexOfItemId(range?.endItemId) }
+    val startIndex: Int get() = startIndexState.value
+    val endIndex: Int get() = endIndexState.value
+
     fun startSelection(startIndex: Int, anchorY: Float, anchorX: Float) {
-        range = SelectionRange(startIndex, -1, startIndex, -1)
+        val id = items.getOrNull(startIndex)?.newest()?.item?.id ?: return
+        range = SelectionRange(id, -1, id, -1)
         selectionState = SelectionState.Selecting
         anchorWindowY = anchorY
         anchorWindowX = anchorX
@@ -96,7 +112,8 @@ class SelectionManager {
 
     fun updateFocusIndex(index: Int) {
         val r = range ?: return
-        range = r.copy(endIndex = index)
+        val id = items.getOrNull(index)?.newest()?.item?.id ?: return
+        range = r.copy(endItemId = id)
     }
 
     fun updateFocusOffset(offset: Int, charRect: Rect = Rect.Zero) {
@@ -112,17 +129,20 @@ class SelectionManager {
     }
 
     // Snaps boundary offsets to include full transformed segments (mentions, links with showText).
-    fun snapSelection(items: List<MergedItem>, linkMode: SimplexLinkMode) {
+    fun snapSelection(linkMode: SimplexLinkMode) {
         val r = range ?: return
-        val startCi = items.getOrNull(r.startIndex)?.newest()?.item
-        val endCi = items.getOrNull(r.endIndex)?.newest()?.item
+        val s = startIndex
+        val e = endIndex
+        if (s < 0 || e < 0) return
+        val startCi = items[s].newest().item
+        val endCi = items[e].newest().item
         // expandRight: snap in the direction that grows the selection
-        val startExpandRight = if (r.startIndex == r.endIndex) r.startOffset > r.endOffset else r.startIndex < r.endIndex
-        val endExpandRight = if (r.startIndex == r.endIndex) r.endOffset > r.startOffset else r.endIndex < r.startIndex
-        val snappedStart = if (startCi != null && r.startOffset >= 0)
+        val startExpandRight = if (s == e) r.startOffset > r.endOffset else s < e
+        val endExpandRight = if (s == e) r.endOffset > r.startOffset else e < s
+        val snappedStart = if (r.startOffset >= 0)
             snapOffset(startCi, r.startOffset, linkMode, expandRight = startExpandRight)
         else r.startOffset
-        val snappedEnd = if (endCi != null && r.endOffset >= 0)
+        val snappedEnd = if (r.endOffset >= 0)
             snapOffset(endCi, r.endOffset, linkMode, expandRight = endExpandRight)
         else r.endOffset
         if (snappedStart != r.startOffset || snappedEnd != r.endOffset) {
@@ -140,9 +160,10 @@ class SelectionManager {
     // Dragging up: button above focus char (bottom-right at char's top-left corner).
     // focusCharRect X is absolute window coords, Y is relative to item.
     fun copyButtonOffset(draggingDown: Boolean, gap: Float, buttonSize: IntSize): IntOffset {
-        val r = range ?: return IntOffset.Zero
+        val e = endIndex
+        if (e < 0) return IntOffset.Zero
         val ls = listState?.value ?: return IntOffset.Zero
-        val itemInfo = ls.layoutInfo.visibleItemsInfo.find { it.index == r.endIndex }
+        val itemInfo = ls.layoutInfo.visibleItemsInfo.find { it.index == e }
             ?: return IntOffset(-10000, -10000) // focus item scrolled off screen
         // Item top in viewport coords (reversed layout: viewportEnd - offset - size)
         val itemWindowY = (ls.layoutInfo.viewportEndOffset - itemInfo.offset - itemInfo.size).toFloat()
@@ -196,48 +217,55 @@ class SelectionManager {
         }
     }
 
-    fun getSelectedCopiedText(items: List<MergedItem>, revealedItems: Set<Long>, linkMode: SimplexLinkMode): String {
-        val r = range ?: return ""
-        val lo = minOf(r.startIndex, r.endIndex)
-        val hi = maxOf(r.startIndex, r.endIndex)
+    fun getSelectedCopiedText(revealedItems: Set<Long>, linkMode: SimplexLinkMode): String {
+        val s = startIndex
+        val e = endIndex
+        if (s < 0 || e < 0) return ""
+        val lo = minOf(s, e)
+        val hi = maxOf(s, e)
         return (lo..hi).mapNotNull { idx ->
-            val ci = items.getOrNull(idx)?.newest()?.item ?: return@mapNotNull null
+            val ci = items[idx].newest().item
             if (ci.meta.itemDeleted != null && (!revealedItems.contains(ci.id) || ci.isDeletedContent)) return@mapNotNull null
-            val sel = selectedRange(range, idx) ?: return@mapNotNull null
+            val sel = selectedRange(idx) ?: return@mapNotNull null
             selectedItemCopiedText(ci, sel, linkMode)
         }.reversed().joinToString("\n")
     }
-}
 
-// Returns the character range selected within a given item.
-// Offsets are cursor positions (between characters), so the selected characters
-// are those between min and max cursors: range is min..(max - 1).
-// In reversed layout: higher index = higher on screen.
-// startIndex/startOffset = anchor, endIndex/endOffset = focus.
-fun selectedRange(range: SelectionRange?, index: Int): IntRange? {
-    val r = range ?: return null
-    val lo = minOf(r.startIndex, r.endIndex)
-    val hi = maxOf(r.startIndex, r.endIndex)
-    if (index < lo || index > hi) return null
-    return when {
-        // Single-item selection: characters between the two cursor positions
-        index == r.startIndex && index == r.endIndex ->
-            if (r.startOffset < 0 || r.endOffset < 0 || r.startOffset == r.endOffset) null
-            else minOf(r.startOffset, r.endOffset) .. (maxOf(r.startOffset, r.endOffset) - 1)
-        // Anchor item in multi-item selection: from cursor to end, or from start to cursor
-        index == r.startIndex ->
-            if (r.startOffset < 0) null
-            else if (r.startIndex > r.endIndex) r.startOffset until Int.MAX_VALUE
-            else 0 until r.startOffset
-        // Focus item in multi-item selection: symmetric to anchor
-        index == r.endIndex ->
-            if (r.endOffset < 0) null
-            else if (r.endIndex < r.startIndex) 0 until r.endOffset
-            else r.endOffset until Int.MAX_VALUE
-        // Interior items: fully selected
-        else -> 0 until Int.MAX_VALUE
+    // Returns the character range selected within the item at [index] in the current items list.
+    // Offsets are cursor positions (between characters); selected characters are between min and max
+    // cursors: range is min..(max - 1). In reversed layout: higher index = higher on screen.
+    // startItemId/startOffset = anchor, endItemId/endOffset = focus.
+    fun selectedRange(index: Int): IntRange? {
+        val r = range ?: return null
+        val s = startIndex
+        val e = endIndex
+        if (s < 0 || e < 0) return null
+        val lo = minOf(s, e)
+        val hi = maxOf(s, e)
+        if (index < lo || index > hi) return null
+        return when {
+            // Single-item selection: characters between the two cursor positions
+            index == s && index == e ->
+                if (r.startOffset < 0 || r.endOffset < 0 || r.startOffset == r.endOffset) null
+                else minOf(r.startOffset, r.endOffset) .. (maxOf(r.startOffset, r.endOffset) - 1)
+            // Anchor item in multi-item selection: from cursor to end, or from start to cursor
+            index == s ->
+                if (r.startOffset < 0) null
+                else if (s > e) r.startOffset until Int.MAX_VALUE
+                else 0 until r.startOffset
+            // Focus item in multi-item selection: symmetric to anchor
+            index == e ->
+                if (r.endOffset < 0) null
+                else if (e < s) 0 until r.endOffset
+                else r.endOffset until Int.MAX_VALUE
+            // Interior items: fully selected
+            else -> 0 until Int.MAX_VALUE
+        }
     }
 }
+
+private fun List<MergedItem>.indexOfItemId(id: Long?): Int =
+    if (id == null) -1 else indexOfFirst { it.newest().item.id == id }
 
 // Extracts source text for the selected range within one item.
 // Selection offsets are in display-text space. For transformed segments (mentions, links with showText),
@@ -313,8 +341,17 @@ fun BoxScope.SelectionHandler(
 
     manager.listState = listState
     manager.onCopySelection = {
-        clipboard.setText(AnnotatedString(manager.getSelectedCopiedText(mergedItems.value.items, revealedItems.value, linkMode)))
+        clipboard.setText(AnnotatedString(manager.getSelectedCopiedText(revealedItems.value, linkMode)))
         showToast(generalGetString(MR.strings.copied))
+    }
+
+    // Keep the manager's view of the items list in sync, then clear the selection synchronously
+    // (same frame, no visible flash) if either anchored item no longer exists — e.g. it was deleted.
+    SideEffect {
+        manager.items = mergedItems.value.items
+        if (manager.range != null && (manager.startIndex < 0 || manager.endIndex < 0)) {
+            manager.clearSelection()
+        }
     }
 
     return Modifier
@@ -374,7 +411,7 @@ fun BoxScope.SelectionHandler(
                         SelectionState.Selecting -> {
                             if (!event.pressed) {
                                 manager.endSelection()
-                                manager.snapSelection(mergedItems.value.items, linkMode)
+                                manager.snapSelection(linkMode)
                                 return@awaitEachGesture
                             }
                             val windowPos = event.position + manager.viewportPosition
@@ -411,7 +448,7 @@ fun setupItemSelection(selectionManager: SelectionManager?, selectionIndex: Int,
 
     if (selectionManager != null && selectionIndex >= 0 && !isLive) {
         val isAnchor = remember(selectionIndex) {
-            derivedStateOf { selectionManager.range?.startIndex == selectionIndex && selectionManager.selectionState == SelectionState.Selecting }
+            derivedStateOf { selectionManager.startIndex == selectionIndex && selectionManager.selectionState == SelectionState.Selecting }
         }
         LaunchedEffect(isAnchor.value) {
             if (!isAnchor.value) return@LaunchedEffect
@@ -424,7 +461,7 @@ fun setupItemSelection(selectionManager: SelectionManager?, selectionIndex: Int,
         }
 
         val isFocus = remember(selectionIndex) {
-            derivedStateOf { selectionManager.range?.endIndex == selectionIndex && selectionManager.selectionState == SelectionState.Selecting }
+            derivedStateOf { selectionManager.endIndex == selectionIndex && selectionManager.selectionState == SelectionState.Selecting }
         }
         if (isFocus.value) {
             LaunchedEffect(Unit) {
@@ -452,7 +489,7 @@ fun setupItemSelection(selectionManager: SelectionManager?, selectionIndex: Int,
     }
 
     val highlightRange = if (selectionManager != null && selectionIndex >= 0) {
-        remember(selectionIndex) { derivedStateOf { selectedRange(selectionManager.range, selectionIndex) } }.value
+        remember(selectionIndex) { derivedStateOf { selectionManager.selectedRange(selectionIndex) } }.value
     } else null
 
     val positionModifier = if (selectionManager != null) {
@@ -475,7 +512,7 @@ fun setupEmojiSelection(selectionManager: SelectionManager?, selectionIndex: Int
     if (selectionManager == null || selectionIndex < 0) return false
 
     val isAnchor = remember(selectionIndex) {
-        derivedStateOf { selectionManager.range?.startIndex == selectionIndex && selectionManager.selectionState == SelectionState.Selecting }
+        derivedStateOf { selectionManager.startIndex == selectionIndex && selectionManager.selectionState == SelectionState.Selecting }
     }
     LaunchedEffect(isAnchor.value) {
         if (!isAnchor.value) return@LaunchedEffect
@@ -483,7 +520,7 @@ fun setupEmojiSelection(selectionManager: SelectionManager?, selectionIndex: Int
     }
 
     val isFocus = remember(selectionIndex) {
-        derivedStateOf { selectionManager.range?.endIndex == selectionIndex && selectionManager.selectionState == SelectionState.Selecting }
+        derivedStateOf { selectionManager.endIndex == selectionIndex && selectionManager.selectionState == SelectionState.Selecting }
     }
     if (isFocus.value) {
         LaunchedEffect(Unit) {
@@ -492,7 +529,7 @@ fun setupEmojiSelection(selectionManager: SelectionManager?, selectionIndex: Int
         }
     }
 
-    return remember(selectionIndex) { derivedStateOf { selectedRange(selectionManager.range, selectionIndex) != null } }.value
+    return remember(selectionIndex) { derivedStateOf { selectionManager.selectedRange(selectionIndex) != null } }.value
 }
 
 @Composable
@@ -500,7 +537,10 @@ fun SelectionCopyButton() {
     val manager = LocalSelectionManager.current ?: return
     val range = manager.range ?: return
     if (manager.selectionState != SelectionState.Selected || manager.focusCharRect == Rect.Zero) return
-    val draggingDown = range.startIndex > range.endIndex || (range.startIndex == range.endIndex && range.startOffset < range.endOffset)
+    val s = manager.startIndex
+    val e = manager.endIndex
+    if (s < 0 || e < 0) return
+    val draggingDown = s > e || (s == e && range.startOffset < range.endOffset)
     val gap = with(LocalDensity.current) { 4.dp.toPx() }
     var buttonSize by remember { mutableStateOf(IntSize.Zero) }
     Row(

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/TextSelection.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/TextSelection.kt
@@ -50,12 +50,11 @@ data class ItemContext(
 
 val LocalItemContext = compositionLocalOf { ItemContext() }
 
-// Selection is anchored to ChatItem IDs, not list positions, so it survives list mutations
-// (new message arrives, item deleted, etc.). Positional indices are derived from the current
-// items list on read — see SelectionManager.startIndex / endIndex.
 data class SelectionRange(
+    val startIndex: Int,
     val startItemId: Long,
     val startOffset: Int,
+    val endIndex: Int,
     val endItemId: Long,
     val endOffset: Int
 )
@@ -68,10 +67,6 @@ class SelectionManager {
 
     var range by mutableStateOf<SelectionRange?>(null)
         private set
-
-    // Current merged-items list, kept in sync by SelectionHandler so the manager can resolve
-    // item-id-anchored positions without callers threading the list through every call site.
-    var items by mutableStateOf<List<MergedItem>>(emptyList())
 
     var anchorWindowY by mutableStateOf(0f)
         private set
@@ -86,20 +81,13 @@ class SelectionManager {
     var viewportPosition by mutableStateOf(Offset.Zero)
     var focusCharRect by mutableStateOf(Rect.Zero) // X: absolute window, Y: relative to item
     var listState: State<LazyListState>? = null
+    var mergedItemsState: State<MergedItems>? = null
     var onCopySelection: (() -> Unit)? = null
     private var autoScrollJob: Job? = null
 
-    // Positional indices derived from anchored item IDs against the current list.
-    // Cached via derivedStateOf so the O(n) scan runs once per items/range change, not once per
-    // per-item composable read (which would be O(n²)). Returns -1 if the anchored item is gone.
-    private val startIndexState = derivedStateOf { items.indexOfItemId(range?.startItemId) }
-    private val endIndexState = derivedStateOf { items.indexOfItemId(range?.endItemId) }
-    val startIndex: Int get() = startIndexState.value
-    val endIndex: Int get() = endIndexState.value
-
     fun startSelection(startIndex: Int, anchorY: Float, anchorX: Float) {
-        val id = items.getOrNull(startIndex)?.newest()?.item?.id ?: return
-        range = SelectionRange(id, -1, id, -1)
+        val id = mergedItemsState?.value?.items?.getOrNull(startIndex)?.newest()?.item?.id ?: return
+        range = SelectionRange(startIndex, id, -1, startIndex, id, -1)
         selectionState = SelectionState.Selecting
         anchorWindowY = anchorY
         anchorWindowX = anchorX
@@ -112,8 +100,8 @@ class SelectionManager {
 
     fun updateFocusIndex(index: Int) {
         val r = range ?: return
-        val id = items.getOrNull(index)?.newest()?.item?.id ?: return
-        range = r.copy(endItemId = id)
+        val id = mergedItemsState?.value?.items?.getOrNull(index)?.newest()?.item?.id ?: return
+        range = r.copy(endIndex = index, endItemId = id)
     }
 
     fun updateFocusOffset(offset: Int, charRect: Rect = Rect.Zero) {
@@ -129,20 +117,17 @@ class SelectionManager {
     }
 
     // Snaps boundary offsets to include full transformed segments (mentions, links with showText).
-    fun snapSelection(linkMode: SimplexLinkMode) {
+    fun snapSelection(items: List<MergedItem>, linkMode: SimplexLinkMode) {
         val r = range ?: return
-        val s = startIndex
-        val e = endIndex
-        if (s < 0 || e < 0) return
-        val startCi = items[s].newest().item
-        val endCi = items[e].newest().item
+        val startCi = items.getOrNull(r.startIndex)?.newest()?.item
+        val endCi = items.getOrNull(r.endIndex)?.newest()?.item
         // expandRight: snap in the direction that grows the selection
-        val startExpandRight = if (s == e) r.startOffset > r.endOffset else s < e
-        val endExpandRight = if (s == e) r.endOffset > r.startOffset else e < s
-        val snappedStart = if (r.startOffset >= 0)
+        val startExpandRight = if (r.startIndex == r.endIndex) r.startOffset > r.endOffset else r.startIndex < r.endIndex
+        val endExpandRight = if (r.startIndex == r.endIndex) r.endOffset > r.startOffset else r.endIndex < r.startIndex
+        val snappedStart = if (startCi != null && r.startOffset >= 0)
             snapOffset(startCi, r.startOffset, linkMode, expandRight = startExpandRight)
         else r.startOffset
-        val snappedEnd = if (r.endOffset >= 0)
+        val snappedEnd = if (endCi != null && r.endOffset >= 0)
             snapOffset(endCi, r.endOffset, linkMode, expandRight = endExpandRight)
         else r.endOffset
         if (snappedStart != r.startOffset || snappedEnd != r.endOffset) {
@@ -160,10 +145,9 @@ class SelectionManager {
     // Dragging up: button above focus char (bottom-right at char's top-left corner).
     // focusCharRect X is absolute window coords, Y is relative to item.
     fun copyButtonOffset(draggingDown: Boolean, gap: Float, buttonSize: IntSize): IntOffset {
-        val e = endIndex
-        if (e < 0) return IntOffset.Zero
+        val r = range ?: return IntOffset.Zero
         val ls = listState?.value ?: return IntOffset.Zero
-        val itemInfo = ls.layoutInfo.visibleItemsInfo.find { it.index == e }
+        val itemInfo = ls.layoutInfo.visibleItemsInfo.find { it.index == r.endIndex }
             ?: return IntOffset(-10000, -10000) // focus item scrolled off screen
         // Item top in viewport coords (reversed layout: viewportEnd - offset - size)
         val itemWindowY = (ls.layoutInfo.viewportEndOffset - itemInfo.offset - itemInfo.size).toFloat()
@@ -196,6 +180,15 @@ class SelectionManager {
         updateFocusIndex(idx)
     }
 
+    fun resyncIndices() {
+        val r = range ?: return
+        val items = mergedItemsState?.value?.items ?: return
+        val newStartIndex = items.indexOfFirst { it.newest().item.id == r.startItemId }
+        val newEndIndex = items.indexOfFirst { it.newest().item.id == r.endItemId }
+        if (newStartIndex < 0 || newEndIndex < 0) clearSelection()
+        else range = r.copy(startIndex = newStartIndex, endIndex = newEndIndex)
+    }
+
     fun updateAutoScroll(draggingDown: Boolean, pointerY: Float, scope: CoroutineScope) {
         val edgeDistance = if (draggingDown) viewportBottom - pointerY else pointerY - viewportTop
         if (edgeDistance !in 0f..AUTO_SCROLL_ZONE_PX) {
@@ -217,55 +210,48 @@ class SelectionManager {
         }
     }
 
-    fun getSelectedCopiedText(revealedItems: Set<Long>, linkMode: SimplexLinkMode): String {
-        val s = startIndex
-        val e = endIndex
-        if (s < 0 || e < 0) return ""
-        val lo = minOf(s, e)
-        val hi = maxOf(s, e)
+    fun getSelectedCopiedText(items: List<MergedItem>, revealedItems: Set<Long>, linkMode: SimplexLinkMode): String {
+        val r = range ?: return ""
+        val lo = minOf(r.startIndex, r.endIndex)
+        val hi = maxOf(r.startIndex, r.endIndex)
         return (lo..hi).mapNotNull { idx ->
-            val ci = items[idx].newest().item
+            val ci = items.getOrNull(idx)?.newest()?.item ?: return@mapNotNull null
             if (ci.meta.itemDeleted != null && (!revealedItems.contains(ci.id) || ci.isDeletedContent)) return@mapNotNull null
-            val sel = selectedRange(idx) ?: return@mapNotNull null
+            val sel = selectedRange(range, idx) ?: return@mapNotNull null
             selectedItemCopiedText(ci, sel, linkMode)
         }.reversed().joinToString("\n")
     }
-
-    // Returns the character range selected within the item at [index] in the current items list.
-    // Offsets are cursor positions (between characters); selected characters are between min and max
-    // cursors: range is min..(max - 1). In reversed layout: higher index = higher on screen.
-    // startItemId/startOffset = anchor, endItemId/endOffset = focus.
-    fun selectedRange(index: Int): IntRange? {
-        val r = range ?: return null
-        val s = startIndex
-        val e = endIndex
-        if (s < 0 || e < 0) return null
-        val lo = minOf(s, e)
-        val hi = maxOf(s, e)
-        if (index < lo || index > hi) return null
-        return when {
-            // Single-item selection: characters between the two cursor positions
-            index == s && index == e ->
-                if (r.startOffset < 0 || r.endOffset < 0 || r.startOffset == r.endOffset) null
-                else minOf(r.startOffset, r.endOffset) .. (maxOf(r.startOffset, r.endOffset) - 1)
-            // Anchor item in multi-item selection: from cursor to end, or from start to cursor
-            index == s ->
-                if (r.startOffset < 0) null
-                else if (s > e) r.startOffset until Int.MAX_VALUE
-                else 0 until r.startOffset
-            // Focus item in multi-item selection: symmetric to anchor
-            index == e ->
-                if (r.endOffset < 0) null
-                else if (e < s) 0 until r.endOffset
-                else r.endOffset until Int.MAX_VALUE
-            // Interior items: fully selected
-            else -> 0 until Int.MAX_VALUE
-        }
-    }
 }
 
-private fun List<MergedItem>.indexOfItemId(id: Long?): Int =
-    if (id == null) -1 else indexOfFirst { it.newest().item.id == id }
+// Returns the character range selected within a given item.
+// Offsets are cursor positions (between characters), so the selected characters
+// are those between min and max cursors: range is min..(max - 1).
+// In reversed layout: higher index = higher on screen.
+// startIndex/startOffset = anchor, endIndex/endOffset = focus.
+fun selectedRange(range: SelectionRange?, index: Int): IntRange? {
+    val r = range ?: return null
+    val lo = minOf(r.startIndex, r.endIndex)
+    val hi = maxOf(r.startIndex, r.endIndex)
+    if (index < lo || index > hi) return null
+    return when {
+        // Single-item selection: characters between the two cursor positions
+        index == r.startIndex && index == r.endIndex ->
+            if (r.startOffset < 0 || r.endOffset < 0 || r.startOffset == r.endOffset) null
+            else minOf(r.startOffset, r.endOffset) .. (maxOf(r.startOffset, r.endOffset) - 1)
+        // Anchor item in multi-item selection: from cursor to end, or from start to cursor
+        index == r.startIndex ->
+            if (r.startOffset < 0) null
+            else if (r.startIndex > r.endIndex) r.startOffset until Int.MAX_VALUE
+            else 0 until r.startOffset
+        // Focus item in multi-item selection: symmetric to anchor
+        index == r.endIndex ->
+            if (r.endOffset < 0) null
+            else if (r.endIndex < r.startIndex) 0 until r.endOffset
+            else r.endOffset until Int.MAX_VALUE
+        // Interior items: fully selected
+        else -> 0 until Int.MAX_VALUE
+    }
+}
 
 // Extracts source text for the selected range within one item.
 // Selection offsets are in display-text space. For transformed segments (mentions, links with showText),
@@ -340,19 +326,14 @@ fun BoxScope.SelectionHandler(
     }
 
     manager.listState = listState
+    manager.mergedItemsState = mergedItems
     manager.onCopySelection = {
-        clipboard.setText(AnnotatedString(manager.getSelectedCopiedText(revealedItems.value, linkMode)))
+        clipboard.setText(AnnotatedString(manager.getSelectedCopiedText(mergedItems.value.items, revealedItems.value, linkMode)))
         showToast(generalGetString(MR.strings.copied))
     }
 
-    // Keep the manager's view of the items list in sync, then clear the selection synchronously
-    // (same frame, no visible flash) if either anchored item no longer exists — e.g. it was deleted.
-    SideEffect {
-        manager.items = mergedItems.value.items
-        if (manager.range != null && (manager.startIndex < 0 || manager.endIndex < 0)) {
-            manager.clearSelection()
-        }
-    }
+    // Resync after the items list mutates (new message arrives, item deleted).
+    SideEffect { manager.resyncIndices() }
 
     return Modifier
         .focusRequester(focusRequester)
@@ -411,7 +392,7 @@ fun BoxScope.SelectionHandler(
                         SelectionState.Selecting -> {
                             if (!event.pressed) {
                                 manager.endSelection()
-                                manager.snapSelection(linkMode)
+                                manager.snapSelection(mergedItems.value.items, linkMode)
                                 return@awaitEachGesture
                             }
                             val windowPos = event.position + manager.viewportPosition
@@ -448,7 +429,7 @@ fun setupItemSelection(selectionManager: SelectionManager?, selectionIndex: Int,
 
     if (selectionManager != null && selectionIndex >= 0 && !isLive) {
         val isAnchor = remember(selectionIndex) {
-            derivedStateOf { selectionManager.startIndex == selectionIndex && selectionManager.selectionState == SelectionState.Selecting }
+            derivedStateOf { selectionManager.range?.startIndex == selectionIndex && selectionManager.selectionState == SelectionState.Selecting }
         }
         LaunchedEffect(isAnchor.value) {
             if (!isAnchor.value) return@LaunchedEffect
@@ -461,7 +442,7 @@ fun setupItemSelection(selectionManager: SelectionManager?, selectionIndex: Int,
         }
 
         val isFocus = remember(selectionIndex) {
-            derivedStateOf { selectionManager.endIndex == selectionIndex && selectionManager.selectionState == SelectionState.Selecting }
+            derivedStateOf { selectionManager.range?.endIndex == selectionIndex && selectionManager.selectionState == SelectionState.Selecting }
         }
         if (isFocus.value) {
             LaunchedEffect(Unit) {
@@ -489,7 +470,7 @@ fun setupItemSelection(selectionManager: SelectionManager?, selectionIndex: Int,
     }
 
     val highlightRange = if (selectionManager != null && selectionIndex >= 0) {
-        remember(selectionIndex) { derivedStateOf { selectionManager.selectedRange(selectionIndex) } }.value
+        remember(selectionIndex) { derivedStateOf { selectedRange(selectionManager.range, selectionIndex) } }.value
     } else null
 
     val positionModifier = if (selectionManager != null) {
@@ -512,7 +493,7 @@ fun setupEmojiSelection(selectionManager: SelectionManager?, selectionIndex: Int
     if (selectionManager == null || selectionIndex < 0) return false
 
     val isAnchor = remember(selectionIndex) {
-        derivedStateOf { selectionManager.startIndex == selectionIndex && selectionManager.selectionState == SelectionState.Selecting }
+        derivedStateOf { selectionManager.range?.startIndex == selectionIndex && selectionManager.selectionState == SelectionState.Selecting }
     }
     LaunchedEffect(isAnchor.value) {
         if (!isAnchor.value) return@LaunchedEffect
@@ -520,7 +501,7 @@ fun setupEmojiSelection(selectionManager: SelectionManager?, selectionIndex: Int
     }
 
     val isFocus = remember(selectionIndex) {
-        derivedStateOf { selectionManager.endIndex == selectionIndex && selectionManager.selectionState == SelectionState.Selecting }
+        derivedStateOf { selectionManager.range?.endIndex == selectionIndex && selectionManager.selectionState == SelectionState.Selecting }
     }
     if (isFocus.value) {
         LaunchedEffect(Unit) {
@@ -529,7 +510,7 @@ fun setupEmojiSelection(selectionManager: SelectionManager?, selectionIndex: Int
         }
     }
 
-    return remember(selectionIndex) { derivedStateOf { selectionManager.selectedRange(selectionIndex) != null } }.value
+    return remember(selectionIndex) { derivedStateOf { selectedRange(selectionManager.range, selectionIndex) != null } }.value
 }
 
 @Composable
@@ -537,10 +518,7 @@ fun SelectionCopyButton() {
     val manager = LocalSelectionManager.current ?: return
     val range = manager.range ?: return
     if (manager.selectionState != SelectionState.Selected || manager.focusCharRect == Rect.Zero) return
-    val s = manager.startIndex
-    val e = manager.endIndex
-    if (s < 0 || e < 0) return
-    val draggingDown = s > e || (s == e && range.startOffset < range.endOffset)
+    val draggingDown = range.startIndex > range.endIndex || (range.startIndex == range.endIndex && range.startOffset < range.endOffset)
     val gap = with(LocalDensity.current) { 4.dp.toPx() }
     var buttonSize by remember { mutableStateOf(IntSize.Zero) }
     Row(

--- a/plans/2026-05-08-desktop-text-selection-id-anchored.md
+++ b/plans/2026-05-08-desktop-text-selection-id-anchored.md
@@ -1,0 +1,145 @@
+# Desktop Text Selection — Anchor by Item Id
+
+## 1. The bug
+
+`SelectionRange` stored two **positional** indices into the reversed merged-items list:
+
+```kotlin
+data class SelectionRange(
+    val startIndex: Int,
+    val startOffset: Int,
+    val endIndex: Int,
+    val endOffset: Int
+)
+```
+
+`reversedChatItems` grows from the front: a new message is prepended at index 0, every existing item shifts +1. Selection indices were never adjusted, so once the user had a selection on a message and another message arrived (or was sent), the indices kept pointing to the same numerical positions while the items at those positions had changed. The highlight (and the copy result) silently moved onto neighbouring messages.
+
+Same root cause for the deletion case: removing an item from the list left selection indices pointing into a different item.
+
+## 2. Root cause
+
+Selection is **about items**, not positions. Storing positions into a list whose front grows is structurally wrong. The data structure must encode the stable identity (`ChatItem.id`), not the volatile position.
+
+Two ingredients are mandatory for any correct fix:
+
+1. **Remember which items** are anchor and focus (their stable `ChatItem.id`s).
+2. **Update the positional indices** when the list mutates, so that everything downstream that reads `range.startIndex` / `range.endIndex` (highlight rendering, copy iteration, snap, copy-button placement, anchor/focus detection in `setupItemSelection` / `setupEmojiSelection`, drag direction in `SelectionCopyButton`) stays correct.
+
+Anything beyond this is structural overreach.
+
+## 3. Approaches considered
+
+| # | Approach | Note |
+|---|----------|------|
+| A | Replace positional indices with ids in `SelectionRange`; cache items on the manager via `mutableStateOf`; expose indices via `derivedStateOf`; rename every reader from `range?.startIndex` to `manager.startIndex`; move top-level `selectedRange` into the manager as a method. | Structurally clean (single source of truth = ids), but renames every reader and moves a function for no behaviour reason. Ripples through `setupItemSelection`, `setupEmojiSelection`, `SelectionCopyButton`, `getSelectedCopiedText`, `snapSelection`, `copyButtonOffset`. |
+| B | Same as A but replace the cached `var items` with `var mergedItemsState: State<MergedItems>?` (mirrors the existing `listState` field; eliminates duplicated state and the items-sync line in `SideEffect`). | Marginal improvement; the cost is still the renames and the function move, neither of which the bug requires. |
+| C | **Final** — keep positional indices in `SelectionRange`, **add** `startItemId, endItemId` alongside them; resync the indices to the items they were anchored to on every recomposition via a `SideEffect`. | Every existing reader of `range.startIndex` / `range.endIndex` keeps working unchanged. The fix is a pure addition. |
+
+Approach C accepts one piece of structural duplication that A and B do not have: anchor ids and positional indices coexist in `SelectionRange`, kept consistent by `resyncIndices`. For a bug-fix change, the trade-off favours diff minimality — migrating to a single source of truth (ids only, indices derived) is a separate refactor that should not be bundled with a fix.
+
+## 4. Final implementation
+
+### 4.1 `SelectionRange` — two new fields
+
+```kotlin
+data class SelectionRange(
+    val startIndex: Int,
+    val startItemId: Long,   // NEW — stable anchor for the selection start
+    val startOffset: Int,
+    val endIndex: Int,
+    val endItemId: Long,     // NEW — stable anchor for the selection focus
+    val endOffset: Int,
+)
+```
+
+Existing `r.copy(startOffset = …)`, `r.copy(endOffset = …)`, `r.copy(startOffset = …, endOffset = …)` calls in `setAnchorOffset` / `updateFocusOffset` / `snapSelection` automatically preserve the new fields (data-class `copy` semantics). No change to those methods.
+
+### 4.2 `SelectionManager` — one new field, two body additions, one new method
+
+```kotlin
+var mergedItemsState: State<MergedItems>? = null   // mirrors existing listState
+```
+
+`startSelection` looks up the id once at click time:
+
+```kotlin
+fun startSelection(startIndex: Int, anchorY: Float, anchorX: Float) {
+    val id = mergedItemsState?.value?.items?.getOrNull(startIndex)?.newest()?.item?.id ?: return
+    range = SelectionRange(startIndex, id, -1, startIndex, id, -1)
+    selectionState = SelectionState.Selecting
+    anchorWindowY = anchorY
+    anchorWindowX = anchorX
+}
+```
+
+`updateFocusIndex` updates `endItemId` whenever it updates `endIndex` (called both from `updateDragFocus` and from the scroll snapshotFlow — both paths covered by this single method):
+
+```kotlin
+fun updateFocusIndex(index: Int) {
+    val r = range ?: return
+    val id = mergedItemsState?.value?.items?.getOrNull(index)?.newest()?.item?.id ?: return
+    range = r.copy(endIndex = index, endItemId = id)
+}
+```
+
+New method:
+
+```kotlin
+fun resyncIndices() {
+    val r = range ?: return
+    val items = mergedItemsState?.value?.items ?: return
+    val newStartIndex = items.indexOfFirst { it.newest().item.id == r.startItemId }
+    val newEndIndex = items.indexOfFirst { it.newest().item.id == r.endItemId }
+    if (newStartIndex < 0 || newEndIndex < 0) clearSelection()
+    else range = r.copy(startIndex = newStartIndex, endIndex = newEndIndex)
+}
+```
+
+### 4.3 `SelectionHandler` — three new lines
+
+```kotlin
+manager.listState = listState
+manager.mergedItemsState = mergedItems        // NEW — wires items into the manager
+manager.onCopySelection = { … }
+
+// Resync after the items list mutates (new message arrives, item deleted).
+SideEffect { manager.resyncIndices() }        // NEW — the trigger
+```
+
+### 4.4 What is *not* changed
+
+- `selectedRange(range, index)` — still a top-level function with its existing signature.
+- `getSelectedCopiedText(items, revealedItems, linkMode)` — same signature, same body.
+- `snapSelection(items, linkMode)` — same signature, same body.
+- `copyButtonOffset(...)` — uses `r.endIndex` directly; no change.
+- `setupItemSelection`, `setupEmojiSelection`, `SelectionCopyButton` — every `range?.startIndex` / `range?.endIndex` reference is preserved verbatim.
+- `startDragSelection`, `updateDragFocus`, `startSelection` (signature), `updateFocusIndex` (signature) — unchanged. `mergedItemsState` is reached via the manager's own field, so callers don't thread items.
+
+This is the structural property that compresses the diff: callers see no API change, and the file's structure (top-level `selectedRange`, top-level `selectedItemCopiedText`, top-level `snapOffset`, top-level extension helpers) is untouched.
+
+## 5. Why this works in Compose
+
+`SideEffect { manager.resyncIndices() }` runs after every successful composition of `SelectionHandler`. `SelectionHandler` returns a `Modifier` (non-Unit return → non-skippable), so it re-runs whenever its caller (`ChatView`) re-runs, which `ChatView` does whenever `mergedItems.value` changes (it iterates the items list directly). Within the same Compose frame, the `SideEffect` mutation of `range` invalidates the children that read `range`, and Compose re-runs them to convergence before commit. Net visible result: the selection highlight stays on the originally selected items on the same frame the new message arrives — same fidelity as a `derivedStateOf`-based approach, no observable lag.
+
+`mergedItemsState` is a plain `var` (not `mutableStateOf`) — this is fine because (a) it is reassigned on every recomposition of `SelectionHandler` to the same `State<MergedItems>` reference, and (b) the values inside it are read through `State.value`, which Compose tracks. The pattern is identical to the existing `var listState: State<LazyListState>? = null` field on the manager.
+
+## 6. Behaviour changes — full inventory
+
+1. **Selection follows the original messages when the items list mutates.** This is the bug fix.
+2. **Selection clears if either anchor item is removed from the list** (e.g. message deleted from another session). Previously, indices silently slid onto neighbouring messages. The new behaviour is `clearSelection()` when `indexOfFirst` returns -1. This is a side-effect of anchoring by id — once the anchor is gone, "the selection" is no longer well-defined. It is the same class of bug as #6.1 and is fixed by the same mechanism.
+3. **Defensive `?: return` in `startSelection` and `updateFocusIndex`** when the id lookup fails. In practice this branch is unreachable: `mergedItemsState` is wired before any user input; the index passed in always comes from `resolveIndexAtY` (which only returns visible-item indices); `newest().item` is non-null for any merged item. No observable change, but worth flagging for completeness.
+
+Nothing else changes. Verified by reading the diff against master line-by-line.
+
+## 7. Verification
+
+1. **Linux desktop build** succeeded end-to-end, producing `SimpleX_Chat-x86_64.AppImage`. No compilation errors, no Compose runtime issues from the new field on the manager or the new fields on `SelectionRange`.
+2. **Manual flow against the test plan**: selection persists across `new-message-arrives`, `new-message-sent`, multi-item span; deletion clears (see §6.2); drag-select & copy button behaviour preserved.
+
+## 8. Trade-offs and follow-ups
+
+The two pieces of structural debt this change knowingly leaves in place:
+
+1. **Anchor ids and positional indices coexist in `SelectionRange`.** Single source of truth would store only ids and derive indices on read. The cost of unifying is the rename and function-move churn, which is independent of this bug. A follow-up could collapse these into ids-only without behaviour change, scoped to its own commit.
+2. **`resyncIndices` runs on every recomposition of `SelectionHandler`.** The two `indexOfFirst` calls are O(n) on the items list. If profiling ever shows this on a hot path, the cheap fix is to gate on the pointer identity of the items list (`if (lastResyncedItems !== items) { … }`) — one extra field, one branch. Not worth doing speculatively.


### PR DESCRIPTION
**Problem:** On desktop, selected text jumped onto a neighbouring message whenever a new message arrived or was sent.
**Cause:** Selection stored positional indices into the reversed merged-items list, so any prepend (or deletion) shifted those indices onto different items.
**Fix:** Anchor the selection to `ChatItem.id` alongside the positions, and resync the indices to where the anchored items now live on every recomposition (`SideEffect`); clear the selection if either anchor item is gone.