### PR TITLE
cli: remove help entries for removed commands

### DIFF
--- a/plans/2026-06-15-fix-cli-outdated-help.md
+++ b/plans/2026-06-15-fix-cli-outdated-help.md
@@ -4,7 +4,7 @@ Branch: `nd/fix-cli-outdated-help` · file `src/Simplex/Chat/Help.hs`.
 
 ## 1. Problem statement
 
-Typing `/get stats` in the terminal CLI does nothing useful — it is documented in `/help` but no parser accepts it, so it fails to parse (or, as `//get stats`, resolves to `CustomChatCommand` → "not supported"). Investigation found this is not isolated: four documented commands no longer exist in the parser.
+Typing `/get stats` in the terminal CLI does nothing useful — it is documented in `/help` but no parser accepts it, so it fails to parse. Investigation found this is not isolated: four documented commands no longer exist in the parser.
 
 ## 2. Solution summary
 

--- a/plans/2026-06-15-fix-cli-outdated-help.md
+++ b/plans/2026-06-15-fix-cli-outdated-help.md
@@ -1,0 +1,42 @@
+# Remove CLI help entries for long-removed commands
+
+Branch: `nd/fix-cli-outdated-help` · file `src/Simplex/Chat/Help.hs`.
+
+## 1. Problem statement
+
+Typing `/get stats` in the terminal CLI does nothing useful — it is documented in `/help` but no parser accepts it, so it fails to parse (or, as `//get stats`, resolves to `CustomChatCommand` → "not supported"). Investigation found this is not isolated: four documented commands no longer exist in the parser.
+
+## 2. Solution summary
+
+Remove the four stale entries (five lines, including one continuation note) from `Help.hs`:
+
+- `/pq @<name> on/off` + its "(both have to enable…)" note — `contactsHelpInfo`
+- `/pq on/off` — `settingsInfo`
+- `/get stats` — `settingsInfo`
+- `/reset stats` — `settingsInfo`
+
+The stats pair were the tail of `settingsInfo`, so the now-orphaned trailing comma on the preceding `/(un)mute #<group>` element is also dropped to keep the list literal valid.
+
+No replacement text is added: PQ has no command (it is automatic), and the stats functionality has no argument-compatible successor (see §4).
+
+## 3. Root cause
+
+Both removals were core changes that deleted parser, handler, and command constructor but left `Help.hs` untouched:
+
+- **`/pq` (both forms)** — commit `756779186` "core: enable PQ encryption for contacts (#4049)", 2024-04-22. It removed the parsers `"/pq @" *> (SetContactPQ …)` and `"/pq " *> (APISetPQEncryption …)`; post-quantum encryption for contacts became automatic, so the manual toggle was obsolete. `SetContactPQ` and `APISetPQEncryption` no longer exist in `src/`.
+- **`/get stats` / `/reset stats`** — commit `5907d8bd0` "core: remove legacy agent stats (#4375)", 2024-07-01. It removed the parsers `"/get stats" $> GetAgentStats` and `"/reset stats" $> ResetAgentStats`, their handlers, the `GetAgentStats`/`ResetAgentStats` constructors in `Controller.hs`, and the `View.hs` rendering — but its diff touched `Chat.hs`, `Controller.hs`, `View.hs`, `cabal.project`, `sha256map.nix`, not `Help.hs`.
+
+In both cases the help text became a promise the binary could no longer keep.
+
+## 4. Scope verification — no other stale entries, no replacements documented
+
+All 120 commands documented across every section of `Help.hs` were extracted and matched against the parser string literals in `Library/Commands.hs` (`chatCommandP`). Every entry resolves to a live parser except the four above. ~10 entries that a naive prefix match flagged were manually confirmed valid: incognito-suffix forms parsed by `incognitoP` (`/accept incognito`, `/connect incognito`, `/simplex incognito`), usage examples (`/file bob ./photo.jpg`, `/group team`), and inline sub-alternatives (`/start remote host new`, `/stop remote host new`, `/switch remote host local`, `/chats all`).
+
+Why no replacement text:
+
+- **PQ** — there is no command; encryption is negotiated automatically. Documenting nothing is correct.
+- **Stats** — the nearest live commands are `/get servers summary <userId>` and `/reset servers stats`, but they require a `userId` argument and return the agent servers summary, not the old argument-less usage statistics. They were never in CLI help; adding them is a separate documentation enhancement, deliberately out of scope for a "remove what no longer exists" fix.
+
+## 5. Why this shape
+
+Pure deletion of dead documentation — no behavioral change, smallest diff that makes `/help` truthful. Comma handling is the only subtlety: the `/pq @<name>` and `/pq on/off` removals sit before comma-bearing neighbors (a `""` separator and `/network` respectively) and need no adjustment; the `/get stats` + `/reset stats` removal makes `/(un)mute #<group>` the last `settingsInfo` element, so its trailing comma is removed to avoid a dangling-comma parse error before `]`.

--- a/src/Simplex/Chat/Help.hs
+++ b/src/Simplex/Chat/Help.hs
@@ -187,8 +187,6 @@ contactsHelpInfo =
       indent <> highlight "/verify @<name>          " <> " - clear security code verification",
       indent <> highlight "/info @<name>            " <> " - info about contact connection",
       indent <> highlight "/switch @<name>          " <> " - switch receiving messages to another SMP relay",
-      indent <> highlight "/pq @<name> on/off       " <> " - [BETA] toggle quantum resistant / standard e2e encryption for a contact",
-      indent <>           "                         " <> "   (both have to enable for quantum resistance)",
       "",
       green "Contact chat preferences:",
       indent <> highlight "/set voice @<name> yes/no/always   " <> " - allow/prohibit voice messages with the contact",
@@ -324,16 +322,13 @@ settingsInfo =
   map
     styleMarkdown
     [ green "Chat settings:",
-      indent <> highlight "/pq on/off               " <> " - [BETA] toggle quantum resistant / standard e2e encryption for the new contacts",
       indent <> highlight "/network                 " <> " - show / set network access options",
       indent <> highlight "/smp                     " <> " - show / set configured SMP servers",
       indent <> highlight "/xftp                    " <> " - show / set configured XFTP servers",
       indent <> highlight "/info <contact>          " <> " - information about contact connection",
       indent <> highlight "/info #<group> <member>  " <> " - information about member connection",
       indent <> highlight "/(un)mute <contact>      " <> " - (un)mute contact, the last messages can be printed with /tail command",
-      indent <> highlight "/(un)mute #<group>       " <> " - (un)mute group",
-      indent <> highlight "/get stats               " <> " - get usage statistics",
-      indent <> highlight "/reset stats             " <> " - reset usage statistics"
+      indent <> highlight "/(un)mute #<group>       " <> " - (un)mute group"
     ]
 
 databaseHelpInfo :: [StyledString]


### PR DESCRIPTION
Typing `/get stats` in the CLI does nothing — it (and `/reset stats`, `/pq on/off`, `/pq @<name> on/off`) are still in `/help` but no parser accepts them, so they fail to parse. The parsers, handlers, and command constructors were deleted by #4049 (PQ for contacts became automatic) and #4375 (legacy agent stats removed), but `Help.hs` was never updated. This removes the four stale help entries; a plan with the full investigation is in plans/2026-06-15-fix-cli-outdated-help.md.