### PR TITLE
core: restrict channel short-link owner metadata

### DIFF
--- a/src/Simplex/Chat/Library/Commands.hs
+++ b/src/Simplex/Chat/Library/Commands.hs
@@ -3084,6 +3084,7 @@ processChatCommand vr nm = \case
       gInfo <- getGroupInfo db vr user groupId
       gLink <- getGroupLink db user gInfo
       pure (gInfo, gLink)
+    assertUserGroupRole gInfo $ if useRelays' gInfo then GROwner else GRAdmin
     gLink' <- setGroupLinkData nm user gInfo gLink
     pure $ CRGroupLink user gInfo gLink'
   APICreateMemberContact gId gMemberId -> withUser $ \user -> do

--- a/src/Simplex/Chat/Library/Internal.hs
+++ b/src/Simplex/Chat/Library/Internal.hs
@@ -1389,21 +1389,25 @@ updateGroupFromLinkData user gInfo@GroupInfo {groupProfile = p, groupSummary = G
 
 -- TODO [relays] owner: set owners on updating link data (multi-owner)
 groupLinkData :: GroupInfo -> GroupLink -> [GroupRelay] -> (UserConnLinkData 'CMContact, CRClientData)
-groupLinkData gInfo@GroupInfo {groupProfile, groupSummary = GroupSummary {publicMemberCount}, membership = GroupMember {memberId}, groupKeys} GroupLink {groupLinkId} groupRelays =
+groupLinkData gInfo@GroupInfo {groupProfile, groupSummary = GroupSummary {publicMemberCount}, membership = GroupMember {memberId, memberRole}, groupKeys} GroupLink {groupLinkId} groupRelays =
   let direct = not $ useRelays' gInfo
       relays = mapMaybe (\GroupRelay {relayLink} -> relayLink) groupRelays
       publicGroupData_ = PublicGroupData <$> publicMemberCount
       userData = encodeShortLinkData $ GroupShortLinkData {groupProfile, publicGroupData = publicGroupData_}
       owners = case groupKeys of
-        Just GroupKeys {groupRootKey = GRKPrivate rootPrivKey, memberPrivKey} ->
-          let ownerId = unMemberId memberId
-              ownerKey = C.publicKey memberPrivKey
-              authOwnerSig = C.sign' rootPrivKey (ownerId <> C.encodePubKey ownerKey)
-           in [OwnerAuth {ownerId, ownerKey, authOwnerSig}]
+        Just GroupKeys {groupRootKey = GRKPrivate rootPrivKey, memberPrivKey}
+          | groupLinkOwnerAuthAllowed memberRole ->
+              let ownerId = unMemberId memberId
+                  ownerKey = C.publicKey memberPrivKey
+                  authOwnerSig = C.sign' rootPrivKey (ownerId <> C.encodePubKey ownerKey)
+               in [OwnerAuth {ownerId, ownerKey, authOwnerSig}]
         _ -> []
       userLinkData = UserContactLinkData UserContactData {direct, owners, relays, userData}
       crClientData = encodeJSON $ CRDataGroup groupLinkId
    in (userLinkData, crClientData)
+
+groupLinkOwnerAuthAllowed :: GroupMemberRole -> Bool
+groupLinkOwnerAuthAllowed = (== GROwner)
 
 restoreShortLink' :: ConnShortLink m -> CM (ConnShortLink m)
 restoreShortLink' l = (`restoreShortLink` l) <$> asks (shortLinkPresetServers . config)

--- a/tests/ProtocolTests.hs
+++ b/tests/ProtocolTests.hs
@@ -9,6 +9,7 @@ module ProtocolTests where
 import qualified Data.Aeson as J
 import Data.ByteString.Char8 (ByteString)
 import Data.Time.Clock.System (SystemTime (..), systemToUTCTime)
+import Simplex.Chat.Library.Internal (groupLinkOwnerAuthAllowed)
 import Simplex.Chat.Protocol
 import Simplex.Chat.Types
 import Simplex.Chat.Types.Preferences
@@ -22,7 +23,9 @@ import Simplex.Messaging.Version
 import Test.Hspec
 
 protocolTests :: Spec
-protocolTests = decodeChatMessageTest
+protocolTests = do
+  decodeChatMessageTest
+  groupLinkOwnerAuthTests
 
 srv :: SMPServer
 srv = SMPServer "smp.simplex.im" "5223" (C.KeyHash "\215m\248\251")
@@ -108,6 +111,13 @@ testProfile = Profile {displayName = "alice", fullName = "Alice", shortDescr = N
 
 testGroupProfile :: GroupProfile
 testGroupProfile = GroupProfile {displayName = "team", fullName = "Team", description = Nothing, shortDescr = Nothing, image = Nothing, publicGroup = Nothing, groupPreferences = testGroupPreferences, memberAdmission = Nothing}
+
+groupLinkOwnerAuthTests :: Spec
+groupLinkOwnerAuthTests = describe "Group short-link owner metadata" $ do
+  it "allows only owners to publish owner authentication metadata" $ do
+    groupLinkOwnerAuthAllowed GROwner `shouldBe` True
+    groupLinkOwnerAuthAllowed GRAdmin `shouldBe` False
+    groupLinkOwnerAuthAllowed GRMember `shouldBe` False
 
 decodeChatMessageTest :: Spec
 decodeChatMessageTest = describe "Chat message encoding/decoding" $ do


### PR DESCRIPTION
## Summary
- Limit owner authentication metadata in short links to current owners.
- Require owner role for relay short-link creation.

## Tests
- Attempted: `cabal test simplex-chat-test --test-show-details=direct --test-option=--match --test-option='Group short-link owner metadata'`
- Blocked locally by the sandbox permission profile denying `*.key` fixture files during Cabal dependency checkout.