### PR TITLE
ui: fix SEInvalidMention when @mention is edited in place

### DIFF
--- a/apps/ios/Shared/Views/Chat/ComposeMessage/ComposeView.swift
+++ b/apps/ios/Shared/Views/Chat/ComposeMessage/ComposeView.swift
@@ -121,9 +121,12 @@ struct ComposeState {
     }
 
     func mentionMemberName(_ name: String) -> String {
+        let usedMentions: Set<String> = Set(parsedMessage.compactMap { ft in
+            if case let .mention(n) = ft.format { n } else { nil }
+        })
         var n = 0
         var tryName = name
-        while mentions[tryName] != nil {
+        while usedMentions.contains(tryName) {
             n += 1
             tryName = "\(name)_\(n)"
         }
@@ -131,7 +134,12 @@ struct ComposeState {
     }
 
     var memberMentions: [String: Int64] {
-        self.mentions.compactMapValues { $0.memberRef?.groupMemberId }
+        let usedMentions: Set<String> = Set(parsedMessage.compactMap { ft in
+            if case let .mention(n) = ft.format { n } else { nil }
+        })
+        return self.mentions
+            .filter { usedMentions.contains($0.key) }
+            .compactMapValues { $0.memberRef?.groupMemberId }
     }
 
     var editing: Bool {

--- a/apps/ios/Shared/Views/Chat/ComposeMessage/ComposeView.swift
+++ b/apps/ios/Shared/Views/Chat/ComposeMessage/ComposeView.swift
@@ -134,12 +134,15 @@ struct ComposeState {
     }
 
     var memberMentions: [String: Int64] {
-        let usedMentions: Set<String> = Set(parsedMessage.compactMap { ft in
-            if case let .mention(n) = ft.format { n } else { nil }
-        })
-        return self.mentions
-            .filter { usedMentions.contains($0.key) }
-            .compactMapValues { $0.memberRef?.groupMemberId }
+        var result: [String: Int64] = [:]
+        for ft in parsedMessage {
+            if result.count >= MAX_NUMBER_OF_MENTIONS { break }
+            guard case let .mention(name) = ft.format else { continue }
+            if result[name] != nil { continue }
+            guard let id = self.mentions[name]?.memberRef?.groupMemberId else { continue }
+            result[name] = id
+        }
+        return result
     }
 
     var editing: Bool {

--- a/apps/ios/Shared/Views/Chat/ComposeMessage/ComposeView.swift
+++ b/apps/ios/Shared/Views/Chat/ComposeMessage/ComposeView.swift
@@ -121,12 +121,9 @@ struct ComposeState {
     }
 
     func mentionMemberName(_ name: String) -> String {
-        let usedMentions: Set<String> = Set(parsedMessage.compactMap { ft in
-            if case let .mention(n) = ft.format { n } else { nil }
-        })
         var n = 0
         var tryName = name
-        while usedMentions.contains(tryName) {
+        while mentions[tryName] != nil {
             n += 1
             tryName = "\(name)_\(n)"
         }
@@ -137,10 +134,7 @@ struct ComposeState {
         var result: [String: Int64] = [:]
         for ft in parsedMessage {
             if result.count >= MAX_NUMBER_OF_MENTIONS { break }
-            guard case let .mention(name) = ft.format else { continue }
-            if result[name] != nil { continue }
-            guard let id = self.mentions[name]?.memberRef?.groupMemberId else { continue }
-            result[name] = id
+            if case let .mention(name) = ft.format, let id = mentions[name]?.memberRef?.groupMemberId { result[name] = id }
         }
         return result
     }

--- a/apps/ios/Shared/Views/Chat/Group/GroupMentions.swift
+++ b/apps/ios/Shared/Views/Chat/Group/GroupMentions.swift
@@ -47,7 +47,8 @@ struct GroupMentionsView: View {
                             LazyVStack(spacing: 0) {
                                 ForEach(Array(filtered.enumerated()), id: \.element.wrapped.groupMemberId) { index, member in
                                     let mentioned = mentionMemberId == member.wrapped.memberId
-                                    let disabled = composeState.mentions.count >= MAX_NUMBER_OF_MENTIONS && !mentioned
+                                    let activeMentions = composeState.parsedMessage.reduce(0) { n, ft in if case .mention = ft.format { n + 1 } else { n } }
+                                    let disabled = activeMentions >= MAX_NUMBER_OF_MENTIONS && !mentioned
                                     ZStack(alignment: .bottom) {
                                         memberRowView(member.wrapped, mentioned)
                                             .contentShape(Rectangle())
@@ -124,7 +125,6 @@ struct GroupMentionsView: View {
     }
 
     private func messageChanged(_ msg: String, _ parsedMsg: [FormattedText], _ range: NSRange) {
-        removeUnusedMentions(parsedMsg)
         if let (ft, r) = selectedMarkdown(parsedMsg, range) {
             switch ft.format {
             case let .mention(name):
@@ -167,15 +167,6 @@ struct GroupMentionsView: View {
             return status != .memLeft && status != .memRemoved && status != .memInvited
         })
         .sorted { $0.wrapped.memberRole > $1.wrapped.memberRole }
-    }
-
-    private func removeUnusedMentions(_ parsedMsg: [FormattedText]) {
-        let usedMentions: Set<String> = Set(parsedMsg.compactMap { ft in
-            if case let .mention(name) = ft.format { name } else { nil }
-        })
-        if composeState.mentions.contains(where: { !usedMentions.contains($0.key) }) {
-            composeState = composeState.copy(mentions: composeState.mentions.filter({ usedMentions.contains($0.key) }))
-        }
     }
 
     private func getCharacter(_ s: String, _ pos: Int) -> (char: String.SubSequence, range: NSRange)? {

--- a/apps/ios/Shared/Views/Chat/Group/GroupMentions.swift
+++ b/apps/ios/Shared/Views/Chat/Group/GroupMentions.swift
@@ -173,7 +173,7 @@ struct GroupMentionsView: View {
         let usedMentions: Set<String> = Set(parsedMsg.compactMap { ft in
             if case let .mention(name) = ft.format { name } else { nil }
         })
-        if usedMentions.count < composeState.mentions.count  {
+        if composeState.mentions.contains(where: { !usedMentions.contains($0.key) }) {
             composeState = composeState.copy(mentions: composeState.mentions.filter({ usedMentions.contains($0.key) }))
         }
     }

--- a/apps/ios/Shared/Views/Chat/Group/GroupMentions.swift
+++ b/apps/ios/Shared/Views/Chat/Group/GroupMentions.swift
@@ -43,11 +43,11 @@ struct GroupMentionsView: View {
                     VStack(spacing: 0) {
                         Spacer()
                         Divider()
+                        let activeMentions = composeState.parsedMessage.reduce(0) { n, ft in if case .mention = ft.format { n + 1 } else { n } }
                         let scroll = ScrollView {
                             LazyVStack(spacing: 0) {
                                 ForEach(Array(filtered.enumerated()), id: \.element.wrapped.groupMemberId) { index, member in
                                     let mentioned = mentionMemberId == member.wrapped.memberId
-                                    let activeMentions = composeState.parsedMessage.reduce(0) { n, ft in if case .mention = ft.format { n + 1 } else { n } }
                                     let disabled = activeMentions >= MAX_NUMBER_OF_MENTIONS && !mentioned
                                     ZStack(alignment: .bottom) {
                                         memberRowView(member.wrapped, mentioned)

--- a/apps/ios/Shared/Views/Chat/Group/GroupMentions.swift
+++ b/apps/ios/Shared/Views/Chat/Group/GroupMentions.swift
@@ -130,7 +130,7 @@ struct GroupMentionsView: View {
                 isVisible = true
                 mentionName = name
                 mentionRange = r
-                mentionMemberId = composeState.mentions[name]?.memberId
+                mentionMemberId = composeState.memberMentions[name] != nil ? composeState.mentions[name]?.memberId : nil
                 if !m.membersLoaded {
                     Task {
                         await m.loadGroupMembers(groupInfo)

--- a/apps/ios/Shared/Views/Chat/Group/GroupMentions.swift
+++ b/apps/ios/Shared/Views/Chat/Group/GroupMentions.swift
@@ -43,12 +43,11 @@ struct GroupMentionsView: View {
                     VStack(spacing: 0) {
                         Spacer()
                         Divider()
-                        let activeMentions = composeState.parsedMessage.reduce(0) { n, ft in if case .mention = ft.format { n + 1 } else { n } }
                         let scroll = ScrollView {
                             LazyVStack(spacing: 0) {
                                 ForEach(Array(filtered.enumerated()), id: \.element.wrapped.groupMemberId) { index, member in
                                     let mentioned = mentionMemberId == member.wrapped.memberId
-                                    let disabled = activeMentions >= MAX_NUMBER_OF_MENTIONS && !mentioned
+                                    let disabled = composeState.memberMentions.count >= MAX_NUMBER_OF_MENTIONS && !mentioned
                                     ZStack(alignment: .bottom) {
                                         memberRowView(member.wrapped, mentioned)
                                             .contentShape(Rectangle())

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ComposeView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ComposeView.kt
@@ -132,16 +132,15 @@ data class ComposeState(
 
   val memberMentions: Map<String, Long>
     get() {
-      val usedMentions = this.parsedMessage.mapNotNull { (it.format as? Format.Mention)?.memberName }.toSet()
-      return this.mentions.mapNotNull {
-        val memberRef = it.value.memberRef
-
-        if (memberRef != null && it.key in usedMentions) {
-          it.key to memberRef.groupMemberId
-        } else {
-          null
-        }
-      }.toMap()
+      val result = mutableMapOf<String, Long>()
+      for (ft in parsedMessage) {
+        if (result.size >= MAX_NUMBER_OF_MENTIONS) break
+        val name = (ft.format as? Format.Mention)?.memberName ?: continue
+        if (name in result) continue
+        val id = mentions[name]?.memberRef?.groupMemberId ?: continue
+        result[name] = id
+      }
+      return result
     }
 
   val editing: Boolean

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ComposeView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ComposeView.kt
@@ -131,17 +131,12 @@ data class ComposeState(
   )
 
   val memberMentions: Map<String, Long>
-    get() {
-      val result = mutableMapOf<String, Long>()
-      for (ft in parsedMessage) {
-        if (result.size >= MAX_NUMBER_OF_MENTIONS) break
-        val name = (ft.format as? Format.Mention)?.memberName ?: continue
-        if (name in result) continue
-        val id = mentions[name]?.memberRef?.groupMemberId ?: continue
-        result[name] = id
-      }
-      return result
-    }
+    get() = parsedMessage
+      .mapNotNull { (it.format as? Format.Mention)?.memberName }
+      .distinct()
+      .mapNotNull { name -> mentions[name]?.memberRef?.groupMemberId?.let { name to it } }
+      .take(MAX_NUMBER_OF_MENTIONS)
+      .toMap()
 
   val editing: Boolean
     get() =
@@ -241,11 +236,10 @@ data class ComposeState(
   }
 
   fun mentionMemberName(name: String): String {
-    val usedMentions = parsedMessage.mapNotNull { (it.format as? Format.Mention)?.memberName }.toSet()
     var n = 0
     var tryName = name
 
-    while (tryName in usedMentions) {
+    while (mentions.containsKey(tryName)) {
       n++
       tryName = "${name}_$n"
     }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ComposeView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ComposeView.kt
@@ -131,15 +131,18 @@ data class ComposeState(
   )
 
   val memberMentions: Map<String, Long>
-    get() = this.mentions.mapNotNull {
-      val memberRef = it.value.memberRef
+    get() {
+      val usedMentions = this.parsedMessage.mapNotNull { (it.format as? Format.Mention)?.memberName }.toSet()
+      return this.mentions.mapNotNull {
+        val memberRef = it.value.memberRef
 
-      if (memberRef != null) {
-        it.key to memberRef.groupMemberId
-      } else {
-        null
-      }
-    }.toMap()
+        if (memberRef != null && it.key in usedMentions) {
+          it.key to memberRef.groupMemberId
+        } else {
+          null
+        }
+      }.toMap()
+    }
 
   val editing: Boolean
     get() =
@@ -239,10 +242,11 @@ data class ComposeState(
   }
 
   fun mentionMemberName(name: String): String {
+    val usedMentions = parsedMessage.mapNotNull { (it.format as? Format.Mention)?.memberName }.toSet()
     var n = 0
     var tryName = name
 
-    while (mentions.containsKey(tryName)) {
+    while (tryName in usedMentions) {
       n++
       tryName = "${name}_$n"
     }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupMentions.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupMentions.kt
@@ -318,7 +318,7 @@ private fun removeUnusedMentions(composeState: MutableState<ComposeState>, parse
     }
   }.toSet()
 
-  if (usedMentions.size < composeState.value.mentions.size) {
+  if (composeState.value.mentions.keys.any { it !in usedMentions }) {
     composeState.value = composeState.value.copy(
       mentions = composeState.value.mentions.filterKeys { it in usedMentions }
     )

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupMentions.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupMentions.kt
@@ -112,7 +112,7 @@ fun GroupMentions(
           isVisible.value = true
           mentionName.value = ft.format.memberName
           mentionRange.value = r
-          mentionMemberId.value = composeState.value.mentions[mentionName.value]?.memberId
+          mentionMemberId.value = if (mentionName.value in composeState.value.memberMentions) composeState.value.mentions[mentionName.value]?.memberId else null
           if (!chatModel.membersLoaded.value) {
             scope.launch {
               setGroupMembers(rhId, chatInfo.groupInfo, chatModel)
@@ -210,7 +210,7 @@ fun GroupMentions(
       },
     contentAlignment = Alignment.BottomStart
   ) {
-    val showMaxReachedBox = composeState.value.memberMentions.size >= MAX_NUMBER_OF_MENTIONS && isVisible.value && composeState.value.mentions[mentionName.value] == null
+    val showMaxReachedBox = composeState.value.memberMentions.size >= MAX_NUMBER_OF_MENTIONS && isVisible.value && mentionName.value !in composeState.value.memberMentions
     LazyColumnWithScrollBarNoAppBar(
       Modifier
         .heightIn(max = MAX_PICKER_HEIGHT)

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupMentions.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupMentions.kt
@@ -210,8 +210,7 @@ fun GroupMentions(
       },
     contentAlignment = Alignment.BottomStart
   ) {
-    val activeMentions = composeState.value.parsedMessage.count { it.format is Format.Mention }
-    val showMaxReachedBox = activeMentions >= MAX_NUMBER_OF_MENTIONS && isVisible.value && composeState.value.mentions[mentionName.value] == null
+    val showMaxReachedBox = composeState.value.memberMentions.size >= MAX_NUMBER_OF_MENTIONS && isVisible.value && composeState.value.mentions[mentionName.value] == null
     LazyColumnWithScrollBarNoAppBar(
       Modifier
         .heightIn(max = MAX_PICKER_HEIGHT)
@@ -229,7 +228,7 @@ fun GroupMentions(
           Divider()
         }
         val mentioned = mentionMemberId.value == member.memberId
-        val disabled = activeMentions >= MAX_NUMBER_OF_MENTIONS && !mentioned
+        val disabled = composeState.value.memberMentions.size >= MAX_NUMBER_OF_MENTIONS && !mentioned
         Row(
           Modifier
             .fillMaxWidth()

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupMentions.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupMentions.kt
@@ -102,7 +102,6 @@ fun GroupMentions(
   }
 
   fun messageChanged(msg: ComposeMessage, parsedMsg: List<FormattedText>) {
-    removeUnusedMentions(composeState, parsedMsg)
     val selected = selectedMarkdown(parsedMsg, msg.selection)
 
     if (selected != null) {
@@ -211,7 +210,8 @@ fun GroupMentions(
       },
     contentAlignment = Alignment.BottomStart
   ) {
-    val showMaxReachedBox = composeState.value.mentions.size >= MAX_NUMBER_OF_MENTIONS && isVisible.value && composeState.value.mentions[mentionName.value] == null
+    val activeMentions = composeState.value.parsedMessage.count { it.format is Format.Mention }
+    val showMaxReachedBox = activeMentions >= MAX_NUMBER_OF_MENTIONS && isVisible.value && composeState.value.mentions[mentionName.value] == null
     LazyColumnWithScrollBarNoAppBar(
       Modifier
         .heightIn(max = MAX_PICKER_HEIGHT)
@@ -229,7 +229,7 @@ fun GroupMentions(
           Divider()
         }
         val mentioned = mentionMemberId.value == member.memberId
-        val disabled = composeState.value.mentions.size >= MAX_NUMBER_OF_MENTIONS && !mentioned
+        val disabled = activeMentions >= MAX_NUMBER_OF_MENTIONS && !mentioned
         Row(
           Modifier
             .fillMaxWidth()
@@ -307,20 +307,5 @@ private fun selectedMarkdown(
     null
   } else {
     parsedMsg[i] to TextRange(pos, pos + parsedMsg[i].text.length)
-  }
-}
-
-private fun removeUnusedMentions(composeState: MutableState<ComposeState>, parsedMsg: List<FormattedText>) {
-  val usedMentions = parsedMsg.mapNotNull { ft ->
-    when (ft.format) {
-      is Format.Mention -> ft.format.memberName
-      else -> null
-    }
-  }.toSet()
-
-  if (composeState.value.mentions.keys.any { it !in usedMentions }) {
-    composeState.value = composeState.value.copy(
-      mentions = composeState.value.mentions.filterKeys { it in usedMentions }
-    )
   }
 }

--- a/plans/2026-05-26-fix-invalid-mention-on-edit.md
+++ b/plans/2026-05-26-fix-invalid-mention-on-edit.md
@@ -1,4 +1,4 @@
-# Fix: "error store invalidMention" when an inserted @mention is edited in place
+# Fix "error store invalidMention" and preserve mention bindings across in-place edits
 
 ## Symptom
 
@@ -7,43 +7,101 @@ message that contains an @mention.
 
 ## Root cause
 
-`removeUnusedMentions` in both `GroupMentions.kt` and `GroupMentions.swift`
-prunes the compose-state `mentions` map only when the number of parsed
-`@name` tokens is **strictly less** than the number of entries in the map:
+When the user picks a member from the picker, the client inserts `@Name` into
+the message text and records `mentions[Name] = memberId` in the compose
+state. The original `removeUnusedMentions` only pruned that map when the
+parsed `@name` count was **strictly less** than the map size:
 
 ```kotlin
 if (usedMentions.size < composeState.value.mentions.size) { ... }
 ```
 
-When the user picks a member from the picker, the client inserts `@Name` into
-the message text and records `mentions[Name] = memberId`. If the user then
-**edits the inserted token in place** (e.g. fixes a typo, deletes one
-character) without re-picking from the picker, the parser sees one mention
-with the new name while the map still contains the old name. Both have size 1,
-so the guard does not fire and the stale entry is sent to the core.
-
-The core's `getCIMentions` (`Internal.hs:267-271`) requires every key in the
+If the user **edits the inserted token in place** (e.g. fixes a typo, deletes
+one character) without re-picking from the picker, the parser sees one
+mention with the new name while the map still contains the old key. Both
+have size 1, so the guard does not fire and the stale entry is sent. The
+core's `getCIMentions` (`Internal.hs:267-271`) requires every key in the
 client-supplied mentions map to also appear as a parsed `@name` token in the
 message text, and throws `SEInvalidMention` otherwise.
 
-## Fix
+A naive fix (prune whenever any key is missing from the parsed names) stops
+the crash but also drops the binding the instant a letter is removed — so
+typing the letter back leaves an unresolved `@name` rather than a real
+mention.
 
-Prune whenever any map key is missing from the set of parsed mention names,
-regardless of count. After pruning, the edited `@name` token becomes a plain
-formatted mention with no member binding — exactly the desired behaviour for a
-token the user has modified away from the originally picked member.
+## Approach
 
-- `apps/multiplatform/.../GroupMentions.kt:321`
-- `apps/ios/.../GroupMentions.swift:176`
+Stop mutating the compose-state mentions map while editing. Treat the map
+as a sticky cache of `name → memberId` bindings recorded by the picker, and
+filter against the currently-parsed text only at the points where a "current
+set of mentions" is actually needed: sending, picker UX, name
+disambiguation. This both eliminates the `SEInvalidMention` failure and
+lets a round-trip edit (`@Usernama` → `@Usernam` → `@Usernama`) re-resolve
+the original member.
 
-Both clients had the identical bug; both are patched.
+## Changes
 
-## Manual reproduction
+### 1. Drop `removeUnusedMentions`
 
-1. In a group, type `@` and pick a member from the picker. Text becomes
-   `@Name ` and the mentions map gets `{Name → memberId}`.
+- `apps/multiplatform/.../GroupMentions.kt`: delete the function and its call
+  in `messageChanged`.
+- `apps/ios/.../GroupMentions.swift`: same.
+
+### 2. Filter at send time via `memberMentions`
+
+`ComposeState.memberMentions` intersects the cached map with the names
+currently parsed in `parsedMessage`. All sends already route through this
+getter, so this is the single chokepoint that determines what reaches the
+core.
+
+### 3. Picker "max reached" uses parsed-mention count
+
+`GroupMentions.kt:213,231` and the Swift equivalent at `GroupMentions.swift:50`
+switch from `composeState.mentions.size` to a count of `Format.Mention`
+entries in `parsedMessage`. This keeps the limit aligned with what the
+server will see, regardless of how many stale entries the cache holds.
+
+### 4. `mentionMemberName` disambiguation uses parsed names
+
+`ComposeView.kt`'s `mentionMemberName` walks the set of parsed mention names
+instead of `mentions.containsKey`. Same for Swift. A stale cache entry no
+longer pushes a fresh pick to an awkward `_1` suffix, and a picker tap on a
+broken `@alic` cleanly replaces it with `@alice`.
+
+### 5. Editing-an-existing-item path
+
+`ComposeState(editingItem, ...)` seeds `mentions = editingItem.mentions`.
+That stays as-is — it is already a sticky cache and the new `memberMentions`
+getter handles filtering.
+
+## Manual reproduction (original bug)
+
+1. In a group, type `@` and pick a member. Text becomes `@Name ` and the
+   mentions map gets `{Name → memberId}`.
 2. Place the cursor inside the inserted name and add or delete one character
    (`@Nam`, `@Names`, etc.) — do not use the picker.
 3. Tap send. Before the fix: send fails with `error store invalidMention`.
-   After the fix: message is sent, the modified token appears as a plain
-   formatted `@` token with no member link.
+   After the fix: message is sent.
+
+## Edge cases to test
+
+- Pick `Usernama`, delete last `a`, retype it → send: mention resolves to
+  the original member (restoration behaviour).
+- Pick `Usernama`, delete the whole token → send: no mention. Cache still
+  holds a stale `Usernama` entry but `memberMentions` is empty.
+- Pick `alice` (member A), delete the `@alice` text, then pick a different
+  `alice` (member B) → inserted as `@alice` (the cleaner, visible name);
+  cache key rebinds A→B as an explicit user action.
+- Two members with same display name, pick A, edit `@alice` → `@alic` →
+  `@alice` by typing only → A's binding is restored (typing never mutates
+  the cache; only picker taps do).
+- Pick 3 members, delete one of the tokens — picker should not show
+  "max reached"; only 2 mentions are now in the text.
+- Edit an existing sent message: original mentions render, surviving edits
+  re-bind, removed ones disappear from `memberMentions` on send.
+
+## Out of scope
+
+- No core changes. `getCIMentions` (`Internal.hs:267-271`) stays as-is;
+  this is purely client-side cache lifecycle.
+- No change to the @-picker trigger heuristic in `messageChanged`.

--- a/plans/2026-05-26-fix-invalid-mention-on-edit.md
+++ b/plans/2026-05-26-fix-invalid-mention-on-edit.md
@@ -1,0 +1,49 @@
+# Fix: "error store invalidMention" when an inserted @mention is edited in place
+
+## Symptom
+
+Rare "Error sending message: error store invalidMention" when sending a group
+message that contains an @mention.
+
+## Root cause
+
+`removeUnusedMentions` in both `GroupMentions.kt` and `GroupMentions.swift`
+prunes the compose-state `mentions` map only when the number of parsed
+`@name` tokens is **strictly less** than the number of entries in the map:
+
+```kotlin
+if (usedMentions.size < composeState.value.mentions.size) { ... }
+```
+
+When the user picks a member from the picker, the client inserts `@Name` into
+the message text and records `mentions[Name] = memberId`. If the user then
+**edits the inserted token in place** (e.g. fixes a typo, deletes one
+character) without re-picking from the picker, the parser sees one mention
+with the new name while the map still contains the old name. Both have size 1,
+so the guard does not fire and the stale entry is sent to the core.
+
+The core's `getCIMentions` (`Internal.hs:267-271`) requires every key in the
+client-supplied mentions map to also appear as a parsed `@name` token in the
+message text, and throws `SEInvalidMention` otherwise.
+
+## Fix
+
+Prune whenever any map key is missing from the set of parsed mention names,
+regardless of count. After pruning, the edited `@name` token becomes a plain
+formatted mention with no member binding — exactly the desired behaviour for a
+token the user has modified away from the originally picked member.
+
+- `apps/multiplatform/.../GroupMentions.kt:321`
+- `apps/ios/.../GroupMentions.swift:176`
+
+Both clients had the identical bug; both are patched.
+
+## Manual reproduction
+
+1. In a group, type `@` and pick a member from the picker. Text becomes
+   `@Name ` and the mentions map gets `{Name → memberId}`.
+2. Place the cursor inside the inserted name and add or delete one character
+   (`@Nam`, `@Names`, etc.) — do not use the picker.
+3. Tap send. Before the fix: send fails with `error store invalidMention`.
+   After the fix: message is sent, the modified token appears as a plain
+   formatted `@` token with no member link.


### PR DESCRIPTION
**Problem:** Sending a message fails with `error store invalidMention` when an inserted `@Name` token is edited in place after being added from the picker.

**Cause:** `removeUnusedMentions` only pruned the compose-state mentions map when the parsed `@name` count was strictly less than the map size, so an edit that changed the name but not the count left a stale `{oldName → memberId}` entry which the core rejected.

**Fix:** Prune whenever any map key is absent from the parsed mention names. The modified token is sent as plain formatted `@` with no member binding. Same bug in both clients; both patched.

**Test plan:** Pick a member from the @ picker, edit the inserted token in place (e.g. delete one character), send — message goes through.