### PR TITLE
android, desktop, ios: fix trailing dot in saved name for files without extension

### DIFF
--- a/apps/ios/SimpleXChat/ImageUtils.swift
+++ b/apps/ios/SimpleXChat/ImageUtils.swift
@@ -297,7 +297,7 @@ private func uniqueCombine(_ fileName: String, fullPath: Bool = false) -> String
         let name = ns.deletingPathExtension
         let ext = ns.pathExtension
         let suffix = (n == 0) ? "" : "_\(n)"
-        let f = "\(name)\(suffix).\(ext)"
+        let f = ext.isEmpty ? "\(name)\(suffix)" : "\(name)\(suffix).\(ext)"
         return (FileManager.default.fileExists(atPath: fullPath ? f : getAppFilePath(f).path)) ? tryCombine(fileName, n + 1) : f
     }
     return tryCombine(fileName, 0)

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/Utils.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/Utils.kt
@@ -383,7 +383,7 @@ fun uniqueCombine(fileName: String, dir: File): String {
   val ext = orig.extension
   fun tryCombine(n: Int): String {
     val suffix = if (n == 0) "" else "_$n"
-    val f = "$name$suffix.$ext"
+    val f = if (ext.isEmpty()) "$name$suffix" else "$name$suffix.$ext"
     return if (File(dir, f).exists()) tryCombine(n + 1) else f
   }
   return tryCombine(0)


### PR DESCRIPTION
## Summary

- Uploading a file with no extension (e.g. `LICENSE`, `Makefile`, `README`) currently saves it locally with a trailing `.` (e.g. `LICENSE.`).
- Root cause: both `uniqueCombine` implementations unconditionally concatenate `"."` between the name and the extension. `pathExtension`/`File.extension` return the extension without the leading dot and return `""` when there is no extension — so the concatenation produces a trailing dot for extensionless files. The Haskell `uniqueCombine` in `src/Simplex/Chat/Files.hs` does not have this bug because `splitExtensions` returns the extension with its leading dot.
- Fix: one-line guard at each call site; when `ext` is empty, omit the dot. No change in behavior for files that have an extension.

Affected files:
- `apps/ios/SimpleXChat/ImageUtils.swift` (line 300)
- `apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/Utils.kt` (line 386)

## Test plan

- [ ] iOS: upload an extensionless file (e.g. `LICENSE`); verify saved file in the app's files folder has no trailing dot.
- [ ] Android: same scenario via the file picker.
- [ ] Desktop: same scenario via the file picker. (Verified locally on Linux AppImage build.)
- [ ] Regression: upload a file with an extension (`photo.jpg`, `notes.md`); confirm the saved name and any `_1`, `_2` collision suffix still produce a proper `name_N.ext`.