### PR TITLE
ui: keep customized "Additional accent 2" color on theme import

### DIFF
--- a/apps/ios/Shared/Theme/Theme.swift
+++ b/apps/ios/Shared/Theme/Theme.swift
@@ -192,7 +192,7 @@ extension ThemeModeOverride {
                 background: colors.background != tc.background ? colors.background : nil,
                 surface: colors.surface != tc.surface ? colors.surface : nil,
                 title: colors.title != tc.title ? colors.title : nil,
-                primaryVariant2: colors.primaryVariant2 != tc.primaryVariant2 ? colors.primary : nil,
+                primaryVariant2: colors.primaryVariant2 != tc.primaryVariant2 ? colors.primaryVariant2 : nil,
                 sentMessage: colors.sentMessage != tc.sentMessage ? colors.sentMessage : nil,
                 sentQuote: colors.sentQuote != tc.sentQuote ? colors.sentQuote : nil,
                 receivedMessage: colors.receivedMessage != tc.receivedMessage ? colors.receivedMessage : nil,

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/ui/theme/Theme.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/ui/theme/Theme.kt
@@ -568,7 +568,7 @@ data class ThemeModeOverride (
         background = if (colors.background?.colorFromReadableHex() != c.background) colors.background else null,
         surface = if (colors.surface?.colorFromReadableHex() != c.surface) colors.surface else null,
         title = if (colors.title?.colorFromReadableHex() != ac.title) colors.title else null,
-        primaryVariant2 = if (colors.primaryVariant2?.colorFromReadableHex() != ac.primaryVariant2) colors.primary else null,
+        primaryVariant2 = if (colors.primaryVariant2?.colorFromReadableHex() != ac.primaryVariant2) colors.primaryVariant2 else null,
         sentMessage = if (colors.sentMessage?.colorFromReadableHex() != ac.sentMessage) colors.sentMessage else null,
         sentQuote = if (colors.sentQuote?.colorFromReadableHex() != ac.sentQuote) colors.sentQuote else null,
         receivedMessage = if (colors.receivedMessage?.colorFromReadableHex() != ac.receivedMessage) colors.receivedMessage else null,


### PR DESCRIPTION
When stripping default-equal colors from an imported theme, `removeSameColors` stored `colors.primary` in the `primaryVariant2` slot instead of `colors.primaryVariant2` (every sibling field keeps its own value). As a result, importing a theme with a customized "Additional accent 2" color replaced it with the primary accent color. This fixes the field on both Android/desktop (`Theme.kt`) and iOS (`Theme.swift`).