### PR TITLE
android: preserve service restart state on destroy

### DIFF
--- a/apps/multiplatform/android/src/main/java/chat/simplex/app/SimplexService.kt
+++ b/apps/multiplatform/android/src/main/java/chat/simplex/app/SimplexService.kt
@@ -97,11 +97,16 @@ class SimplexService: Service() {
     isServiceStarting = false
     isServiceStarted = false
     stopAfterStart = false
-    saveServiceState(this, ServiceState.STOPPED)
+    val serviceState = serviceStateOnDestroy(
+      allowRestart = SimplexApp.context.allowToStartServiceAfterAppExit(),
+      stopRequested = serviceStopRequested,
+    )
+    saveServiceState(this, serviceState)
 
     // If notification service is enabled and battery optimization is disabled, restart the service
-    if (SimplexApp.context.allowToStartServiceAfterAppExit())
+    if (serviceState == ServiceState.STARTED)
       sendBroadcast(Intent(this, AutoRestartReceiver::class.java))
+    serviceStopRequested = false
     super.onDestroy()
   }
 
@@ -323,6 +328,7 @@ class SimplexService: Service() {
     var isServiceStarting = false
     var isServiceStarted = false
     private var stopAfterStart = false
+    private var serviceStopRequested = false
 
     fun scheduleStart(context: Context) {
       Log.d(TAG, "Enqueuing work to start subscriber service")
@@ -338,6 +344,7 @@ class SimplexService: Service() {
      * exception related to foreground services lifecycle
      * */
     fun safeStopService() {
+      serviceStopRequested = true
       if (isServiceStarted) {
         androidAppContext.stopService(Intent(androidAppContext, SimplexService::class.java))
       } else if (isServiceStarting) {
@@ -351,6 +358,9 @@ class SimplexService: Service() {
         return
       }
       Log.d(TAG, "SimplexService serviceAction: ${action.name}")
+      if (action == Action.START) {
+        serviceStopRequested = false
+      }
       withContext(Dispatchers.IO) {
         Intent(androidAppContext, SimplexService::class.java).also {
           it.action = action.name
@@ -365,6 +375,9 @@ class SimplexService: Service() {
         context.stopService(intent) // Service will auto-restart
       }
     }
+
+    internal fun serviceStateOnDestroy(allowRestart: Boolean, stopRequested: Boolean): ServiceState =
+      if (allowRestart && !stopRequested) ServiceState.STARTED else ServiceState.STOPPED
 
     fun saveServiceState(context: Context, state: ServiceState) {
       getPreferences(context).edit()

--- a/apps/multiplatform/android/src/test/java/chat/simplex/app/SimplexServiceTest.kt
+++ b/apps/multiplatform/android/src/test/java/chat/simplex/app/SimplexServiceTest.kt
@@ -1,0 +1,30 @@
+package chat.simplex.app
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SimplexServiceTest {
+  @Test
+  fun destroyKeepsStartedStateWhenRestartIsAllowed() {
+    assertEquals(
+      SimplexService.ServiceState.STARTED,
+      SimplexService.serviceStateOnDestroy(allowRestart = true, stopRequested = false),
+    )
+  }
+
+  @Test
+  fun destroyStoresStoppedStateWhenRestartIsNotAllowed() {
+    assertEquals(
+      SimplexService.ServiceState.STOPPED,
+      SimplexService.serviceStateOnDestroy(allowRestart = false, stopRequested = false),
+    )
+  }
+
+  @Test
+  fun destroyStoresStoppedStateForExplicitStopRequests() {
+    assertEquals(
+      SimplexService.ServiceState.STOPPED,
+      SimplexService.serviceStateOnDestroy(allowRestart = true, stopRequested = true),
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- Preserve `ServiceState.STARTED` during `SimplexService.onDestroy()` when the service is still configured to restart.
- Track explicit `safeStopService()` requests so intentional stops continue to persist `ServiceState.STOPPED`.
- Add unit coverage for the destroy-state decision.

## Tests
- `git diff --check origin/master..HEAD`
- Not run: `GRADLE_USER_HOME=/private/var/folders/xg/y64hd3px7h5_5qbwynrwx5xr0000gn/T/gradle-home-issue-4 ./gradlew :android:testDebugUnitTest --tests chat.simplex.app.SimplexServiceTest` because this local environment has no Java runtime installed.