### PR TITLE
fix: NullPointerException creating SimpleX address from user picker

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/UserPicker.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/UserPicker.kt
@@ -220,7 +220,10 @@ fun UserPicker(
       UserPickerOptionRow(
         painterResource(MR.images.ic_qr_code),
         if (chatModel.userAddress.value != null) generalGetString(MR.strings.your_simplex_contact_address) else generalGetString(MR.strings.create_simplex_address),
-        showCustomModal { it, close -> UserAddressView(it, shareViaProfile = it.currentUser.value!!.addressShared, close = close) }, disabled = stopped
+        showCustomModal { m, close ->
+          val user = m.currentUser.value ?: return@showCustomModal
+          UserAddressView(m, shareViaProfile = user.addressShared, close = close)
+        }, disabled = stopped
       )
       UserPickerOptionRow(
         painterResource(MR.images.ic_toggle_on),


### PR DESCRIPTION
## Summary
Line 223 of `UserPicker.kt` builds the "create SimpleX address" row with a force-unwrap: `UserAddressView(it, shareViaProfile = it.currentUser.value!!.addressShared, close = close)`. During recomposition `currentUser.value` can be null, and the `!!` assertion throws the NPE seen in the trace. The fix is to make this null-safe, matching the precedent already used a few lines below at line 230 (`PreferencesView(m, m.currentUser.value ?: return@showCustomModal, close)`).

## Why this matters
On desktop (Linux, app 6.5.4) the app crashes with a `java.lang.NullPointerException` when the user opens the user picker and taps to create a SimpleX address. The stack trace points precisely at `UserPicker.kt:223` inside the `ComposableSingletons$UserPickerKt` lambda invoked from `ModalManager.showInView`. The maintainer (Narasimha-sc, COLLABORATOR) asked the reporter to confirm reproduction on 6.5.4 and the reporter confirmed (2026-06-12); the crash is confirmed on the latest release and unfixed (no open PR touches this code path).

See https://github.com/simplex-chat/simplex-chat/issues/7067.

## Testing
- Happy path: with an active user present, opening the user picker and tapping "Create SimpleX address" opens `UserAddressView` with the correct `shareViaProfile` value, no crash.
- Edge case: if `currentUser.value` is momentarily null during recomposition, the row no-ops instead of throwing (modal simply does not open rather than crashing the app).
- Regression: the adjacent "Chat preferences" row (which already uses the safe `?:` pattern) and the rest of the picker continue to behave unchanged.

Fixes #7067
