### PR TITLE
android, desktop, ios: document missing formatting in markdown help

### DIFF
--- a/apps/ios/Shared/Views/UserSettings/MarkdownHelp.swift
+++ b/apps/ios/Shared/Views/UserSettings/MarkdownHelp.swift
@@ -19,6 +19,7 @@ struct MarkdownHelp: View {
             mdFormat("_italic_", Text("italic").italic())
             mdFormat("~strike~", Text("strike").strikethrough())
             mdFormat("`a + b`", Text("`a + b`").font(.body.monospaced()))
+            mdFormat("!- small!", Text("small").font(.footnote).foregroundColor(.secondary))
             mdFormat("!1 colored!", Text("colored").foregroundColor(.red) + Text(verbatim: " (") + color("1", .red) + color("2", .green) + color("3", .blue) + color("4", .yellow) + color("5", .cyan) + Text("6").foregroundColor(.purple) + Text(verbatim: ")"))
             (
                 mdFormat("#secret#", Text("secret")
@@ -26,6 +27,7 @@ struct MarkdownHelp: View {
                     .underline(color: theme.colors.onBackground) + Text(" (can be copied)"))
             )
             .textSelection(.enabled)
+            mdFormat("[link](https://simplex.chat)", Text("link").foregroundColor(theme.colors.primary).underline())
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/apps/ios/bg.lproj/Localizable.strings
+++ b/apps/ios/bg.lproj/Localizable.strings
@@ -4640,3 +4640,15 @@ server test failure */
 /* No comment provided by engineer. */
 "Your SimpleX address" = "Вашият адрес в SimpleX";
 
+
+/* No comment provided by engineer. */
+"!- small!" = "!- малък!";
+
+/* No comment provided by engineer. */
+"small" = "малък";
+
+/* No comment provided by engineer. */
+"[link](https://simplex.chat)" = "\\[връзка](https://simplex.chat)";
+
+/* No comment provided by engineer. */
+"link" = "връзка";

--- a/apps/ios/cs.lproj/Localizable.strings
+++ b/apps/ios/cs.lproj/Localizable.strings
@@ -3716,3 +3716,15 @@ server test failure */
 /* No comment provided by engineer. */
 "Your SimpleX address" = "Vaše SimpleX adresa";
 
+
+/* No comment provided by engineer. */
+"!- small!" = "!- malé!";
+
+/* No comment provided by engineer. */
+"small" = "malé";
+
+/* No comment provided by engineer. */
+"[link](https://simplex.chat)" = "\\[odkaz](https://simplex.chat)";
+
+/* No comment provided by engineer. */
+"link" = "odkaz";

--- a/apps/ios/de.lproj/Localizable.strings
+++ b/apps/ios/de.lproj/Localizable.strings
@@ -7040,3 +7040,12 @@ server test failure */
 /* No comment provided by engineer. */
 "Your SimpleX address" = "Ihre SimpleX-Adresse";
 
+
+/* No comment provided by engineer. */
+"!- small!" = "!- klein!";
+
+/* No comment provided by engineer. */
+"small" = "klein";
+
+/* No comment provided by engineer. */
+"[link](https://simplex.chat)" = "\\[Link](https://simplex.chat)";

--- a/apps/ios/en.lproj/Localizable.strings
+++ b/apps/ios/en.lproj/Localizable.strings
@@ -24,3 +24,6 @@
 
 /* No comment provided by engineer. */
 "No group!" = "Group not found!";
+
+/* No comment provided by engineer. */
+"[link](https://simplex.chat)" = "\\[link](https://simplex.chat)";

--- a/apps/ios/es.lproj/Localizable.strings
+++ b/apps/ios/es.lproj/Localizable.strings
@@ -7040,3 +7040,12 @@ server test failure */
 /* No comment provided by engineer. */
 "Your SimpleX address" = "Mi dirección SimpleX";
 
+
+/* No comment provided by engineer. */
+"!- small!" = "!- pequeño!";
+
+/* No comment provided by engineer. */
+"small" = "pequeño";
+
+/* No comment provided by engineer. */
+"[link](https://simplex.chat)" = "\\[enlace](https://simplex.chat)";

--- a/apps/ios/fi.lproj/Localizable.strings
+++ b/apps/ios/fi.lproj/Localizable.strings
@@ -3346,3 +3346,15 @@ server test failure */
 /* No comment provided by engineer. */
 "Your SimpleX address" = "SimpleX-osoitteesi";
 
+
+/* No comment provided by engineer. */
+"!- small!" = "!- pieni!";
+
+/* No comment provided by engineer. */
+"small" = "pieni";
+
+/* No comment provided by engineer. */
+"[link](https://simplex.chat)" = "\\[linkki](https://simplex.chat)";
+
+/* No comment provided by engineer. */
+"link" = "linkki";

--- a/apps/ios/fr.lproj/Localizable.strings
+++ b/apps/ios/fr.lproj/Localizable.strings
@@ -5672,3 +5672,15 @@ server test failure */
 /* No comment provided by engineer. */
 "Your SimpleX address" = "Votre adresse SimpleX";
 
+
+/* No comment provided by engineer. */
+"!- small!" = "!- petit!";
+
+/* No comment provided by engineer. */
+"small" = "petit";
+
+/* No comment provided by engineer. */
+"[link](https://simplex.chat)" = "\\[lien](https://simplex.chat)";
+
+/* No comment provided by engineer. */
+"link" = "lien";

--- a/apps/ios/hu.lproj/Localizable.strings
+++ b/apps/ios/hu.lproj/Localizable.strings
@@ -7040,3 +7040,12 @@ server test failure */
 /* No comment provided by engineer. */
 "Your SimpleX address" = "Profil SimpleX-címe";
 
+
+/* No comment provided by engineer. */
+"!- small!" = "!- kicsi!";
+
+/* No comment provided by engineer. */
+"small" = "kicsi";
+
+/* No comment provided by engineer. */
+"[link](https://simplex.chat)" = "\\[hivatkozás](https://simplex.chat)";

--- a/apps/ios/it.lproj/Localizable.strings
+++ b/apps/ios/it.lproj/Localizable.strings
@@ -7040,3 +7040,12 @@ server test failure */
 /* No comment provided by engineer. */
 "Your SimpleX address" = "Il tuo indirizzo SimpleX";
 
+
+/* No comment provided by engineer. */
+"!- small!" = "!- piccolo!";
+
+/* No comment provided by engineer. */
+"small" = "piccolo";
+
+/* No comment provided by engineer. */
+"[link](https://simplex.chat)" = "\\[link](https://simplex.chat)";

--- a/apps/ios/ja.lproj/Localizable.strings
+++ b/apps/ios/ja.lproj/Localizable.strings
@@ -3629,3 +3629,15 @@ server test failure */
 /* No comment provided by engineer. */
 "Your SimpleX address" = "あなたのSimpleXアドレス";
 
+
+/* No comment provided by engineer. */
+"!- small!" = "!- 小さい!";
+
+/* No comment provided by engineer. */
+"small" = "小さい";
+
+/* No comment provided by engineer. */
+"[link](https://simplex.chat)" = "\\[リンク](https://simplex.chat)";
+
+/* No comment provided by engineer. */
+"link" = "リンク";

--- a/apps/ios/nl.lproj/Localizable.strings
+++ b/apps/ios/nl.lproj/Localizable.strings
@@ -6007,3 +6007,15 @@ server test failure */
 /* No comment provided by engineer. */
 "Your SimpleX address" = "Uw SimpleX adres";
 
+
+/* No comment provided by engineer. */
+"!- small!" = "!- klein!";
+
+/* No comment provided by engineer. */
+"small" = "klein";
+
+/* No comment provided by engineer. */
+"[link](https://simplex.chat)" = "\\[link](https://simplex.chat)";
+
+/* No comment provided by engineer. */
+"link" = "link";

--- a/apps/ios/pl.lproj/Localizable.strings
+++ b/apps/ios/pl.lproj/Localizable.strings
@@ -6386,3 +6386,15 @@ server test failure */
 /* No comment provided by engineer. */
 "Your SimpleX address" = "Twój adres SimpleX";
 
+
+/* No comment provided by engineer. */
+"!- small!" = "!- małe!";
+
+/* No comment provided by engineer. */
+"small" = "małe";
+
+/* No comment provided by engineer. */
+"[link](https://simplex.chat)" = "\\[odnośnik](https://simplex.chat)";
+
+/* No comment provided by engineer. */
+"link" = "odnośnik";

--- a/apps/ios/ru.lproj/Localizable.strings
+++ b/apps/ios/ru.lproj/Localizable.strings
@@ -7040,3 +7040,12 @@ server test failure */
 /* No comment provided by engineer. */
 "Your SimpleX address" = "Ваш адрес SimpleX";
 
+
+/* No comment provided by engineer. */
+"!- small!" = "!- мелкий!";
+
+/* No comment provided by engineer. */
+"small" = "мелкий";
+
+/* No comment provided by engineer. */
+"[link](https://simplex.chat)" = "\\[ссылка](https://simplex.chat)";

--- a/apps/ios/th.lproj/Localizable.strings
+++ b/apps/ios/th.lproj/Localizable.strings
@@ -3250,3 +3250,15 @@ server test failure */
 /* No comment provided by engineer. */
 "Your SimpleX address" = "ที่อยู่ SimpleX ของคุณ";
 
+
+/* No comment provided by engineer. */
+"!- small!" = "!- เล็ก!";
+
+/* No comment provided by engineer. */
+"small" = "เล็ก";
+
+/* No comment provided by engineer. */
+"[link](https://simplex.chat)" = "\\[ลิงก์](https://simplex.chat)";
+
+/* No comment provided by engineer. */
+"link" = "ลิงก์";

--- a/apps/ios/tr.lproj/Localizable.strings
+++ b/apps/ios/tr.lproj/Localizable.strings
@@ -6309,3 +6309,15 @@ server test failure */
 /* No comment provided by engineer. */
 "Your SimpleX address" = "SimpleX adresin";
 
+
+/* No comment provided by engineer. */
+"!- small!" = "!- küçük!";
+
+/* No comment provided by engineer. */
+"small" = "küçük";
+
+/* No comment provided by engineer. */
+"[link](https://simplex.chat)" = "\\[bağlantı](https://simplex.chat)";
+
+/* No comment provided by engineer. */
+"link" = "bağlantı";

--- a/apps/ios/uk.lproj/Localizable.strings
+++ b/apps/ios/uk.lproj/Localizable.strings
@@ -6211,3 +6211,15 @@ server test failure */
 /* No comment provided by engineer. */
 "Your SimpleX address" = "Ваша адреса SimpleX";
 
+
+/* No comment provided by engineer. */
+"!- small!" = "!- дрібний!";
+
+/* No comment provided by engineer. */
+"small" = "дрібний";
+
+/* No comment provided by engineer. */
+"[link](https://simplex.chat)" = "\\[посилання](https://simplex.chat)";
+
+/* No comment provided by engineer. */
+"link" = "посилання";

--- a/apps/ios/zh-Hans.lproj/Localizable.strings
+++ b/apps/ios/zh-Hans.lproj/Localizable.strings
@@ -6335,3 +6335,15 @@ server test failure */
 /* No comment provided by engineer. */
 "Your SimpleX address" = "您的 SimpleX 地址";
 
+
+/* No comment provided by engineer. */
+"!- small!" = "!- 小!";
+
+/* No comment provided by engineer. */
+"small" = "小";
+
+/* No comment provided by engineer. */
+"[link](https://simplex.chat)" = "\\[链接](https://simplex.chat)";
+
+/* No comment provided by engineer. */
+"link" = "链接";

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/MarkdownHelpView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/MarkdownHelpView.kt
@@ -30,11 +30,14 @@ fun MarkdownHelpView() {
     val equation = stringResource(MR.strings.a_plus_b)
     val colored = stringResource(MR.strings.colored_text)
     val secret = stringResource(MR.strings.secret_text)
+    val small = stringResource(MR.strings.small_text)
+    val link = stringResource(MR.strings.link_text)
 
     MdFormat("*$bold*", bold, Format.Bold())
     MdFormat("_${italic}_", italic, Format.Italic())
     MdFormat("~$strikethrough~", strikethrough, Format.StrikeThrough())
     MdFormat("`$equation`", equation, Format.Snippet())
+    MdFormat("!- $small!", small, Format.Small())
     Row {
       MdSyntax("!1 $colored!")
       Text(buildAnnotatedString {
@@ -56,6 +59,7 @@ fun MarkdownHelpView() {
         })
       }
     }
+    MdFormat("[$link](https://simplex.chat)", link, Format.HyperLink(link, "https://simplex.chat"))
     SectionBottomSpacer()
   }
 }

--- a/apps/multiplatform/common/src/commonMain/resources/MR/ar/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/ar/strings.xml
@@ -998,6 +998,8 @@
     <string name="save_preferences_question">حفظ التفضيلات؟</string>
     <string name="save_settings_question">حفظ الإعدادات؟</string>
     <string name="secret_text">سري</string>
+    <string name="small_text">صغير</string>
+    <string name="link_text">رابط</string>
     <string name="self_destruct_passcode">رمز المرور للتدمير الذاتي</string>
     <string name="self_destruct_passcode_changed">تغيّرت رمز المرور للتدمير الذاتي!</string>
     <string name="self_destruct_passcode_enabled">فعّلت رمز المرور للتدمير الذاتي!</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
@@ -1252,6 +1252,8 @@
   <string name="a_plus_b">a + b</string>
   <string name="colored_text">colored</string>
   <string name="secret_text">secret</string>
+  <string name="small_text">small</string>
+  <string name="link_text">link</string>
 
   <!-- CICallStatus - in chat items -->
   <string name="callstatus_calling">calling…</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/bg/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/bg/strings.xml
@@ -1059,6 +1059,8 @@
     <string name="smp_servers_test_some_failed">Някои сървъри не минаха теста:</string>
     <string name="shutdown_alert_question">Изключване\?</string>
     <string name="secret_text">таен</string>
+    <string name="small_text">малък</string>
+    <string name="link_text">връзка</string>
     <string name="alert_title_skipped_messages">Пропуснати съобщения</string>
     <string name="self_destruct">Самоунищожение</string>
     <string name="receipts_section_groups">Малки групи (максимум 20)</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/ca/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/ca/strings.xml
@@ -2141,6 +2141,8 @@
     <string name="save_settings_question">Voleu desar les preferències?</string>
     <string name="stop_sharing_address">Voleu deixar de compartir l\'adreça?</string>
     <string name="secret_text">secret</string>
+    <string name="small_text">petit</string>
+    <string name="link_text">enllaç</string>
     <string name="icon_descr_speaker_off">Altaveu desactivat</string>
     <string name="icon_descr_speaker_on">Altaveu activat</string>
     <string name="without_tor_or_vpn_ip_address_will_be_visible_to_file_servers">Sense Tor o una VPN, el servidors de fitxers podran veure la vostra adreça.</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/cs/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/cs/strings.xml
@@ -339,6 +339,8 @@
     <string name="network_disable_socks_info">Pokud potvrdíte, budou servery zasílající zprávy vidět vaši IP adresu a váš poskytovatel - ke kterým serverům se připojujete.</string>
     <string name="colored_text">barevné</string>
     <string name="secret_text">tajné</string>
+    <string name="small_text">malé</string>
+    <string name="link_text">odkaz</string>
     <string name="callstatus_calling">volání…</string>
     <string name="callstate_connected">připojen</string>
     <string name="callstate_ended">ukončen</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/de/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/de/strings.xml
@@ -443,6 +443,8 @@
     <string name="a_plus_b">a + b</string>
     <string name="colored_text">farbig</string>
     <string name="secret_text">geheim</string>
+    <string name="small_text">klein</string>
+    <string name="link_text">Link</string>
     <!-- CICallStatus - in chat items -->
     <string name="callstatus_calling">Anruf…</string>
     <string name="callstatus_missed">Anruf verpasst</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/el/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/el/strings.xml
@@ -12,6 +12,8 @@
     <string name="security_code">Κωδικός ασφαλείας</string>
     <string name="smp_servers_scan_qr">Σάρωσε τον QR κωδικό του διακομιστή</string>
     <string name="secret_text">μυστικό</string>
+    <string name="small_text">μικρό</string>
+    <string name="link_text">σύνδεσμος</string>
     <string name="chat_item_ttl_week">1 εβδομάδα</string>
     <string name="v4_2_security_assessment">αξιολόγηση ασφαλείας</string>
     <string name="allow_verb">Επέτρεψε</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/es/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/es/strings.xml
@@ -593,6 +593,8 @@
     <string name="saved_ICE_servers_will_be_removed">Se eliminarán los servidores WebRTC ICE guardados.</string>
     <string name="callstatus_rejected">llamada rechazada</string>
     <string name="secret_text">secreto</string>
+    <string name="small_text">pequeño</string>
+    <string name="link_text">enlace</string>
     <string name="open_simplex_chat_to_accept_call">Abrir SimpleX Chat para aceptar llamada</string>
     <string name="network_options_reset_to_defaults">Reiniciar a valores predetarminados</string>
     <string name="icon_descr_server_status_pending">Pendiente</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/fa/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/fa/strings.xml
@@ -857,6 +857,8 @@
     <string name="we_do_not_store_contacts_or_messages_on_servers">ما هیچکدام از مخاطبان و پیام‌های(وقتی تحویل داده شدند) شما را روی سرورها ذخیره نمی‌کنیم.</string>
     <string name="colored_text">رنگی</string>
     <string name="secret_text">محرمانه</string>
+    <string name="small_text">کوچک</string>
+    <string name="link_text">پیوند</string>
     <string name="callstatus_calling">در حال تماس…</string>
     <string name="callstatus_missed">تماس ناموفق</string>
     <string name="callstatus_in_progress">تماس در جریان است</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/fi/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/fi/strings.xml
@@ -711,6 +711,8 @@
     <string name="network_socks_proxy_settings">SOCKS-välityspalvelimen asetukset</string>
     <string name="callstatus_missed">vastaamaton puhelu</string>
     <string name="secret_text">salainen</string>
+    <string name="small_text">pieni</string>
+    <string name="link_text">linkki</string>
     <string name="share_with_contacts">Jaa kontaktien kanssa</string>
     <string name="self_destruct">Itsetuho</string>
     <string name="self_destruct_passcode_changed">Itsetuhoutuva pääsykoodi vaihdettu!</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/fr/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/fr/strings.xml
@@ -432,6 +432,8 @@
     <string name="a_plus_b">a + b</string>
     <string name="colored_text">coloré</string>
     <string name="secret_text">secret</string>
+    <string name="small_text">petit</string>
+    <string name="link_text">lien</string>
     <string name="callstatus_calling">appel…</string>
     <string name="callstatus_missed">appel manqué</string>
     <string name="callstate_waiting_for_answer">en attente de réponse…</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/hr/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/hr/strings.xml
@@ -396,6 +396,8 @@
     <string name="save_and_notify_contact">Sačuvati i obavestiti kontakt</string>
     <string name="save_and_notify_group_members">Sačuvati i obavestiti članove grupe</string>
     <string name="secret_text">tajna</string>
+    <string name="small_text">malo</string>
+    <string name="link_text">poveznica</string>
     <string name="video_call_no_encryption">video poziv (nije e2e šifrovan)</string>
     <string name="icon_descr_video_on">Video uključen</string>
     <string name="icon_descr_audio_off">Audio isključeno</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/hu/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/hu/strings.xml
@@ -881,6 +881,8 @@
     <string name="rcv_group_event_open_chat">Megnyitás</string>
     <string name="network_option_protocol_timeout">Protokoll időtúllépése</string>
     <string name="secret_text">titok</string>
+    <string name="small_text">kicsi</string>
+    <string name="link_text">hivatkozás</string>
     <string name="settings_notification_preview_mode_title">Értesítésekben megjelenő információk</string>
     <string name="callstate_waiting_for_confirmation">várakozás a visszaigazolásra…</string>
     <string name="stop_file__action">Fájl megállítása</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/in/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/in/strings.xml
@@ -409,6 +409,8 @@
     <string name="create_another_profile_button">Buat profil</string>
     <string name="display_name">Masukkan nama Anda:</string>
     <string name="secret_text">rahasia</string>
+    <string name="small_text">kecil</string>
+    <string name="link_text">tautan</string>
     <string name="italic_text">miring</string>
     <string name="colored_text">berwarna</string>
     <string name="callstatus_connecting">menghubung panggilan…</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/it/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/it/strings.xml
@@ -630,6 +630,8 @@
     <string name="save_and_notify_group_members">Salva e avvisa i membri del gruppo</string>
     <string name="save_preferences_question">Salvare le preferenze\?</string>
     <string name="secret_text">segreto</string>
+    <string name="small_text">piccolo</string>
+    <string name="link_text">link</string>
     <string name="callstate_starting">avvio…</string>
     <string name="strikethrough_text">barrato</string>
     <string name="the_messaging_and_app_platform_protecting_your_privacy_and_security">La piattaforma di messaggistica che protegge la tua privacy e sicurezza.</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/iw/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/iw/strings.xml
@@ -864,6 +864,8 @@
     <string name="smp_save_servers_question">לשמור שרתים\?</string>
     <string name="save_settings_question">לשמור הגדרות\?</string>
     <string name="secret_text">סודי</string>
+    <string name="small_text">קטן</string>
+    <string name="link_text">קישור</string>
     <string name="restore_database_alert_confirm">שחזור</string>
     <string name="button_send_direct_message">שלח הודעה ישירה</string>
     <string name="sender_cancelled_file_transfer">השולח ביטל את העברת הקובץ.</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/ja/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/ja/strings.xml
@@ -735,6 +735,8 @@
     <string name="profile_is_only_shared_with_your_contacts">プロフィールは連絡先にしか共有されません。</string>
     <string name="you_can_use_markdown_to_format_messages__prompt">メッセージの書式をマークダウンで編集できます。</string>
     <string name="secret_text">シークレット</string>
+    <string name="small_text">小さい</string>
+    <string name="link_text">リンク</string>
     <string name="strikethrough_text">取り消し線</string>
     <string name="callstate_starting">接続中…</string>
     <string name="next_generation_of_private_messaging">次世代のプライベートメッセンジャー</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/ko/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/ko/strings.xml
@@ -814,6 +814,8 @@
     <string name="smp_servers_use_server_for_new_conn">새로운 대화에 사용</string>
     <string name="smp_servers_invalid_address">잘못된 서버 주소에요!</string>
     <string name="secret_text">비밀</string>
+    <string name="small_text">작게</string>
+    <string name="link_text">링크</string>
     <string name="status_no_e2e_encryption">종단 간 암호화 안 됨</string>
     <string name="settings_section_title_themes">테마</string>
     <string name="snd_group_event_changed_role_for_yourself">내 역할이 %s로 변경되었어요.</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/lt/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/lt/strings.xml
@@ -1514,6 +1514,8 @@
     <string name="you_can_also_connect_by_clicking_the_link"><![CDATA[Galite prisijungti paspausdami ant nuorodos. Jei ji atsidaro naršyklėje, paspauskite ant <b>Atidaryti mobilioje programėlėje</b> mygtuko.]]></string>
     <string name="unable_to_open_browser_title">Įvyko klaida atveriant naršyklę</string>
     <string name="secret_text">paslaptis</string>
+    <string name="small_text">mažas</string>
+    <string name="link_text">nuoroda</string>
     <string name="shutdown_alert_desc">Pranešimai nustos veikti iki tol kol paleisite programėlę iš naujo</string>
     <string name="you_can_use_markdown_to_format_messages__prompt">Galite naudoti markdown, kad formatuoti žinutes:</string>
     <string name="run_chat_section">Paleisti pokalbius</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/lv/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/lv/strings.xml
@@ -423,6 +423,8 @@
     <string name="strikethrough_text">Pārsvītrots Teksts</string>
     <string name="colored_text">Krāsains Teksts</string>
     <string name="secret_text">Slepenais Teksts</string>
+    <string name="small_text">mazs</string>
+    <string name="link_text">saite</string>
     <string name="callstatus_calling">Zvana Statuss Zvana</string>
     <string name="callstatus_missed">Zvana Statuss Garām Palaists</string>
     <string name="callstatus_rejected">Zvana Statuss Noraidīts</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/ml/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/ml/strings.xml
@@ -91,6 +91,8 @@
     <string name="delete_address__question">വിലാസം ഇല്ലാതാക്കണോ\?</string>
     <string name="settings_notifications_mode_title">അറിയിപ്പ് സേവനം</string>
     <string name="secret_text">രഹസ്യം</string>
+    <string name="small_text">ചെറുത്</string>
+    <string name="link_text">ലിങ്ക്</string>
     <string name="error_creating_address">വിലാസം സൃഷ്ടിക്കുന്നതിൽ പിശക്</string>
     <string name="error_changing_address">വിലാസം മാറ്റുന്നതിൽ പിശക്</string>
     <string name="hide_notification">മറയ്ക്കുക</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/nl/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/nl/strings.xml
@@ -709,6 +709,8 @@
     <string name="you_can_use_markdown_to_format_messages__prompt">U kunt markdown gebruiken voor opmaak in berichten:</string>
     <string name="callstatus_rejected">geweigerde oproep</string>
     <string name="secret_text">geheim</string>
+    <string name="small_text">klein</string>
+    <string name="link_text">link</string>
     <string name="next_generation_of_private_messaging">De toekomst van berichtenuitwisseling</string>
     <string name="callstate_waiting_for_answer">wachten op antwoord…</string>
     <string name="to_protect_privacy_simplex_has_ids_for_queues">Om uw privacy te beschermen, gebruikt SimpleX voor elk van uw contacten afzonderlijke ID\'s.</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/pl/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/pl/strings.xml
@@ -417,6 +417,8 @@
     <string name="callstate_received_confirmation">otrzymano potwierdzenie…</string>
     <string name="callstatus_rejected">odrzucone połączenie</string>
     <string name="secret_text">sekret</string>
+    <string name="small_text">małe</string>
+    <string name="link_text">odnośnik</string>
     <string name="callstate_starting">uruchamianie…</string>
     <string name="strikethrough_text">przekreślenie</string>
     <string name="first_platform_without_user_ids">Brak identyfikatorów użytkownika.</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/pt-rBR/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/pt-rBR/strings.xml
@@ -718,6 +718,8 @@
     <string name="developer_options">IDs de banco de dados e opção de isolamento de transporte.</string>
     <string name="profile_is_only_shared_with_your_contacts">O perfil é compartilhado apenas com seus contatos.</string>
     <string name="secret_text">segredo</string>
+    <string name="small_text">pequeno</string>
+    <string name="link_text">link</string>
     <string name="italic_text">Itálico</string>
     <string name="callstatus_missed">chamada perdida</string>
     <string name="you_can_use_markdown_to_format_messages__prompt">Você pode usar markdown para formatar mensagens:</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/ro/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/ro/strings.xml
@@ -292,6 +292,8 @@
     <string name="show_dev_options">Afișează:</string>
     <string name="show_internal_errors">Afișează erorile interne</string>
     <string name="secret_text">secret</string>
+    <string name="small_text">mic</string>
+    <string name="link_text">link</string>
     <string name="settings_section_title_settings">Setări</string>
     <string name="rcv_group_event_1_member_connected">%s conectat</string>
     <string name="profile_update_event_set_new_picture">setați o nouă poză de profil</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/ru/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/ru/strings.xml
@@ -440,6 +440,8 @@
     <string name="a_plus_b">a + b</string>
     <string name="colored_text">цвет</string>
     <string name="secret_text">секрет</string>
+    <string name="small_text">мелкий</string>
+    <string name="link_text">ссылка</string>
     <string name="connect_via_link">Соединиться через ссылку</string>
     <string name="this_string_is_not_a_connection_link">Эта строка не является ссылкой-приглашением!</string>
     <string name="you_can_also_connect_by_clicking_the_link"><![CDATA[Вы также можете соединиться, открыв ссылку там, где Вы её получили. Если ссылка откроется в браузере, нажмите кнопку <b>Открыть в приложении</b>.]]></string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/th/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/th/strings.xml
@@ -853,6 +853,8 @@
     <string name="custom_time_unit_seconds">วินาที</string>
     <string name="self_destruct_passcode">รหัสผ่านแบบทําลายตัวเอง</string>
     <string name="secret_text">ความลับ</string>
+    <string name="small_text">เล็ก</string>
+    <string name="link_text">ลิงก์</string>
     <string name="v4_2_security_assessment">การประเมินความปลอดภัย</string>
     <string name="self_destruct_passcode_enabled">เปิดใช้งานรหัสผ่านแบบทําลายตัวเองแล้ว!</string>
     <string name="send_disappearing_message_send">ส่ง</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/tr/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/tr/strings.xml
@@ -1271,6 +1271,8 @@
     <string name="using_simplex_chat_servers">SimpleX Chat serverları kullanılıyor.</string>
     <string name="smp_servers_preset_add">Ön ayarlı sunucular ekle</string>
     <string name="secret_text">gizli</string>
+    <string name="small_text">küçük</string>
+    <string name="link_text">bağlantı</string>
     <string name="receipts_groups_disable_for_all">Bütün gruplar için devre dışı bırak</string>
     <string name="v4_6_group_welcome_message_descr">Yeni üyeler için gösterilecek mesajı seç!</string>
     <string name="stop_snd_file__message">Dosya gönderimi durdurulacaktır.</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/uk/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/uk/strings.xml
@@ -504,6 +504,8 @@
     <string name="custom_time_picker_select">Вибрати</string>
     <string name="custom_time_picker_custom">інше</string>
     <string name="secret_text">прихований</string>
+    <string name="small_text">дрібний</string>
+    <string name="link_text">посилання</string>
     <string name="join_group_button">Приєднатися</string>
     <string name="role_in_group">Роль</string>
     <string name="conn_level_desc_indirect">непряме (%1$s)</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/vi/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/vi/strings.xml
@@ -1590,6 +1590,8 @@
     <string name="sender_at_ts">%s vào %s</string>
     <string name="select_contacts">Chọn các liên hệ</string>
     <string name="secret_text">bí mật</string>
+    <string name="small_text">nhỏ</string>
+    <string name="link_text">liên kết</string>
     <string name="sending_files_not_yet_supported">gửi tệp chưa được hỗ trợ</string>
     <string name="send_disappearing_message">Gửi tin nhắn tự xóa</string>
     <string name="cannot_share_message_alert_text">Các tùy chọn của cuộc trò chuyện được chọn không cho phép tin nhắn này.</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/zh-rCN/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/zh-rCN/strings.xml
@@ -707,6 +707,8 @@
     <string name="scan_code_from_contacts_app">从你联系人的应用程序中扫描安全码。</string>
     <string name="security_code">安全码</string>
     <string name="secret_text">秘密</string>
+    <string name="small_text">小</string>
+    <string name="link_text">链接</string>
     <string name="v4_2_security_assessment">安全评估</string>
     <string name="ntf_channel_messages">SimpleX 消息</string>
     <string name="is_not_verified">%s 未验证</string>

--- a/apps/multiplatform/common/src/commonMain/resources/MR/zh-rTW/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/zh-rTW/strings.xml
@@ -74,6 +74,8 @@
     <string name="callstatus_calling">正在撥打…</string>
     <string name="callstatus_in_progress">通話中</string>
     <string name="secret_text">私密</string>
+    <string name="small_text">小</string>
+    <string name="link_text">連結</string>
     <string name="callstate_connected">已連接</string>
     <string name="onboarding_notifications_mode_off_desc"><![CDATA[<b>對電量最好</b>。 只有在應用程式運行中的時侯才可以接收訊息通知。（沒有後台服務）]]></string>
     <string name="encrypted_video_call">端對端加密的視訊通話</string>


### PR DESCRIPTION
**Problem:** The "How to use" markdown help screen documented only some of the supported formatting codes. **Fix:** Added the missing small text (`!- text!`) and link (`[text](https://…)`) formats, with translations, on Android, desktop and iOS. **Cause:** These two formats were never added to the help screen when they were introduced to the parser.