### PR TITLE
support bot: escalate to team when Grok's reply contains /team

### DIFF
--- a/apps/simplex-support-bot/bot.test.ts
+++ b/apps/simplex-support-bot/bot.test.ts
@@ -870,6 +870,52 @@ describe("Grok Conversation", () => {
   })
 })
 
+describe("Grok requests /team", () => {
+  beforeEach(() => setup())
+
+  test("Grok per-message reply containing /team → team added, teamAddedMessage sent, reply still sent", async () => {
+    await reachGrok()
+    await bot.flush()
+    grokApi.willRespond("I can't help with billing — please send /team for a human.")
+    addCustomerMessageToHistory("Can you refund me?", GROK_LOCAL_GROUP_ID)
+    await bot.onGrokNewChatItems(grokViewCustomerMessage("Can you refund me?"))
+
+    expectAnySent("I can't help with billing")
+    expectMemberAdded(CUSTOMER_GROUP_ID, TEAM_MEMBER_1_ID)
+    expectMemberAdded(CUSTOMER_GROUP_ID, TEAM_MEMBER_2_ID)
+    expectSentToGroup(CUSTOMER_GROUP_ID, "We will reply within")
+  })
+
+  test("Grok per-message reply without /team → no team members added", async () => {
+    await reachGrok()
+    await bot.flush()
+    grokApi.willRespond("To create a group, tap +, then New Group.")
+    addCustomerMessageToHistory("How do I create a group?", GROK_LOCAL_GROUP_ID)
+    await bot.onGrokNewChatItems(grokViewCustomerMessage("How do I create a group?"))
+
+    expect(chat.added.some(a => a.groupId === CUSTOMER_GROUP_ID && a.contactId === TEAM_MEMBER_1_ID)).toBe(false)
+  })
+
+  test("/team in Grok's initial reply after /grok → escalates", async () => {
+    await reachQueue()
+    addBotMessage("The team will reply to your message")
+    // Customer's question visible in Grok's view → activateGrok reads it for the initial reply
+    chat.groups.set(GROK_LOCAL_GROUP_ID, makeGroupInfo(GROK_LOCAL_GROUP_ID))
+    addCustomerMessageToHistory("I'm really stuck, please help", GROK_LOCAL_GROUP_ID)
+    grokApi.willRespond("That sounds urgent — send /team to reach a person.")
+
+    const grokJoinPromise = simulateGrokJoinSuccess()
+    await bot.onNewChatItems(customerMessage("/grok"))
+    await grokJoinPromise
+    await bot.flush()
+
+    expectAnySent("That sounds urgent")
+    expectMemberAdded(CUSTOMER_GROUP_ID, TEAM_MEMBER_1_ID)
+    expectMemberAdded(CUSTOMER_GROUP_ID, TEAM_MEMBER_2_ID)
+    expectSentToGroup(CUSTOMER_GROUP_ID, "We will reply within")
+  })
+})
+
 describe("/team Activation", () => {
   beforeEach(() => setup())
 

--- a/apps/simplex-support-bot/src/bot.ts
+++ b/apps/simplex-support-bot/src/bot.ts
@@ -587,6 +587,9 @@ export class SupportBot {
       await this.withGrokProfile(() =>
         this.chat.apiSendTextMessage([T.ChatType.Group, grokGroupId], response)
       )
+
+      // Grok asked for the team → escalate as if the customer sent /team
+      if (mainGroupId !== undefined && response.includes("/team")) await this.activateTeam(mainGroupId)
     } catch (err) {
       logError(`Grok per-message error for grokGroup ${grokGroupId}`, err)
       try {
@@ -722,6 +725,9 @@ export class SupportBot {
         await this.withGrokProfile(() =>
           this.chat.apiSendTextMessage([T.ChatType.Group, grokLocalGId], response)
         )
+
+        // Grok asked for the team → escalate as if the customer sent /team
+        if (response.includes("/team")) await this.activateTeam(groupId)
       } catch (err) {
         logError(`Grok initial response failed for group ${groupId}`, err)
         await this.sendToGroup(groupId, grokUnavailableMessage)


### PR DESCRIPTION
Grok answers customer questions in the support bot, but until now it had no way to hand a conversation to a human — the customer had to notice and type `/team` themselves. This change lets Grok escalate by simply including `/team` anywhere in its reply (per-message replies and its initial post-join reply): the bot then runs the exact same escalation as a customer `/team` — invites the team members and switches the conversation to TEAM-PENDING — while still posting Grok's reply. Detection is on Grok's generated text only, so the `/team` mention in the API-error fallback message can't trigger a false escalation.