### PR TITLE
core: validate remote upload filenames

### DIFF
--- a/src/Simplex/Chat/Remote.hs
+++ b/src/Simplex/Chat/Remote.hs
@@ -564,9 +564,17 @@ handleRecv time events = do
 
 -- TODO this command could remember stored files and return IDs to allow removing files that are not needed.
 -- Also, there should be some process removing unused files uploaded to remote host (possibly, all unused files).
-handleStoreFile :: C.SbKeyNonce -> FilePath -> Word32 -> FileDigest -> GetChunk -> CM' RemoteResponse
+handleStoreFile ::
+  C.SbKeyNonce ->
+  FilePath ->
+  Word32 ->
+  FileDigest ->
+  GetChunk ->
+  CM' RemoteResponse
 handleStoreFile rfKN fileName fileSize fileDigest getChunk =
-  either RRProtocolError RRFileStored <$> (chatReadVar' filesFolder >>= storeFile)
+  if isValidRemoteStoreFileName fileName
+    then either RRProtocolError RRFileStored <$> (chatReadVar' filesFolder >>= storeFile)
+    else pure $ RRProtocolError RPEInvalidFileName
   where
     storeFile :: Maybe FilePath -> CM' (Either RemoteProtocolError FilePath)
     storeFile = \case
@@ -577,6 +585,14 @@ handleStoreFile rfKN fileName fileSize fileDigest getChunk =
       filePath <- liftIO $ dir `uniqueCombine` fileName
       receiveEncryptedFile rfKN getChunk fileSize fileDigest filePath
       pure filePath
+
+isValidRemoteStoreFileName :: FilePath -> Bool
+isValidRemoteStoreFileName fileName =
+  not (null fileName)
+    && fileName /= "."
+    && fileName /= ".."
+    && fileName == takeFileName fileName
+    && not (any (`elem` (['/', '\\', ':', '\0'] :: [Char])) fileName)
 
 handleGetFile :: User -> RemoteFile -> Respond -> CM ()
 handleGetFile User {userId} RemoteFile {userId = commandUserId, fileId, sent, fileSource = cf'@CryptoFile {filePath}} reply = do

--- a/src/Simplex/Chat/Remote/Types.hs
+++ b/src/Simplex/Chat/Remote/Types.hs
@@ -152,6 +152,7 @@ data RemoteProtocolError
     RPEUnexpectedResponse {response :: Text}
   | -- | A file already exists in the destination position
     RPEStoredFileExists
+  | RPEInvalidFileName
   | PRERemoteControl {rcError :: RCErrorType}
   | RPEHTTP2 {http2Error :: Text}
   | RPEException {someException :: Text}

--- a/tests/RemoteTests.hs
+++ b/tests/RemoteTests.hs
@@ -20,7 +20,7 @@ import Simplex.Chat.Controller (ChatCommand (..), ChatConfig (..), versionNumber
 import Simplex.Chat.Library.Commands (parseChatCommand)
 import qualified Simplex.Chat.Controller as Controller
 import Simplex.Chat.Mobile.File
-import Simplex.Chat.Remote (remoteFilesFolder)
+import Simplex.Chat.Remote (isValidRemoteStoreFileName, remoteFilesFolder)
 import Simplex.Chat.Remote.Types
 import Simplex.Messaging.Crypto.File (CryptoFileArgs (..))
 import Simplex.Messaging.Encoding.String (strEncode)
@@ -40,6 +40,24 @@ remoteTests = describe "Remote" $ do
         `shouldSatisfy` \case
           Right (StartRemoteHost Nothing (Just (RCCtrlAddress _ "Ethernet 2")) (Just 12345)) -> True
           _ -> False
+  describe "remote file names" $ do
+    it "rejects path-like names for remote file storage" $ \_ -> do
+      isValidRemoteStoreFileName "test.pdf" `shouldBe` True
+      isValidRemoteStoreFileName "test_1.pdf" `shouldBe` True
+      forM_
+        [ "",
+          ".",
+          "..",
+          "../test.pdf",
+          "nested/test.pdf",
+          "nested\\test.pdf",
+          "/tmp/test.pdf",
+          "C:\\tmp\\test.pdf",
+          "C:test.pdf",
+          "test.pdf:ads",
+          "test\0.pdf"
+        ]
+        (`shouldSatisfy` (not . isValidRemoteStoreFileName))
   xdescribe "No compression" $ aroundWith (. ((False, False),)) runRemoteTests
   xdescribe "Mobile offers compression" $ aroundWith (. ((True, False),)) runRemoteTests
   xdescribe "Desktop offers compression" $ aroundWith (. ((False, True),)) runRemoteTests


### PR DESCRIPTION
## Summary
- Reject remote stored-file names that are empty, special path components, path-like, or contain path separators, drive separators, or NUL.
- Return a protocol error instead of joining attacker-controlled path text with the remote files folder.
- Add a regression test for accepted simple names and rejected path-like names.

## Tests
- `git diff --check origin/master..HEAD`
- Attempted: `cabal test simplex-chat-test --test-show-details=direct --test-option=--match --test-option='remote file names'`
- Blocked locally by the sandbox permission profile denying `*.key` fixture files during Cabal dependency checkout.