### PR TITLE
docs: fix user groups guide link

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -49,7 +49,7 @@ This button will disappear once you make the first connection. To connect to the
 
 ### Join some user groups
 
-There are links to join several [user groups](../../README.md#join-user-groups) on our GitHub page - join them to ask any questions and discuss ideas.
+There are links to join several [user groups](https://github.com/simplex-chat/simplex-chat#join-user-groups) on our GitHub page - join them to ask any questions and discuss ideas.
 
 You can also find some other user-managed groups via online search.
 


### PR DESCRIPTION
## Summary
- replace the guide's relative README link with an absolute GitHub link to the user groups section
- avoid generating a broken `/docs/guide/https%3A/...` URL on the published docs site

Closes #6782

## Verification
- `git diff --check`
- `rg -n "../../README.md#join-user-groups|https://github.com/simplex-chat/simplex-chat#join-user-groups" docs/guide/README.md`
- curl check: `https://github.com/simplex-chat/simplex-chat#join-user-groups` returns 200