### PR TITLE
android, desktop, ios: document missing markdown formats in help and make examples interactive

### DIFF
--- a/apps/ios/Shared/Views/UserSettings/MarkdownHelp.swift
+++ b/apps/ios/Shared/Views/UserSettings/MarkdownHelp.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct MarkdownHelp: View {
     @EnvironmentObject var theme: AppTheme
+    @State private var secretRevealed = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -19,13 +20,15 @@ struct MarkdownHelp: View {
             mdFormat("_italic_", Text("italic").italic())
             mdFormat("~strike~", Text("strike").strikethrough())
             mdFormat("`a + b`", Text("`a + b`").font(.body.monospaced()))
+            mdFormat("!- small!", Text("small").font(.footnote).foregroundColor(.secondary))
             mdFormat("!1 colored!", Text("colored").foregroundColor(.red) + Text(verbatim: " (") + color("1", .red) + color("2", .green) + color("3", .blue) + color("4", .yellow) + color("5", .cyan) + Text("6").foregroundColor(.purple) + Text(verbatim: ")"))
-            (
-                mdFormat("#secret#", Text("secret")
-                    .foregroundColor(.clear)
-                    .underline(color: theme.colors.onBackground) + Text(" (can be copied)"))
-            )
-            .textSelection(.enabled)
+            // matches how secret text works in chat: tap to reveal/hide
+            mdFormat("#secret#", secretRevealed
+                ? Text("secret")
+                : Text("secret").foregroundColor(.clear).underline(color: theme.colors.onBackground))
+                .onTapGesture { secretRevealed.toggle() }
+            mdFormat("[link](https://simplex.chat)", Text("link").foregroundColor(theme.colors.primary).underline())
+                .onTapGesture { if let url = URL(string: "https://simplex.chat") { openExternalLink(url) } }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/apps/ios/en.lproj/Localizable.strings
+++ b/apps/ios/en.lproj/Localizable.strings
@@ -24,3 +24,6 @@
 
 /* No comment provided by engineer. */
 "No group!" = "Group not found!";
+
+/* No comment provided by engineer. */
+"[link](https://simplex.chat)" = "\\[link](https://simplex.chat)";

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/MarkdownHelpView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/MarkdownHelpView.kt
@@ -1,11 +1,19 @@
 package chat.simplex.common.views.usersettings
 
 import SectionBottomSpacer
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.platform.LocalUriHandler
 import dev.icerock.moko.resources.compose.stringResource
 import androidx.compose.ui.text.*
 import androidx.compose.desktop.ui.tooling.preview.Preview
@@ -14,6 +22,7 @@ import chat.simplex.common.model.Format
 import chat.simplex.common.model.FormatColor
 import chat.simplex.common.ui.theme.DEFAULT_PADDING
 import chat.simplex.common.ui.theme.SimpleXTheme
+import chat.simplex.common.views.helpers.openExternalLink
 import chat.simplex.res.MR
 
 @Composable
@@ -30,11 +39,15 @@ fun MarkdownHelpView() {
     val equation = stringResource(MR.strings.a_plus_b)
     val colored = stringResource(MR.strings.colored_text)
     val secret = stringResource(MR.strings.secret_text)
+    val small = stringResource(MR.strings.small_text)
+    val link = stringResource(MR.strings.link_text)
+    val uriHandler = LocalUriHandler.current
 
     MdFormat("*$bold*", bold, Format.Bold())
     MdFormat("_${italic}_", italic, Format.Italic())
     MdFormat("~$strikethrough~", strikethrough, Format.StrikeThrough())
     MdFormat("`$equation`", equation, Format.Snippet())
+    MdFormat("!- $small!", small, Format.Small())
     Row {
       MdSyntax("!1 $colored!")
       Text(buildAnnotatedString {
@@ -48,13 +61,25 @@ fun MarkdownHelpView() {
         appendColor(this, "6", FormatColor.magenta, ")")
       })
     }
+    var secretRevealed by remember { mutableStateOf(false) }
     Row {
       MdSyntax("#$secret#")
-      SelectionContainer {
-        Text(buildAnnotatedString {
-          withStyle(Format.Secret().style) { append(secret) }
-        })
-      }
+      Text(
+        buildAnnotatedString {
+          if (secretRevealed) append(secret)
+          else withStyle(Format.Secret().style) { append(secret) }
+        },
+        mdClickable { secretRevealed = !secretRevealed }
+      )
+    }
+    Row {
+      MdSyntax("[$link](https://simplex.chat)")
+      Text(
+        buildAnnotatedString {
+          withStyle(Format.HyperLink(link, "https://simplex.chat").style) { append(link) }
+        },
+        mdClickable { uriHandler.openExternalLink("https://simplex.chat") }
+      )
     }
     SectionBottomSpacer()
   }
@@ -66,6 +91,13 @@ fun MdSyntax(markdown: String) {
     .width(120.dp)
     .padding(bottom = 4.dp))
 }
+
+// hand cursor on hover, no click highlight - matches how secret text and links behave in chat
+@Composable
+fun mdClickable(onClick: () -> Unit): Modifier =
+  Modifier
+    .pointerHoverIcon(PointerIcon.Hand)
+    .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, onClick = onClick)
 
 @Composable
 fun MdFormat(markdown: String, example: String, format: Format) {

--- a/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
@@ -1252,6 +1252,8 @@
   <string name="a_plus_b">a + b</string>
   <string name="colored_text">colored</string>
   <string name="secret_text">secret</string>
+  <string name="small_text">small</string>
+  <string name="link_text">link</string>
 
   <!-- CICallStatus - in chat items -->
   <string name="callstatus_calling">calling…</string>


### PR DESCRIPTION
The "How to use" markdown help didn't list all formats and its examples weren't interactive. It now documents small text (`!- text!`) and links (`[text](url)`), opens the link via the standard "Open external link?" prompt, and reveals secret text on tap — matching how they behave in chat.
<img width="371" height="549" alt="fixmissingformatting" src="https://github.com/user-attachments/assets/b816a1e0-407d-4602-a458-9bad1121d58b" />
