### PR TITLE
ios: open SimpleX links in chat messages via in-app connect flow

### DIFF
--- a/apps/ios/Shared/Views/Chat/ChatItem/MsgContentView.swift
+++ b/apps/ios/Shared/Views/Chat/ChatItem/MsgContentView.swift
@@ -191,9 +191,14 @@ private func handleTextTaps(
                         }
                     }
                 }
-                if let index, let (uri, browser) = attributedStringLink(s, for: index) {
+                if let index, let (uri, browser, simplex) = attributedStringLink(s, for: index) {
                     if browser {
                         openBrowserAlert(uri: uri)
+                    } else if simplex, let url = URL(string: uri) {
+                        // SimpleX links target this same app (simplex: scheme / simplex.chat universal link),
+                        // so UIApplication.shared.open is dropped by iOS while the app is in the foreground.
+                        // Route to the in-app connect flow instead (same sink onOpenURL feeds).
+                        ChatModel.shared.appOpenUrl = url
                     } else if let url = URL(string: uri) {
                         UIApplication.shared.open(url)
                     } else {
@@ -203,9 +208,10 @@ private func handleTextTaps(
             })
     }
 
-    func attributedStringLink(_ s: NSAttributedString, for index: CFIndex) -> (String, Bool)? {
+    func attributedStringLink(_ s: NSAttributedString, for index: CFIndex) -> (String, Bool, Bool)? {
         var linkURL: String?
         var browser: Bool = false
+        var simplex: Bool = false
         s.enumerateAttributes(in: NSRange(location: 0, length: s.length)) { attrs, range, stop in
             if index >= range.location && index < range.location + range.length {
                 if let nameInfo = attrs[nameAttrKey] as? SimplexNameInfo {
@@ -213,6 +219,7 @@ private func handleTextTaps(
                 } else if let url = attrs[linkAttrKey] as? String {
                     linkURL = url
                     browser = attrs[webLinkAttrKey] != nil
+                    simplex = attrs[simplexLinkAttrKey] != nil
                 } else if let showSecrets, let i = attrs[secretAttrKey] as? Int {
                     if showSecrets.wrappedValue.contains(i) {
                         showSecrets.wrappedValue.remove(i)
@@ -225,7 +232,7 @@ private func handleTextTaps(
                 stop.pointee = true
             }
         }
-        return if let linkURL { (linkURL, browser) } else { nil }
+        return if let linkURL { (linkURL, browser, simplex) } else { nil }
     }
 }
 
@@ -249,6 +256,8 @@ func hiddenSecretsView<V: View>(_ v: V) -> some View {
 private let linkAttrKey = NSAttributedString.Key("chat.simplex.app.link")
 
 private let webLinkAttrKey = NSAttributedString.Key("chat.simplex.app.webLink")
+
+private let simplexLinkAttrKey = NSAttributedString.Key("chat.simplex.app.simplexLink")
 
 private let secretAttrKey = NSAttributedString.Key("chat.simplex.app.secret")
 
@@ -392,6 +401,7 @@ func messageText(
                 attrs = linkAttrs()
                 if !preview {
                     attrs[linkAttrKey] = simplexUri
+                    attrs[simplexLinkAttrKey] = true
                     handleTaps = true
                 }
                 if let s = text ?? (privacySimplexLinkModeDefault.get() == .description ? linkType.description : nil) {

--- a/apps/ios/Shared/Views/ChatList/ChatHelp.swift
+++ b/apps/ios/Shared/Views/ChatList/ChatHelp.swift
@@ -26,7 +26,9 @@ struct ChatHelp: View {
                 Button("connect to SimpleX Chat developers.") {
                     dismissSettingsSheet()
                     DispatchQueue.main.async {
-                        UIApplication.shared.open(simplexTeamURL)
+                        // simplexTeamURL targets this same app; route to the in-app connect flow
+                        // (UIApplication.shared.open is dropped for self-owned URLs in the foreground)
+                        ChatModel.shared.appOpenUrl = simplexTeamURL
                     }
                 }
                 .padding(.top, 2)

--- a/apps/ios/Shared/Views/UserSettings/SettingsView.swift
+++ b/apps/ios/Shared/Views/UserSettings/SettingsView.swift
@@ -390,7 +390,9 @@ struct SettingsView: View {
                     Button("Send questions and ideas") {
                         dismiss()
                         DispatchQueue.main.async {
-                            UIApplication.shared.open(simplexTeamURL)
+                            // simplexTeamURL targets this same app; route to the in-app connect flow
+                            // (UIApplication.shared.open is dropped for self-owned URLs in the foreground)
+                            ChatModel.shared.appOpenUrl = simplexTeamURL
                         }
                     }
                 }


### PR DESCRIPTION
## Problem

On iOS (reproduced on iPhone 17, v6.5.2 and v6.5.5), tapping a **SimpleX connection/invitation link inside message text** does nothing — it never reaches the connection flow. Tapping web links (open in browser) and the connection-link **card** both work, so only inline SimpleX links appear dead.

## Root cause

Inline links are dispatched in `MsgContentView.handleTextTaps`:

- web links (`webLinkAttrKey`) → `openBrowserAlert` (Safari)
- everything else → `UIApplication.shared.open(url)`

SimpleX links fell into the second branch. iOS drops `UIApplication.shared.open` for a URL that the **same** app owns while it is in the foreground — both the `simplex:` scheme and the `simplex.chat` universal links are registered to this app. So the tap was silently swallowed: `onOpenURL` never fired and `connectViaUrl` was never reached.

`mailto:`/`tel:` use the same branch but target **other** apps (Mail/Phone), so they keep working — which is why the failure looked specific to SimpleX links.

The connection-link card never had this bug because it calls `planAndConnect` in-process (`FramedItemView`), and the multiplatform clients do the same via `openVerifiedSimplexUri` → `connectIfOpenedViaUri` → `planAndConnect`. iOS inline links were the only path relying on an OS round-trip.

## Fix

Restore the three-way dispatch that the multiplatform clients use (`WEB_URL` / `OTHER_URL` / `SIMPLEX_URL`):

- web → `openBrowserAlert` (unchanged)
- `mailto:`/`tel:` → `UIApplication.shared.open` (unchanged, other apps)
- **SimpleX → `ChatModel.appOpenUrl`** — the same sink `onOpenURL` feeds, leading to `connectViaUrl` → `planAndConnect`, with no OS round-trip

SimpleX links are identified by a dedicated attribute key set on the `.simplexLink` format (mirroring the multiplatform `SIMPLEX_URL` tag), rather than sniffing the URL string, so all link types (contact, invitation, group, channel, relay) and both URI schemes are covered.

This is the same mechanism already used by `ShareSheet.openExternalLink`, which routes SimpleX links to `appOpenUrl`.

Also fixes the same problem for the **"Send questions and ideas"** (Settings) and **"connect to SimpleX Chat developers"** (chat help) buttons, which open `simplexTeamURL` (a `simplex:` link) the same broken way.

## Scope

`MsgContentView.swift`, `SettingsView.swift`, `ChatHelp.swift` — 19 insertions, 5 deletions. No behavior change for web/mailto/tel links.

## Testing

Needs a build + device check (the dispatch is iOS-version-dependent). Verify: tapping an inline SimpleX invitation/contact link in a message opens the connection sheet, and the two developer-contact buttons open the connect flow.