### PR TITLE
android: wrap gallery picker intents in createChooser to prevent priority-based hijacking

### DIFF
--- a/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/views/helpers/GetImageView.android.kt
+++ b/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/views/helpers/GetImageView.android.kt
@@ -208,19 +208,25 @@ actual fun GetImageBottomSheet(
 
 class PickFromGallery: ActivityResultContract<Int, Uri?>() {
   override fun createIntent(context: Context, input: Int) =
-    Intent(Intent.ACTION_PICK, MediaStore.Images.Media.INTERNAL_CONTENT_URI).apply {
-      type = "image/*"
-    }
+    Intent.createChooser(
+      Intent(Intent.ACTION_PICK, MediaStore.Images.Media.INTERNAL_CONTENT_URI).apply {
+        type = "image/*"
+      },
+      null
+    )
 
   override fun parseResult(resultCode: Int, intent: Intent?): Uri? = intent?.data
 }
 
 class PickMultipleImagesFromGallery: ActivityResultContract<Int, List<Uri>>() {
   override fun createIntent(context: Context, input: Int) =
-    Intent(Intent.ACTION_PICK, MediaStore.Images.Media.INTERNAL_CONTENT_URI).apply {
-      putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
-      type = "image/*"
-    }
+    Intent.createChooser(
+      Intent(Intent.ACTION_PICK, MediaStore.Images.Media.INTERNAL_CONTENT_URI).apply {
+        putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+        type = "image/*"
+      },
+      null
+    )
 
   override fun parseResult(resultCode: Int, intent: Intent?): List<Uri> =
     if (intent?.data != null)
@@ -244,10 +250,13 @@ class PickMultipleImagesFromGallery: ActivityResultContract<Int, List<Uri>>() {
 
 class PickMultipleVideosFromGallery: ActivityResultContract<Int, List<Uri>>() {
   override fun createIntent(context: Context, input: Int) =
-    Intent(Intent.ACTION_PICK, MediaStore.Video.Media.INTERNAL_CONTENT_URI).apply {
-      putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
-      type = "video/*"
-    }
+    Intent.createChooser(
+      Intent(Intent.ACTION_PICK, MediaStore.Video.Media.INTERNAL_CONTENT_URI).apply {
+        putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+        type = "video/*"
+      },
+      null
+    )
 
   override fun parseResult(resultCode: Int, intent: Intent?): List<Uri> =
     if (intent?.data != null)


### PR DESCRIPTION
Fixes #7142

## Problem
When users select images/videos from gallery, the `ACTION_PICK` intent is fired as a bare implicit intent. If another app (e.g. Canon PRINT) declares a higher-priority intent-filter for `ACTION_PICK` + `image/*`, Android routes straight to it without showing a disambiguation dialog, effectively hijacking the gallery picker.

## Fix
Wrap each of the three picker intents — `PickFromGallery`, `PickMultipleImagesFromGallery`, `PickMultipleVideosFromGallery` — in `Intent.createChooser()`. This forces Android to always display the system picker dialog regardless of any other app's priority, completely preventing silent hijacking.

No behavioral change otherwise — the chooser only affects resolution, not the returned data.

## Files changed
- `apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/views/helpers/GetImageView.android.kt` — wrapped all 3 `ACTION_PICK` intents in `Intent.createChooser()`
