### PR TITLE
nodejs: fix apiChatItemReaction checking wrong response type

### DIFF
--- a/packages/simplex-chat-nodejs/src/api.ts
+++ b/packages/simplex-chat-nodejs/src/api.ts
@@ -498,10 +498,10 @@ export class ChatApi {
     chatItemId: number,
     add: boolean,
     reaction: T.MsgReaction
-  ) {
+  ): Promise<T.ACIReaction> {
     const r = await this.sendChatCmd(CC.APIChatItemReaction.cmdString({chatRef: {chatType, chatId}, chatItemId, add, reaction}))
-    if (r.type === "chatItemsDeleted") return r.chatItemDeletions
-    throw new ChatCommandError("error setting item reaction", r)  
+    if (r.type === "chatItemReaction") return r.reaction
+    throw new ChatCommandError("error setting item reaction", r)
   }
 
   /**


### PR DESCRIPTION
## Problem

`ChatApi.apiChatItemReaction` in `packages/simplex-chat-nodejs/src/api.ts` checks the response against `"chatItemsDeleted"` and returns `r.chatItemDeletions`:

```ts
const r = await this.sendChatCmd(CC.APIChatItemReaction.cmdString({chatRef: {chatType, chatId}, chatItemId, add, reaction}))
if (r.type === "chatItemsDeleted") return r.chatItemDeletions
throw new ChatCommandError("error setting item reaction", r)
```

Those values were copy-pasted from `apiDeleteMemberChatItem` directly above it. The `/_reaction` command (`APIChatItemReaction`) **never** returns `chatItemsDeleted` — its success response is `CR.ChatItemReaction` (`type: "chatItemReaction"`, field `reaction: T.ACIReaction`), as declared by `APIChatItemReaction.Response` in `commands.ts`.

### Impact
- The method **always throws** `ChatCommandError("error setting item reaction")`, even when adding/removing a reaction succeeds.
- `r.chatItemDeletions` does not exist on the reaction response, and the method had no return type annotation.

## Fix

Match on `"chatItemReaction"` and return `r.reaction`, typed `Promise<T.ACIReaction>`:

```ts
): Promise<T.ACIReaction> {
  const r = await this.sendChatCmd(CC.APIChatItemReaction.cmdString({chatRef: {chatType, chatId}, chatItemId, add, reaction}))
  if (r.type === "chatItemReaction") return r.reaction
  throw new ChatCommandError("error setting item reaction", r)
}
```

This matches:
- `APIChatItemReaction.Response = CR.ChatItemReaction | CR.ChatCmdError` in `packages/simplex-chat-client/types/typescript/src/commands.ts`
- the `CR.ChatItemReaction` interface (`type: "chatItemReaction"`, `reaction: T.ACIReaction`) in `responses.ts`
- the Python client's `api_chat_item_reaction`, which already returns `r["reaction"]` on `type == "chatItemReaction"`

## Notes
- One-line behavioural change plus a return-type annotation; no API surface change for callers that were (necessarily) catching the spurious error.
