### PR TITLE
Remind-me-about-this functionality for messages

### DIFF
--- a/apps/ios/Shared/Model/MessageReminder.swift
+++ b/apps/ios/Shared/Model/MessageReminder.swift
@@ -1,0 +1,100 @@
+//
+//  MessageReminder.swift
+//  SimpleX
+//
+//  Client-local message reminder (issue #7135).
+//
+
+import Foundation
+import SimpleXChat
+
+let GROUP_DEFAULT_MESSAGE_REMINDERS = "MessageReminders"
+
+enum ReminderPreset: String, CaseIterable {
+    case in1Hour
+    case in3Hours
+    case tomorrow
+    case nextWeek
+
+    var menuTitle: String {
+        switch self {
+        case .in1Hour:
+            return NSLocalizedString("In 1 hour", comment: "message reminder preset")
+        case .in3Hours:
+            return NSLocalizedString("In 3 hours", comment: "message reminder preset")
+        case .tomorrow:
+            return NSLocalizedString("Tomorrow", comment: "message reminder preset")
+        case .nextWeek:
+            return NSLocalizedString("Next week", comment: "message reminder preset")
+        }
+    }
+
+    func dueAt(from now: Date = .now, calendar: Calendar = .current) -> Date {
+        switch self {
+        case .in1Hour:
+            return now.addingTimeInterval(3600)
+        case .in3Hours:
+            return now.addingTimeInterval(3 * 3600)
+        case .tomorrow:
+            let startOfToday = calendar.startOfDay(for: now)
+            guard let tomorrow = calendar.date(byAdding: .day, value: 1, to: startOfToday) else {
+                return now.addingTimeInterval(24 * 3600)
+            }
+            return calendar.date(bySettingHour: 9, minute: 0, second: 0, of: tomorrow) ?? tomorrow
+        case .nextWeek:
+            let today = calendar.startOfDay(for: now)
+            let weekday = calendar.component(.weekday, from: today)
+            let daysUntilMonday = (9 - weekday) % 7
+            let addDays = daysUntilMonday == 0 ? 7 : daysUntilMonday
+            guard let monday = calendar.date(byAdding: .day, value: addDays, to: today) else {
+                return now.addingTimeInterval(7 * 24 * 3600)
+            }
+            return calendar.date(bySettingHour: 9, minute: 0, second: 0, of: monday) ?? monday
+        }
+    }
+}
+
+struct MessageReminder: Codable, Equatable, Identifiable {
+    let id: String
+    let userId: Int64
+    let chatId: ChatId
+    let itemId: Int64
+    let dueAt: Date
+    let createdAt: Date
+    var completedAt: Date?
+    var messagePreview: String
+    var chatDisplayName: String
+
+    var isComplete: Bool { completedAt != nil }
+    var isOverdue: Bool { !isComplete && dueAt < .now }
+}
+
+func newMessageReminderId() -> String { UUID().uuidString }
+
+let messageReminderJsonEncoder: JSONEncoder = {
+    let e = JSONEncoder()
+    e.dateEncodingStrategy = .iso8601
+    return e
+}()
+
+let messageReminderJsonDecoder: JSONDecoder = {
+    let d = JSONDecoder()
+    d.dateDecodingStrategy = .iso8601
+    return d
+}()
+
+func canSetMessageReminder(_ ci: ChatItem, _ chat: Chat, live: Bool) -> Bool {
+    guard chat.chatInfo.sendMsgEnabled else { return false }
+    guard ci.meta.itemDeleted == nil, !ci.isReport, !ci.localNote, !ci.isLiveDummy, !live, !ci.meta.isLive else { return false }
+    guard ci.content.msgContent != nil || !ci.content.text.isEmpty else { return false }
+    switch ci.chatDir {
+    case .channelRcv: return false
+    default: return true
+    }
+}
+
+func messageReminderPreview(_ ci: ChatItem, _ chat: Chat) -> String {
+    let isChannel = chat.chatInfo.isChannel
+    let text = ci.text(isChannel: isChannel)
+    return String(text.prefix(200))
+}

--- a/apps/ios/Shared/Model/NtfManager.swift
+++ b/apps/ios/Shared/Model/NtfManager.swift
@@ -18,6 +18,8 @@ let ntfActionRejectCall = "NTF_ACT_REJECT_CALL"
 
 private let ntfTimeInterval: TimeInterval = 1
 
+private let messageReminderUserInfoKeys = (chatId: "chatId", itemId: "itemId", reminderId: "reminderId", userId: "userId")
+
 enum NtfCallAction {
     case accept
     case reject
@@ -74,6 +76,13 @@ class NtfManager: NSObject, UNUserNotificationCenterDelegate, ObservableObject {
             } else {
                 chatModel.ntfCallInvitationAction = (chatId, ntfAction)
             }
+        } else if content.categoryIdentifier == ntfCategoryMessageReminder {
+            if action == ntfActionCompleteMessageReminder,
+               let reminderId = content.userInfo[messageReminderUserInfoKeys.reminderId] as? String {
+                ReminderStore.shared.completeReminder(reminderId: reminderId)
+            } else if action == UNNotificationDefaultActionIdentifier {
+                openChatFromMessageReminder(content, chatModel)
+            }
         } else {
             if let chatId = content.targetContentIdentifier {
                 self.navigatingToChat = true
@@ -94,6 +103,24 @@ class NtfManager: NSObject, UNUserNotificationCenterDelegate, ObservableObject {
             }
         }
         return nil
+    }
+
+    private func openChatFromMessageReminder(_ content: UNNotificationContent, _ chatModel: ChatModel) {
+        guard let chatId = content.userInfo[messageReminderUserInfoKeys.chatId] as? String else { return }
+        let itemId = content.userInfo[messageReminderUserInfoKeys.itemId] as? Int64
+        self.navigatingToChat = true
+        if let itemId {
+            chatModel.openAroundItemId = itemId
+            ItemsModel.shared.loadOpenChatNoWait(chatId, itemId)
+        } else {
+            ItemsModel.shared.loadOpenChat(chatId) {
+                self.navigatingToChat = false
+            }
+            return
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.navigatingToChat = false
+        }
     }
 
     // Handle notification when the app is in foreground
@@ -207,6 +234,18 @@ class NtfManager: NSObject, UNUserNotificationCenterDelegate, ObservableObject {
                 actions: [],
                 intentIdentifiers: [],
                 hiddenPreviewsBodyPlaceholder: NSLocalizedString("New events", comment: "notification")
+            ),
+            UNNotificationCategory(
+                identifier: ntfCategoryMessageReminder,
+                actions: [
+                    UNNotificationAction(
+                        identifier: ntfActionCompleteMessageReminder,
+                        title: NSLocalizedString("Mark complete", comment: "message reminder notification action"),
+                        options: []
+                    )
+                ],
+                intentIdentifiers: [],
+                hiddenPreviewsBodyPlaceholder: NSLocalizedString("Message reminder", comment: "notification")
             )
         ])
     }
@@ -286,6 +325,66 @@ class NtfManager: NSObject, UNUserNotificationCenterDelegate, ObservableObject {
         if settings.authorizationStatus == .authorized {
             nc.removeAllPendingNotificationRequests()
             nc.removeAllDeliveredNotifications()
+        }
+    }
+
+    func scheduleMessageReminder(_ reminder: MessageReminder) {
+        guard granted, !reminder.isComplete else { return }
+        let content = UNMutableNotificationContent()
+        content.categoryIdentifier = ntfCategoryMessageReminder
+        content.title = NSLocalizedString("Message reminder", comment: "notification")
+        let preview = reminder.messagePreview.trimmingCharacters(in: .whitespacesAndNewlines)
+        if preview.isEmpty {
+            content.body = NSLocalizedString("You asked to be reminded about a message", comment: "notification")
+        } else {
+            content.body = preview
+        }
+        if !reminder.chatDisplayName.isEmpty {
+            content.subtitle = reminder.chatDisplayName
+        }
+        content.targetContentIdentifier = reminder.chatId
+        content.userInfo = [
+            messageReminderUserInfoKeys.chatId: reminder.chatId,
+            messageReminderUserInfoKeys.itemId: reminder.itemId,
+            messageReminderUserInfoKeys.reminderId: reminder.id,
+            messageReminderUserInfoKeys.userId: reminder.userId,
+        ]
+        content.sound = .default
+
+        let due = reminder.dueAt
+        let now = Date.now
+        let trigger: UNNotificationTrigger?
+        if due <= now {
+            trigger = UNTimeIntervalNotificationTrigger(timeInterval: max(ntfTimeInterval, 1), repeats: false)
+        } else {
+            let components = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: due)
+            trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: false)
+        }
+        guard let trigger else { return }
+        let request = UNNotificationRequest(
+            identifier: messageReminderNotificationId(reminder.id),
+            content: content,
+            trigger: trigger
+        )
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error = error { logger.error("scheduleMessageReminder error: \(error.localizedDescription)") }
+        }
+    }
+
+    func cancelMessageReminder(_ reminderId: String) {
+        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [messageReminderNotificationId(reminderId)])
+        UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [messageReminderNotificationId(reminderId)])
+    }
+
+    func rescheduleMessageReminders(_ reminders: [MessageReminder]) {
+        let nc = UNUserNotificationCenter.current()
+        nc.getPendingNotificationRequests { requests in
+            let prefix = "chat.simplex.app.messageReminder."
+            let ids = requests.map(\.identifier).filter { $0.hasPrefix(prefix) }
+            nc.removePendingNotificationRequests(withIdentifiers: ids)
+            for reminder in reminders {
+                self.scheduleMessageReminder(reminder)
+            }
         }
     }
 }

--- a/apps/ios/Shared/Model/ReminderStore.swift
+++ b/apps/ios/Shared/Model/ReminderStore.swift
@@ -54,7 +54,7 @@ final class ReminderStore: ObservableObject {
             messagePreview: String(messagePreview.prefix(200)),
             chatDisplayName: chatDisplayName
         )
-        reminders.append(reminder)
+        reminders = reminders + [reminder]
         persist()
         NtfManager.shared.scheduleMessageReminder(reminder)
         return reminder

--- a/apps/ios/Shared/Model/ReminderStore.swift
+++ b/apps/ios/Shared/Model/ReminderStore.swift
@@ -1,0 +1,87 @@
+//
+//  ReminderStore.swift
+//  SimpleX
+//
+//  Client-local message reminders (issue #7135).
+//
+
+import Foundation
+import Combine
+import SimpleXChat
+
+final class ReminderStore: ObservableObject {
+    static let shared = ReminderStore()
+
+    @Published private(set) var reminders: [MessageReminder] = []
+
+    var activeLaterReminders: [MessageReminder] {
+        reminders.filter { !$0.isComplete }.sorted { $0.dueAt < $1.dueAt }
+    }
+
+    private init() {}
+
+    func load() {
+        let raw = groupDefaults.string(forKey: GROUP_DEFAULT_MESSAGE_REMINDERS) ?? "[]"
+        reminders = (try? messageReminderJsonDecoder.decode([MessageReminder].self, from: Data(raw.utf8))) ?? []
+        NtfManager.shared.rescheduleMessageReminders(activeLaterReminders)
+    }
+
+    private func persist() {
+        guard let data = try? messageReminderJsonEncoder.encode(reminders),
+              let encoded = String(data: data, encoding: .utf8) else { return }
+        groupDefaults.set(encoded, forKey: GROUP_DEFAULT_MESSAGE_REMINDERS)
+        groupDefaults.synchronize()
+    }
+
+    @discardableResult
+    func createReminder(
+        chatId: ChatId,
+        itemId: Int64,
+        preset: ReminderPreset,
+        messagePreview: String,
+        chatDisplayName: String
+    ) -> MessageReminder? {
+        guard let userId = ChatModel.shared.currentUser?.userId else { return nil }
+        let now = Date.now
+        let reminder = MessageReminder(
+            id: newMessageReminderId(),
+            userId: userId,
+            chatId: chatId,
+            itemId: itemId,
+            dueAt: preset.dueAt(from: now),
+            createdAt: now,
+            completedAt: nil,
+            messagePreview: String(messagePreview.prefix(200)),
+            chatDisplayName: chatDisplayName
+        )
+        reminders.append(reminder)
+        persist()
+        NtfManager.shared.scheduleMessageReminder(reminder)
+        return reminder
+    }
+
+    func completeReminder(reminderId: String) {
+        let now = Date.now
+        var changed = false
+        reminders = reminders.map {
+            guard $0.id == reminderId, !$0.isComplete else { return $0 }
+            changed = true
+            var copy = $0
+            copy.completedAt = now
+            return copy
+        }
+        if changed {
+            persist()
+            NtfManager.shared.cancelMessageReminder(reminderId)
+        }
+    }
+
+    func reminderById(_ id: String) -> MessageReminder? {
+        reminders.first { $0.id == id }
+    }
+
+    func remindersForCurrentUser() -> [MessageReminder] {
+        guard let userId = ChatModel.shared.currentUser?.userId else { return [] }
+        return activeLaterReminders.filter { $0.userId == userId }
+    }
+}

--- a/apps/ios/Shared/Model/SimpleXAPI.swift
+++ b/apps/ios/Shared/Model/SimpleXAPI.swift
@@ -2210,6 +2210,7 @@ func startChat(refreshInvitations: Bool = true, onboarding: Bool = false) throws
     ChatReceiver.shared.start()
     m.chatRunning = true
     chatLastStartGroupDefault.set(Date.now)
+    ReminderStore.shared.load()
 }
 
 func startChatWithTemporaryDatabase(ctrl: chat_ctrl) throws -> User? {

--- a/apps/ios/Shared/Views/Chat/ChatView.swift
+++ b/apps/ios/Shared/Views/Chat/ChatView.swift
@@ -2294,6 +2294,9 @@ struct ChatView: View {
                 if ci.meta.itemDeleted == nil && !ci.isLiveDummy && !live && !ci.localNote && chat.chatInfo.sendMsgEnabled {
                     replyButton
                 }
+                if canSetMessageReminder(ci, chat, live: live) {
+                    remindMenu(ci)
+                }
                 let fileSource = getLoadedFileSource(ci.file)
                 let fileExists = if let fs = fileSource, FileManager.default.fileExists(atPath: getAppFilePath(fs.filePath).path) { true } else { false }
                 let copyAndShareAllowed = !ci.content.text.isEmpty || (ci.content.msgContent?.isImage == true && fileExists)
@@ -2387,6 +2390,30 @@ struct ChatView: View {
                 Label(
                     NSLocalizedString("Reply", comment: "chat item action"),
                     systemImage: "arrowshape.turn.up.left"
+                )
+            }
+        }
+
+        @ViewBuilder
+        private func remindMenu(_ ci: ChatItem) -> some View {
+            Menu {
+                ForEach(ReminderPreset.allCases, id: \.rawValue) { preset in
+                    Button {
+                        ReminderStore.shared.createReminder(
+                            chatId: chat.id,
+                            itemId: ci.id,
+                            preset: preset,
+                            messagePreview: messageReminderPreview(ci, chat),
+                            chatDisplayName: chat.chatInfo.chatViewName
+                        )
+                    } label: {
+                        Text(preset.menuTitle)
+                    }
+                }
+            } label: {
+                Label(
+                    NSLocalizedString("Remind me", comment: "chat item action"),
+                    systemImage: "bell"
                 )
             }
         }

--- a/apps/ios/Shared/Views/ChatList/ChatListView.swift
+++ b/apps/ios/Shared/Views/ChatList/ChatListView.swift
@@ -156,6 +156,7 @@ struct ChatListView: View {
     @State private var userPickerShown: Bool = false
     @State private var sheet: SomeSheet<AnyView>? = nil
     @StateObject private var chatTagsModel = ChatTagsModel.shared
+    @StateObject private var reminderStore = ReminderStore.shared
     @State private var scrollToItemId: ChatItem.ID? = nil
 
     // iOS 15 is required it to show/hide toolbar while chat is hidden/visible
@@ -400,6 +401,10 @@ struct ChatListView: View {
                         .frame(maxWidth: .infinity)
                         .padding(.top, oneHandUI ? 8 : 0)
                         .id("searchBar")
+                    }
+                    let laterReminders = reminderStore.remindersForCurrentUser()
+                    if !laterReminders.isEmpty {
+                        LaterRemindersSection(reminderStore: reminderStore, reminders: laterReminders)
                     }
                     if !oneHandUICardShown {
                         OneHandUICard()

--- a/apps/ios/Shared/Views/ChatList/LaterRemindersSection.swift
+++ b/apps/ios/Shared/Views/ChatList/LaterRemindersSection.swift
@@ -1,0 +1,92 @@
+//
+//  LaterRemindersSection.swift
+//  SimpleX
+//
+//  Message reminders list section (issue #7135).
+//
+
+import SwiftUI
+import SimpleXChat
+
+struct LaterRemindersSection: View {
+    @EnvironmentObject var theme: AppTheme
+    @ObservedObject var reminderStore: ReminderStore
+    @AppStorage(GROUP_DEFAULT_ONE_HAND_UI, store: groupDefaults) private var oneHandUI = true
+    let reminders: [MessageReminder]
+
+    var body: some View {
+        Section {
+            ForEach(reminders) { reminder in
+                LaterReminderRow(reminder: reminder, oneHandUI: oneHandUI)
+                    .scaleEffect(x: 1, y: oneHandUI ? -1 : 1, anchor: .center)
+                    .listRowBackground(Color.clear)
+                    .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                        Button {
+                            reminderStore.completeReminder(reminderId: reminder.id)
+                        } label: {
+                            SwipeLabel(
+                                NSLocalizedString("Mark complete", comment: "swipe action"),
+                                systemImage: "checkmark.circle.fill",
+                                inverted: oneHandUI
+                            )
+                        }
+                        .tint(theme.colors.primary)
+                    }
+            }
+        } header: {
+            Text(NSLocalizedString("Later", comment: "chat list section"))
+                .font(.subheadline.weight(.semibold))
+                .foregroundColor(theme.colors.secondary)
+                .scaleEffect(x: 1, y: oneHandUI ? -1 : 1, anchor: .center)
+                .textCase(nil)
+        }
+    }
+}
+
+private struct LaterReminderRow: View {
+    @EnvironmentObject var theme: AppTheme
+    let reminder: MessageReminder
+    let oneHandUI: Bool
+
+    var body: some View {
+        Button {
+            ChatModel.shared.openAroundItemId = reminder.itemId
+            ItemsModel.shared.loadOpenChatNoWait(reminder.chatId, reminder.itemId)
+        } label: {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: "bell.fill")
+                    .foregroundColor(reminder.isOverdue ? .orange : theme.colors.secondary)
+                    .frame(width: 22)
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text(reminder.chatDisplayName.isEmpty ? reminder.chatId : reminder.chatDisplayName)
+                            .font(.headline)
+                            .foregroundColor(theme.colors.onBackground)
+                            .lineLimit(1)
+                        Spacer(minLength: 8)
+                        Text(reminderDueLabel(reminder))
+                            .font(.caption)
+                            .foregroundColor(reminder.isOverdue ? .orange : theme.colors.secondary)
+                    }
+                    if !reminder.messagePreview.isEmpty {
+                        Text(reminder.messagePreview)
+                            .font(.subheadline)
+                            .foregroundColor(theme.colors.secondary)
+                            .lineLimit(2)
+                    }
+                }
+            }
+            .padding(.vertical, 6)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func reminderDueLabel(_ reminder: MessageReminder) -> String {
+        if reminder.isOverdue {
+            return NSLocalizedString("Overdue", comment: "message reminder status")
+        }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: reminder.dueAt, relativeTo: .now)
+    }
+}

--- a/apps/ios/SimpleX.xcodeproj/project.pbxproj
+++ b/apps/ios/SimpleX.xcodeproj/project.pbxproj
@@ -221,6 +221,9 @@
 		8CC317462D4FEBA800292A20 /* ScrollViewCells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC317452D4FEBA800292A20 /* ScrollViewCells.swift */; };
 		8CC4ED902BD7B8530078AEE8 /* CallAudioDeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC4ED8F2BD7B8530078AEE8 /* CallAudioDeviceManager.swift */; };
 		8CC956EE2BC0041000412A11 /* NetworkObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC956ED2BC0041000412A11 /* NetworkObserver.swift */; };
+		E5713A012F71350000713501 /* MessageReminder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5713A002F71350000713500 /* MessageReminder.swift */; };
+		E5713A032F71350000713503 /* ReminderStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5713A022F71350000713502 /* ReminderStore.swift */; };
+		E5713A052F71350000713505 /* LaterRemindersSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5713A042F71350000713504 /* LaterRemindersSection.swift */; };
 		8CE848A32C5A0FA000D5C7C8 /* SelectableChatItemToolbars.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE848A22C5A0FA000D5C7C8 /* SelectableChatItemToolbars.swift */; };
 		B70A39732D24090D00E80A5F /* TagListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70A39722D24090D00E80A5F /* TagListView.swift */; };
 		B70CE9E62D4BE5930080F36D /* GroupMentions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70CE9E52D4BE5930080F36D /* GroupMentions.swift */; };
@@ -599,6 +602,9 @@
 		8CC317452D4FEBA800292A20 /* ScrollViewCells.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScrollViewCells.swift; sourceTree = "<group>"; };
 		8CC4ED8F2BD7B8530078AEE8 /* CallAudioDeviceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallAudioDeviceManager.swift; sourceTree = "<group>"; };
 		8CC956ED2BC0041000412A11 /* NetworkObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkObserver.swift; sourceTree = "<group>"; };
+		E5713A002F71350000713500 /* MessageReminder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReminder.swift; sourceTree = "<group>"; };
+		E5713A022F71350000713502 /* ReminderStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderStore.swift; sourceTree = "<group>"; };
+		E5713A042F71350000713504 /* LaterRemindersSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaterRemindersSection.swift; sourceTree = "<group>"; };
 		8CE848A22C5A0FA000D5C7C8 /* SelectableChatItemToolbars.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableChatItemToolbars.swift; sourceTree = "<group>"; };
 		B70A39722D24090D00E80A5F /* TagListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagListView.swift; sourceTree = "<group>"; };
 		B70CE9E52D4BE5930080F36D /* GroupMentions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupMentions.swift; sourceTree = "<group>"; };
@@ -843,6 +849,8 @@
 			children = (
 				E5DDBE6D2DC4106200A0EFF0 /* AppAPITypes.swift */,
 				5C764E88279CBCB3000C6508 /* ChatModel.swift */,
+				E5713A002F71350000713500 /* MessageReminder.swift */,
+				E5713A022F71350000713502 /* ReminderStore.swift */,
 				5C2E260627A2941F00F70299 /* SimpleXAPI.swift */,
 				5C35CFC727B2782E00FB6C6D /* BGManager.swift */,
 				5C35CFCA27B2E91D00FB6C6D /* NtfManager.swift */,
@@ -1026,6 +1034,7 @@
 			isa = PBXGroup;
 			children = (
 				5C2E260A27A30CFA00F70299 /* ChatListView.swift */,
+				E5713A042F71350000713504 /* LaterRemindersSection.swift */,
 				5C5346A727B59A6A004DF848 /* ChatHelp.swift */,
 				5CB9250C27A9432000ACCCDD /* ChatListNavLink.swift */,
 				5C063D2627A4564100AEC577 /* ChatPreviewView.swift */,
@@ -1613,6 +1622,7 @@
 				5C2E260F27A30FDC00F70299 /* ChatView.swift in Sources */,
 				CEFB2EDF2CA1BCC7004B1ECE /* SheetRepresentable.swift in Sources */,
 				5C2E260B27A30CFA00F70299 /* ChatListView.swift in Sources */,
+				E5713A052F71350000713505 /* LaterRemindersSection.swift in Sources */,
 				6442E0BA287F169300CEC0F9 /* AddGroupView.swift in Sources */,
 				5CF937232B2503D000E1D781 /* NSESubscriber.swift in Sources */,
 				6419EC582AB97507004A607A /* CIMemberCreatedContactView.swift in Sources */,
@@ -1654,6 +1664,8 @@
 				8C81482C2BD91CD4002CBEC3 /* AudioDevicePicker.swift in Sources */,
 				5CCB939C297EFCB100399E78 /* NavStackCompat.swift in Sources */,
 				5C764E89279CBCB3000C6508 /* ChatModel.swift in Sources */,
+				E5713A012F71350000713501 /* MessageReminder.swift in Sources */,
+				E5713A032F71350000713503 /* ReminderStore.swift in Sources */,
 				5C971E1D27AEBEF600C8A3CE /* ChatInfoView.swift in Sources */,
 				5CBD285C29575B8E00EC2CF4 /* WhatsNewView.swift in Sources */,
 				8CB3476E2CF5F58B006787A5 /* ConditionsWebView.swift in Sources */,

--- a/apps/ios/SimpleXChat/Notifications.swift
+++ b/apps/ios/SimpleXChat/Notifications.swift
@@ -18,8 +18,15 @@ public let ntfCategoryCallInvitation = "NTF_CAT_CALL_INVITATION"
 public let ntfCategoryConnectionEvent = "NTF_CAT_CONNECTION_EVENT"
 public let ntfCategoryManyEvents = "NTF_CAT_MANY_EVENTS"
 public let ntfCategoryCheckMessage = "NTF_CAT_CHECK_MESSAGE"
+public let ntfCategoryMessageReminder = "NTF_CAT_MESSAGE_REMINDER"
+
+public let ntfActionCompleteMessageReminder = "NTF_ACT_COMPLETE_MESSAGE_REMINDER"
 
 public let appNotificationId = "chat.simplex.app.notification"
+
+public func messageReminderNotificationId(_ reminderId: String) -> String {
+    "chat.simplex.app.messageReminder.\(reminderId)"
+}
 
 let contactHidden = NSLocalizedString("Contact hidden:", comment: "notification")
 

--- a/apps/ios/en.lproj/Localizable.strings
+++ b/apps/ios/en.lproj/Localizable.strings
@@ -24,3 +24,15 @@
 
 /* No comment provided by engineer. */
 "No group!" = "Group not found!";
+
+/* Message reminders (issue #7135) */
+"Remind me" = "Remind me";
+"Later" = "Later";
+"In 1 hour" = "In 1 hour";
+"In 3 hours" = "In 3 hours";
+"Tomorrow" = "Tomorrow";
+"Next week" = "Next week";
+"Overdue" = "Overdue";
+"Mark complete" = "Mark complete";
+"Message reminder" = "Message reminder";
+"You asked to be reminded about a message" = "You asked to be reminded about a message";

--- a/apps/multiplatform/android/src/main/AndroidManifest.xml
+++ b/apps/multiplatform/android/src/main/AndroidManifest.xml
@@ -168,6 +168,11 @@
         android:enabled="true"
         android:exported="false" />
 
+    <receiver
+        android:name=".model.ReminderNotificationReceiver"
+        android:enabled="true"
+        android:exported="false" />
+
     <!-- SimplexService foreground service -->
     <service
         android:name=".SimplexService"

--- a/apps/multiplatform/android/src/main/java/chat/simplex/app/MainActivity.kt
+++ b/apps/multiplatform/android/src/main/java/chat/simplex/app/MainActivity.kt
@@ -137,9 +137,10 @@ fun processNotificationIntent(intent: Intent?) {
   when (intent?.action) {
     NtfManager.OpenChatAction -> {
       val chatId = intent.getStringExtra("chatId")
+      val itemId = intent.getLongExtra(NtfManager.ItemIdKey, -1L).let { if (it == -1L) null else it }
       Log.d(TAG, "processNotificationIntent: OpenChatAction $chatId")
       if (chatId != null) {
-        ntfManager.openChatAction(userId, chatId)
+        ntfManager.openChatAction(userId, chatId, itemId)
       }
     }
     NtfManager.ShowChatsAction -> {

--- a/apps/multiplatform/android/src/main/java/chat/simplex/app/SimplexApp.kt
+++ b/apps/multiplatform/android/src/main/java/chat/simplex/app/SimplexApp.kt
@@ -192,7 +192,7 @@ class SimplexApp: Application(), LifecycleEventObserver {
       override fun hasNotificationsForChat(chatId: String): Boolean = NtfManager.hasNotificationsForChat(chatId)
       override fun cancelNotificationsForChat(chatId: String) = NtfManager.cancelNotificationsForChat(chatId)
       override fun cancelNotificationsForUser(userId: Long) = NtfManager.cancelNotificationsForUser(userId)
-      override fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String?, actions: List<Pair<NotificationAction, () -> Unit>>) = NtfManager.displayNotification(user, chatId, displayName, msgText, image, actions.map { it.first })
+      override fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String?, actions: List<Pair<NotificationAction, () -> Unit>>, reminderId: String?, itemId: Long?) = NtfManager.displayNotification(user, chatId, displayName, msgText, image, actions.map { it.first }, reminderId, itemId)
       override fun androidCreateNtfChannelsMaybeShowAlert() = NtfManager.createNtfChannelsMaybeShowAlert()
       override fun cancelCallNotification() = NtfManager.cancelCallNotification()
       override fun cancelAllNotifications() = NtfManager.cancelAllNotifications()

--- a/apps/multiplatform/android/src/main/java/chat/simplex/app/model/MessageReminderScheduler.android.kt
+++ b/apps/multiplatform/android/src/main/java/chat/simplex/app/model/MessageReminderScheduler.android.kt
@@ -1,0 +1,73 @@
+package chat.simplex.app.model
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import chat.simplex.app.SimplexApp
+import chat.simplex.common.model.MessageReminder
+import chat.simplex.common.platform.MessageReminderScheduler
+import chat.simplex.common.platform.ntfManager
+import kotlinx.datetime.Clock
+
+actual object MessageReminderScheduler {
+  const val ReminderAlarmAction: String = "chat.simplex.app.MESSAGE_REMINDER_ALARM"
+
+  private val context: Context
+    get() = SimplexApp.context
+
+  private val alarmManager: AlarmManager
+    get() = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+
+  actual fun schedule(reminder: MessageReminder) {
+    cancel(reminder.id)
+    val triggerAt = reminder.dueAt.toEpochMilliseconds()
+    val now = Clock.System.now().toEpochMilliseconds()
+    if (triggerAt <= now) {
+      ntfManager.notifyMessageReminder(reminder)
+      return
+    }
+    val pendingIntent = reminderPendingIntent(reminder)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt, pendingIntent)
+    } else {
+      @Suppress("DEPRECATION")
+      alarmManager.setExact(AlarmManager.RTC_WAKEUP, triggerAt, pendingIntent)
+    }
+  }
+
+  actual fun cancel(reminderId: String) {
+    alarmManager.cancel(reminderPendingIntent(reminderId))
+  }
+
+  actual fun rescheduleAll(reminders: List<MessageReminder>) {
+    reminders.forEach { schedule(it) }
+  }
+
+  actual fun cancelNotification(reminderId: String) {
+    NtfManager.cancelReminderNotification(reminderId)
+  }
+
+  private fun reminderPendingIntent(reminder: MessageReminder): PendingIntent =
+    reminderPendingIntent(reminder.id, reminder.userId, reminder.chatId, reminder.itemId)
+
+  private fun reminderPendingIntent(reminderId: String): PendingIntent {
+    val intent = Intent(context, ReminderNotificationReceiver::class.java)
+      .setAction(ReminderAlarmAction)
+      .putExtra(NtfManager.ReminderIdKey, reminderId)
+    val flags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+    return PendingIntent.getBroadcast(context, reminderId.hashCode(), intent, flags)
+  }
+
+  private fun reminderPendingIntent(reminderId: String, userId: Long, chatId: String, itemId: Long): PendingIntent {
+    val intent = Intent(context, ReminderNotificationReceiver::class.java)
+      .setAction(ReminderAlarmAction)
+      .putExtra(NtfManager.ReminderIdKey, reminderId)
+      .putExtra(NtfManager.UserIdKey, userId)
+      .putExtra(NtfManager.ChatIdKey, chatId)
+      .putExtra(NtfManager.ItemIdKey, itemId)
+    val flags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+    return PendingIntent.getBroadcast(context, reminderId.hashCode(), intent, flags)
+  }
+}

--- a/apps/multiplatform/android/src/main/java/chat/simplex/app/model/NtfManager.android.kt
+++ b/apps/multiplatform/android/src/main/java/chat/simplex/app/model/NtfManager.android.kt
@@ -36,8 +36,10 @@ object NtfManager {
   const val RejectCallAction: String = "chat.simplex.app.REJECT_CALL"
   const val EndCallAction: String = "chat.simplex.app.END_CALL"
   const val CallNotificationId: Int = -1
-  private const val UserIdKey: String = "userId"
-  private const val ChatIdKey: String = "chatId"
+  const val UserIdKey: String = "userId"
+  const val ChatIdKey: String = "chatId"
+  const val ReminderIdKey: String = "reminderId"
+  const val ItemIdKey: String = "itemId"
   private val appPreferences: AppPreferences = ChatController.appPrefs
   private val context: Context
     get() = SimplexApp.context
@@ -99,7 +101,7 @@ object NtfManager {
     }
   }
 
-  fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String? = null, actions: List<NotificationAction> = emptyList()) {
+  fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String? = null, actions: List<NotificationAction> = emptyList(), reminderId: String? = null, itemId: Long? = null) {
     if (!user.showNotifications) return
     Log.d(TAG, "notifyMessageReceived $chatId")
     val now = Clock.System.now().toEpochMilliseconds()
@@ -124,7 +126,7 @@ object NtfManager {
       .setColor(0x88FFFF)
       .setAutoCancel(true)
       .setVibrate(if (actions.isEmpty()) null else longArrayOf(0, 250, 250, 250))
-      .setContentIntent(chatPendingIntent(OpenChatAction, user.userId, chatId))
+      .setContentIntent(chatPendingIntent(OpenChatAction, user.userId, chatId, itemId = itemId))
       .setSilent(if (actions.isEmpty()) recentNotification else false)
 
     for (action in actions) {
@@ -133,9 +135,13 @@ object NtfManager {
       actionIntent.action = action.name
       actionIntent.putExtra(UserIdKey, user.userId)
       actionIntent.putExtra(ChatIdKey, chatId)
-      val actionPendingIntent: PendingIntent = PendingIntent.getBroadcast(SimplexApp.context, 0, actionIntent, flags)
+      if (reminderId != null) actionIntent.putExtra(ReminderIdKey, reminderId)
+      if (itemId != null) actionIntent.putExtra(ItemIdKey, itemId)
+      val requestCode = (reminderId ?: chatId).hashCode()
+      val actionPendingIntent: PendingIntent = PendingIntent.getBroadcast(SimplexApp.context, requestCode, actionIntent, flags)
       val actionButton = when (action) {
         NotificationAction.ACCEPT_CONTACT_REQUEST -> generalGetString(MR.strings.accept)
+        NotificationAction.COMPLETE_MESSAGE_REMINDER -> generalGetString(MR.strings.mark_reminder_complete)
       }
       builder.addAction(0, actionButton, actionPendingIntent)
     }
@@ -149,10 +155,12 @@ object NtfManager {
       .build()
 
     with(NotificationManagerCompat.from(context)) {
-      // using cInfo.id only shows one notification per chat and updates it when the message arrives
       if (ActivityCompat.checkSelfPermission(SimplexApp.context, android.Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) {
-        notify(chatId.hashCode(), builder.build())
-        notify(0, summary)
+        val ntfId = if (reminderId != null) reminderNotificationId(reminderId) else chatId.hashCode()
+        notify(ntfId, builder.build())
+        if (reminderId == null) {
+          notify(0, summary)
+        }
       }
     }
   }
@@ -266,9 +274,15 @@ object NtfManager {
     manager.cancelAll()
   }
 
+  fun reminderNotificationId(reminderId: String): Int = ("reminder:" + reminderId).hashCode()
+
+  fun cancelReminderNotification(reminderId: String) {
+    manager.cancel(reminderNotificationId(reminderId))
+  }
+
   fun hasNotificationsForChat(chatId: String): Boolean = manager.activeNotifications.any { it.id == chatId.hashCode() }
 
-  private fun chatPendingIntent(intentAction: String, userId: Long?, chatId: String? = null, broadcast: Boolean = false): PendingIntent {
+  private fun chatPendingIntent(intentAction: String, userId: Long?, chatId: String? = null, broadcast: Boolean = false, itemId: Long? = null): PendingIntent {
     Log.d(TAG, "chatPendingIntent for $intentAction")
     val uniqueInt = (System.currentTimeMillis() and 0xfffffff).toInt()
     var intent = Intent(context, if (!broadcast) MainActivity::class.java else NtfActionReceiver::class.java)
@@ -276,6 +290,7 @@ object NtfManager {
       .setAction(intentAction)
       .putExtra(UserIdKey, userId)
     if (chatId != null) intent = intent.putExtra(ChatIdKey, chatId)
+    if (itemId != null) intent = intent.putExtra(ItemIdKey, itemId)
     return if (!broadcast) {
       TaskStackBuilder.create(context).run {
         addNextIntentWithParentStack(intent)
@@ -311,11 +326,19 @@ object NtfManager {
   class NtfActionReceiver: BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
       val userId = getUserIdFromIntent(intent)
-      val chatId = intent?.getStringExtra(ChatIdKey) ?: return
+      val chatId = intent?.getStringExtra(ChatIdKey)
       val m = SimplexApp.context.chatModel
       when (intent.action) {
-        NotificationAction.ACCEPT_CONTACT_REQUEST.name -> ntfManager.acceptContactRequestAction(userId, incognito = false, chatId)
+        NotificationAction.COMPLETE_MESSAGE_REMINDER.name -> {
+          val reminderId = intent?.getStringExtra(ReminderIdKey) ?: return
+          ntfManager.completeReminderAction(reminderId)
+        }
+        NotificationAction.ACCEPT_CONTACT_REQUEST.name -> {
+          if (chatId == null) return
+          ntfManager.acceptContactRequestAction(userId, incognito = false, chatId)
+        }
         RejectCallAction -> {
+          if (chatId == null) return
           val invitation = m.callInvitations[chatId]
           if (invitation != null) {
             m.callManager.endCall(invitation = invitation)

--- a/apps/multiplatform/android/src/main/java/chat/simplex/app/model/ReminderNotificationReceiver.kt
+++ b/apps/multiplatform/android/src/main/java/chat/simplex/app/model/ReminderNotificationReceiver.kt
@@ -1,0 +1,19 @@
+package chat.simplex.app.model
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import chat.simplex.app.SimplexApp
+import chat.simplex.common.platform.ntfManager
+
+class ReminderNotificationReceiver : BroadcastReceiver() {
+  override fun onReceive(context: Context?, intent: Intent?) {
+    if (intent?.action != MessageReminderScheduler.ReminderAlarmAction) return
+    val reminderId = intent.getStringExtra(NtfManager.ReminderIdKey) ?: return
+    val repo = SimplexApp.context.chatModel.reminderRepository
+    val reminder = repo.reminderById(reminderId)
+    if (reminder != null && !reminder.isComplete) {
+      ntfManager.notifyMessageReminder(reminder)
+    }
+  }
+}

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
@@ -109,6 +109,7 @@ object ChannelRelaysModel {
 @Stable
 object ChatModel {
   val controller: ChatController = ChatController
+  val reminderRepository = MessageReminderRepository()
   val setDeliveryReceipts = mutableStateOf(false)
   val currentUser = mutableStateOf<User?>(null)
   val users = mutableStateListOf<UserInfo>()

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/MessageReminder.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/MessageReminder.kt
@@ -45,4 +45,14 @@ fun ReminderPreset.dueAt(now: Instant = Clock.System.now(), timeZone: TimeZone =
     }
   }
 
+
+
+fun canSetMessageReminder(cInfo: ChatInfo, cItem: ChatItem, live: Boolean): Boolean {
+  if (!cInfo.sendMsgEnabled) return false
+  if (cItem.meta.itemDeleted != null || cItem.isReport || cItem.localNote || cItem.isLiveDummy || live || cItem.meta.isLive) return false
+  if (cItem.content.msgContent == null && cItem.text(cInfo.isChannel).isEmpty()) return false
+  if (cItem.chatDir is CIDirection.ChannelRcv) return false
+  return cItem.id >= 0
+}
+
 fun newMessageReminderId(): String = UUID.randomUUID().toString()

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/MessageReminder.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/MessageReminder.kt
@@ -3,6 +3,7 @@ package chat.simplex.common.model
 import kotlinx.datetime.*
 import kotlinx.serialization.Serializable
 import java.util.UUID
+import kotlin.time.Duration.Companion.hours
 
 /** Client-local message reminder (issue #7135). */
 @Serializable

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/MessageReminder.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/MessageReminder.kt
@@ -1,0 +1,48 @@
+package chat.simplex.common.model
+
+import kotlinx.datetime.*
+import kotlinx.serialization.Serializable
+import java.util.UUID
+
+/** Client-local message reminder (issue #7135). */
+@Serializable
+data class MessageReminder(
+  val id: String,
+  val userId: Long,
+  val chatId: ChatId,
+  val itemId: Long,
+  val dueAt: Instant,
+  val createdAt: Instant,
+  val completedAt: Instant? = null,
+  val messagePreview: String = "",
+  val chatDisplayName: String = "",
+) {
+  val isComplete: Boolean get() = completedAt != null
+  val isOverdue: Boolean get() = !isComplete && dueAt < Clock.System.now()
+}
+
+enum class ReminderPreset {
+  In1Hour,
+  In3Hours,
+  Tomorrow,
+  NextWeek,
+}
+
+fun ReminderPreset.dueAt(now: Instant = Clock.System.now(), timeZone: TimeZone = TimeZone.currentSystemDefault()): Instant =
+  when (this) {
+    ReminderPreset.In1Hour -> now + 1.hours
+    ReminderPreset.In3Hours -> now + 3.hours
+    ReminderPreset.Tomorrow -> {
+      val today = now.toLocalDateTime(timeZone).date
+      val tomorrowStart = today.plus(1, DateTimeUnit.DAY).atTime(9, 0)
+      tomorrowStart.toInstant(timeZone)
+    }
+    ReminderPreset.NextWeek -> {
+      val today = now.toLocalDateTime(timeZone).date
+      val daysUntilMonday = (8 - today.dayOfWeek.isoDayNumber) % 7
+      val addDays = if (daysUntilMonday == 0) 7 else daysUntilMonday
+      today.plus(addDays, DateTimeUnit.DAY).atTime(9, 0).toInstant(timeZone)
+    }
+  }
+
+fun newMessageReminderId(): String = UUID.randomUUID().toString()

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/MessageReminderRepository.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/MessageReminderRepository.kt
@@ -1,0 +1,78 @@
+package chat.simplex.common.model
+
+import chat.simplex.common.platform.MessageReminderScheduler
+import chat.simplex.common.platform.chatController
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.datetime.Clock
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+
+class MessageReminderRepository {
+  private val json = Json { ignoreUnknownKeys = true }
+  private val _reminders = MutableStateFlow<List<MessageReminder>>(emptyList())
+  val reminders: StateFlow<List<MessageReminder>> = _reminders.asStateFlow()
+
+  val activeLaterReminders: List<MessageReminder>
+    get() = _reminders.value.filter { !it.isComplete }.sortedBy { it.dueAt }
+
+  fun load() {
+    val raw = chatController.appPrefs.messageReminders.get() ?: "[]"
+    _reminders.value = runCatching {
+      json.decodeFromString(ListSerializer(MessageReminder.serializer()), raw)
+    }.getOrElse { emptyList() }
+    MessageReminderScheduler.rescheduleAll(_reminders.value.filter { !it.isComplete })
+  }
+
+  private fun persist() {
+    val encoded = json.encodeToString(ListSerializer(MessageReminder.serializer()), _reminders.value)
+    chatController.appPrefs.messageReminders.set(encoded)
+  }
+
+  fun createReminder(
+    chatId: ChatId,
+    itemId: Long,
+    preset: ReminderPreset,
+    messagePreview: String,
+    chatDisplayName: String,
+    timeZone: kotlinx.datetime.TimeZone = kotlinx.datetime.TimeZone.currentSystemDefault(),
+  ): MessageReminder? {
+    val userId = ChatModel.currentUser.value?.userId ?: return null
+    val now = Clock.System.now()
+    val reminder = MessageReminder(
+      id = newMessageReminderId(),
+      userId = userId,
+      chatId = chatId,
+      itemId = itemId,
+      dueAt = preset.dueAt(now, timeZone),
+      createdAt = now,
+      messagePreview = messagePreview.take(200),
+      chatDisplayName = chatDisplayName,
+    )
+    _reminders.update { it + reminder }
+    persist()
+    MessageReminderScheduler.schedule(reminder)
+    return reminder
+  }
+
+  fun completeReminder(reminderId: String) {
+    val now = Clock.System.now()
+    _reminders.update { list ->
+      list.map { if (it.id == reminderId && !it.isComplete) it.copy(completedAt = now) else it }
+    }
+    persist()
+    MessageReminderScheduler.cancel(reminderId)
+    MessageReminderScheduler.cancelNotification(reminderId)
+  }
+
+  fun deleteReminder(reminderId: String) {
+    _reminders.update { list -> list.filter { it.id != reminderId } }
+    persist()
+    MessageReminderScheduler.cancel(reminderId)
+    MessageReminderScheduler.cancelNotification(reminderId)
+  }
+
+  fun reminderById(id: String): MessageReminder? = _reminders.value.firstOrNull { it.id == id }
+}

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
@@ -264,6 +264,7 @@ class AppPreferences {
 
   val oneHandUI = mkBoolPreference(SHARED_PREFS_ONE_HAND_UI, true)
   val chatBottomBar = mkBoolPreference(SHARED_PREFS_CHAT_BOTTOM_BAR, true)
+  val messageReminders = mkStrPreference(SHARED_PREFS_MESSAGE_REMINDERS, "[]")
 
   val hintPreferences: List<HintPref> = listOf(
     hintPref(laNoticeShown, false),
@@ -471,6 +472,7 @@ class AppPreferences {
     private const val SHARED_PREFS_CONFIRM_DB_UPGRADES = "ConfirmDBUpgrades"
     private const val SHARED_PREFS_ONE_HAND_UI = "OneHandUI"
     private const val SHARED_PREFS_CHAT_BOTTOM_BAR = "ChatBottomBar"
+    private const val SHARED_PREFS_MESSAGE_REMINDERS = "MessageReminders"
     private const val SHARED_PREFS_SELF_DESTRUCT = "LocalAuthenticationSelfDestruct"
     private const val SHARED_PREFS_SELF_DESTRUCT_DISPLAY_NAME = "LocalAuthenticationSelfDestructDisplayName"
     private const val SHARED_PREFS_PQ_EXPERIMENTAL_ENABLED = "PQExperimentalEnabled" // no longer used
@@ -589,6 +591,7 @@ object ChatController {
       }
       apiStartChat()
       appPrefs.chatStopped.set(false)
+      chatModel.reminderRepository.load()
     } catch (e: Throwable) {
       Log.e(TAG, "failed starting chat $e")
       throw e

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/platform/MessageReminderScheduler.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/platform/MessageReminderScheduler.kt
@@ -1,0 +1,10 @@
+package chat.simplex.common.platform
+
+import chat.simplex.common.model.MessageReminder
+
+expect object MessageReminderScheduler {
+  fun schedule(reminder: MessageReminder)
+  fun cancel(reminderId: String)
+  fun rescheduleAll(reminders: List<MessageReminder>)
+  fun cancelNotification(reminderId: String)
+}

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/platform/NtfManager.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/platform/NtfManager.kt
@@ -10,7 +10,8 @@ import chat.simplex.res.MR
 import kotlinx.coroutines.delay
 
 enum class NotificationAction {
-  ACCEPT_CONTACT_REQUEST
+  ACCEPT_CONTACT_REQUEST,
+  COMPLETE_MESSAGE_REMINDER,
 }
 
 // Spec: spec/services/notifications.md#ntfManager
@@ -35,6 +36,23 @@ abstract class NtfManager {
     )
   )
 
+  fun notifyMessageReminder(reminder: MessageReminder) {
+    val user = chatModel.getUser(reminder.userId) ?: ReminderNotificationUser(reminder.userId)
+    val title = reminder.chatDisplayName.ifEmpty { generalGetString(MR.strings.message_reminder_notification_title) }
+    val body = reminder.messagePreview.ifEmpty { generalGetString(MR.strings.message_reminder_notification_body) }
+    displayNotification(
+      user = user,
+      chatId = reminder.chatId,
+      displayName = title,
+      msgText = body,
+      actions = listOf(
+        NotificationAction.COMPLETE_MESSAGE_REMINDER to { completeReminderAction(reminder.id) }
+      ),
+      reminderId = reminder.id,
+      itemId = reminder.itemId,
+    )
+  }
+
   fun notifyMessageReceived(rhId: Long?, user: UserLike, cInfo: ChatInfo, cItem: ChatItem) {
     if (
       cItem.showNotification &&
@@ -56,7 +74,7 @@ abstract class NtfManager {
     cancelNotificationsForChat(chatId)
   }
 
-  fun openChatAction(userId: Long?, chatId: ChatId) {
+  fun openChatAction(userId: Long?, chatId: ChatId, itemId: Long? = null) {
     withLongRunningApi {
       awaitChatStartedIfNeeded(chatModel)
       if (userId != null && userId != chatModel.currentUser.value?.userId && chatModel.currentUser.value != null) {
@@ -65,10 +83,17 @@ abstract class NtfManager {
           chatModel.controller.changeActiveUser(null, userId, null)
         }
       }
+      if (itemId != null) {
+        chatModel.openAroundItemId.value = itemId
+      }
       val cInfo = chatModel.getChat(chatId)?.chatInfo
       chatModel.clearOverlays.value = true
       if (cInfo != null && (cInfo is ChatInfo.Direct || cInfo is ChatInfo.Group)) openChat(secondaryChatsCtx = null, rhId = null, cInfo)
     }
+  }
+
+  fun completeReminderAction(reminderId: String) {
+    chatModel.reminderRepository.completeReminder(reminderId)
   }
 
   fun showChatsAction(userId: Long?) {
@@ -99,7 +124,16 @@ abstract class NtfManager {
   abstract fun hasNotificationsForChat(chatId: String): Boolean
   abstract fun cancelNotificationsForChat(chatId: String)
   abstract fun cancelNotificationsForUser(userId: Long)
-  abstract fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String? = null, actions: List<Pair<NotificationAction, () -> Unit>> = emptyList())
+  abstract fun displayNotification(
+    user: UserLike,
+    chatId: String,
+    displayName: String,
+    msgText: String,
+    image: String? = null,
+    actions: List<Pair<NotificationAction, () -> Unit>> = emptyList(),
+    reminderId: String? = null,
+    itemId: Long? = null,
+  )
   abstract fun cancelCallNotification()
   abstract fun cancelAllNotifications()
   abstract fun showMessage(title: String, text: String)
@@ -118,6 +152,12 @@ abstract class NtfManager {
       }
     }
   }
+
+  private data class ReminderNotificationUser(
+    override val userId: Long,
+    override val activeUser: Boolean = false,
+    override val showNtfs: Boolean = true,
+  ) : UserLike
 
   private fun hideSecrets(cItem: ChatItem, isChannel: Boolean = false): String {
     val md = cItem.formattedText

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/ChatItemView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/ChatItemView.kt
@@ -474,6 +474,7 @@ fun ChatItemView(
                         showMenu.value = false
                       })
                     }
+                    RemindMessageItemActions(showMenu, cInfo, cItem, live)
                     ItemInfoAction(cInfo, cItem, showItemDetails, showMenu)
                     if (revealed.value) {
                       HideItemAction(revealed, showMenu, reveal)

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/ReminderItemAction.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/ReminderItemAction.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.unit.sp
 import chat.simplex.common.model.ChatInfo
 import chat.simplex.common.model.ChatItem
 import chat.simplex.common.model.ReminderPreset
+import chat.simplex.common.model.canSetMessageReminder
 import chat.simplex.common.platform.chatModel
 import chat.simplex.common.ui.theme.DEFAULT_PADDING
 import chat.simplex.common.ui.theme.DEFAULT_PADDING_HALF
@@ -30,11 +31,7 @@ fun RemindMessageItemActions(
   live: Boolean,
 ) {
   val showRemindPresets = remember { mutableStateOf(false) }
-  val canRemind =
-    cItem.meta.itemDeleted == null &&
-      !live &&
-      !cItem.isLiveDummy &&
-      cItem.id >= 0
+  val canRemind = canSetMessageReminder(cInfo, cItem, live)
 
   if (canRemind) {
     ItemAction(

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/ReminderItemAction.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/ReminderItemAction.kt
@@ -1,0 +1,99 @@
+package chat.simplex.common.views.chat.item
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import chat.simplex.common.model.ChatInfo
+import chat.simplex.common.model.ChatItem
+import chat.simplex.common.model.ReminderPreset
+import chat.simplex.common.platform.chatModel
+import chat.simplex.common.ui.theme.DEFAULT_PADDING
+import chat.simplex.common.ui.theme.DEFAULT_PADDING_HALF
+import chat.simplex.common.views.helpers.DefaultDropdownMenu
+import chat.simplex.common.views.helpers.withBGApi
+import chat.simplex.res.MR
+import dev.icerock.moko.resources.compose.painterResource
+import dev.icerock.moko.resources.compose.stringResource
+
+@Composable
+fun RemindMessageItemActions(
+  showMenu: MutableState<Boolean>,
+  cInfo: ChatInfo,
+  cItem: ChatItem,
+  live: Boolean,
+) {
+  val showRemindPresets = remember { mutableStateOf(false) }
+  val canRemind =
+    cItem.meta.itemDeleted == null &&
+      !live &&
+      !cItem.isLiveDummy &&
+      cItem.id >= 0
+
+  if (canRemind) {
+    ItemAction(
+      stringResource(MR.strings.remind_me),
+      painterResource(MR.images.ic_timer),
+      onClick = {
+        showRemindPresets.value = true
+        showMenu.value = false
+      }
+    )
+  }
+
+  RemindMessagePresetsMenu(
+    showMenu = showRemindPresets,
+    cInfo = cInfo,
+    cItem = cItem,
+  )
+}
+
+@Composable
+private fun RemindMessagePresetsMenu(
+  showMenu: MutableState<Boolean>,
+  cInfo: ChatInfo,
+  cItem: ChatItem,
+) {
+  DefaultDropdownMenu(showMenu) {
+    Text(
+      stringResource(MR.strings.later_section),
+      Modifier.padding(vertical = DEFAULT_PADDING_HALF, horizontal = DEFAULT_PADDING * 1.5f),
+      fontSize = 16.sp,
+      color = MaterialTheme.colors.secondary
+    )
+    ItemAction(stringResource(MR.strings.remind_in_1_hour)) {
+      createMessageReminder(cInfo, cItem, ReminderPreset.In1Hour)
+      showMenu.value = false
+    }
+    ItemAction(stringResource(MR.strings.remind_in_3_hours)) {
+      createMessageReminder(cInfo, cItem, ReminderPreset.In3Hours)
+      showMenu.value = false
+    }
+    ItemAction(stringResource(MR.strings.remind_tomorrow)) {
+      createMessageReminder(cInfo, cItem, ReminderPreset.Tomorrow)
+      showMenu.value = false
+    }
+    ItemAction(stringResource(MR.strings.remind_next_week)) {
+      createMessageReminder(cInfo, cItem, ReminderPreset.NextWeek)
+      showMenu.value = false
+    }
+  }
+}
+
+private fun createMessageReminder(cInfo: ChatInfo, cItem: ChatItem, preset: ReminderPreset) {
+  withBGApi {
+    chatModel.reminderRepository.createReminder(
+      cInfo.id,
+      cItem.id,
+      preset,
+      cItem.text(cInfo.isChannel),
+      cInfo.displayName,
+    )
+  }
+}

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.*
 import androidx.compose.ui.draw.clip
@@ -958,6 +959,16 @@ private fun BoxScope.ChatList(searchText: MutableState<TextFieldValue>, listStat
           TagsView(searchText)
           Divider()
         }
+      }
+    }
+    val allReminders by chatModel.reminderRepository.reminders.collectAsState()
+    val laterReminders = remember(allReminders, chatModel.currentUser.value?.userId) {
+      val userId = chatModel.currentUser.value?.userId ?: return@remember emptyList<MessageReminder>()
+      allReminders.filter { !it.isComplete && it.userId == userId }.sortedBy { it.dueAt }
+    }
+    if (laterReminders.isNotEmpty()) {
+      item(key = "later_reminders") {
+        LaterRemindersSection(laterReminders)
       }
     }
     if (!oneHandUICardShown.value) {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
@@ -921,6 +921,12 @@ private fun BoxScope.ChatList(searchText: MutableState<TextFieldValue>, listStat
   val chats = filteredChats(searchShowingSimplexLink, searchChatFilteredBySimplexLink, searchText.value.text, allChats.value.toList(), activeFilter.value)
   val topPaddingToContent = topPaddingToContent(false)
   val blankSpaceSize = if (oneHandUI.value) WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + AppBarHeight * fontSizeSqrtMultiplier else topPaddingToContent
+  val allReminders by chatModel.reminderRepository.reminders.collectAsState()
+  val laterReminders = remember(allReminders, chatModel.currentUser.value?.userId) {
+    val userId = chatModel.currentUser.value?.userId ?: return@remember emptyList<MessageReminder>()
+    allReminders.filter { !it.isComplete && it.userId == userId }.sortedBy { it.dueAt }
+  }
+  val reminderScope = rememberCoroutineScope()
   LazyColumnWithScrollBar(
     if (!oneHandUI.value) Modifier.imePadding() else Modifier,
     listState,
@@ -961,14 +967,41 @@ private fun BoxScope.ChatList(searchText: MutableState<TextFieldValue>, listStat
         }
       }
     }
-    val allReminders by chatModel.reminderRepository.reminders.collectAsState()
-    val laterReminders = remember(allReminders, chatModel.currentUser.value?.userId) {
-      val userId = chatModel.currentUser.value?.userId ?: return@remember emptyList<MessageReminder>()
-      allReminders.filter { !it.isComplete && it.userId == userId }.sortedBy { it.dueAt }
-    }
     if (laterReminders.isNotEmpty()) {
-      item(key = "later_reminders") {
-        LaterRemindersSection(laterReminders)
+      stickyHeader(key = "later_reminders_header") {
+        Column(
+          Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colors.background)
+        ) {
+          LaterSectionHeader()
+        }
+      }
+      items(laterReminders, key = { it.id }) { reminder ->
+        LaterReminderListItem(
+          reminder = reminder,
+          onOpen = {
+            reminderScope.launch {
+              val chat = chatModel.getChat(reminder.chatId)
+              if (chat != null) {
+                chatModel.openAroundItemId.value = reminder.itemId
+                openChat(
+                  secondaryChatsCtx = null,
+                  rhId = chat.remoteHostId,
+                  chat.chatInfo.chatType,
+                  chat.chatInfo.apiId,
+                  openAroundItemId = reminder.itemId,
+                )
+              }
+            }
+          },
+          onComplete = {
+            withBGApi { chatModel.reminderRepository.completeReminder(reminder.id) }
+          },
+        )
+      }
+      item(key = "later_reminders_divider") {
+        Divider(Modifier.padding(horizontal = DEFAULT_PADDING))
       }
     }
     if (!oneHandUICardShown.value) {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/LaterRemindersSection.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/LaterRemindersSection.kt
@@ -1,0 +1,140 @@
+package chat.simplex.common.views.chatlist
+
+import SectionItemViewLongClickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import chat.simplex.common.model.MessageReminder
+import chat.simplex.common.platform.chatModel
+import chat.simplex.common.ui.theme.DEFAULT_PADDING
+import chat.simplex.common.ui.theme.DEFAULT_PADDING_HALF
+import chat.simplex.common.views.chat.item.ItemAction
+import chat.simplex.common.views.helpers.DefaultDropdownMenu
+import chat.simplex.common.views.helpers.withBGApi
+import chat.simplex.res.MR
+import dev.icerock.moko.resources.compose.painterResource
+import dev.icerock.moko.resources.compose.stringResource
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+@Composable
+fun LaterRemindersSection(reminders: List<MessageReminder>) {
+  if (reminders.isEmpty()) return
+  val scope = rememberCoroutineScope()
+  Column(Modifier.fillMaxWidth()) {
+    Text(
+      stringResource(MR.strings.later_section),
+      Modifier.padding(horizontal = DEFAULT_PADDING, vertical = DEFAULT_PADDING_HALF),
+      fontSize = 14.sp,
+      fontWeight = FontWeight.SemiBold,
+      color = MaterialTheme.colors.secondary,
+    )
+    reminders.forEach { reminder ->
+      LaterReminderRow(
+        reminder = reminder,
+        onOpen = {
+          scope.launch {
+            val chat = chatModel.getChat(reminder.chatId)
+            if (chat != null) {
+              chatModel.openAroundItemId.value = reminder.itemId
+              openChat(
+                secondaryChatsCtx = null,
+                rhId = chat.remoteHostId,
+                chat.chatInfo.chatType,
+                chat.chatInfo.apiId,
+                openAroundItemId = reminder.itemId,
+              )
+            }
+          }
+        },
+        onComplete = {
+          withBGApi { chatModel.reminderRepository.completeReminder(reminder.id) }
+        },
+      )
+    }
+    Divider(Modifier.padding(horizontal = DEFAULT_PADDING))
+  }
+}
+
+@Composable
+private fun LaterReminderRow(
+  reminder: MessageReminder,
+  onOpen: () -> Unit,
+  onComplete: () -> Unit,
+) {
+  val showMenu = remember { mutableStateOf(false) }
+  val dueColor = if (reminder.isOverdue) MaterialTheme.colors.error else MaterialTheme.colors.secondary
+  SectionItemViewLongClickable(
+    click = onOpen,
+    longClick = { showMenu.value = true },
+    padding = PaddingValues(horizontal = DEFAULT_PADDING, vertical = 8.dp),
+  ) {
+    Icon(
+      painterResource(MR.images.ic_timer),
+      contentDescription = null,
+      tint = dueColor,
+      modifier = Modifier.size(22.dp).padding(end = 10.dp),
+    )
+    Column(Modifier.weight(1f)) {
+      Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Text(
+          reminder.chatDisplayName.ifEmpty { reminder.chatId },
+          Modifier.weight(1f),
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+          style = MaterialTheme.typography.body1,
+          fontWeight = FontWeight.Medium,
+        )
+        Text(
+          reminderDueLabel(reminder),
+          fontSize = 12.sp,
+          color = dueColor,
+        )
+      }
+      if (reminder.messagePreview.isNotEmpty()) {
+        Text(
+          reminder.messagePreview,
+          maxLines = 2,
+          overflow = TextOverflow.Ellipsis,
+          style = MaterialTheme.typography.body2,
+          color = MaterialTheme.colors.secondary,
+        )
+      }
+    }
+  }
+  DefaultDropdownMenu(showMenu) {
+    ItemAction(stringResource(MR.strings.mark_reminder_complete)) {
+      onComplete()
+      showMenu.value = false
+    }
+  }
+}
+
+@Composable
+private fun reminderDueLabel(reminder: MessageReminder): String {
+  if (reminder.isOverdue) {
+    return stringResource(MR.strings.reminder_overdue)
+  }
+  return formatRelativeDue(reminder.dueAt)
+}
+
+private fun formatRelativeDue(dueAt: Instant): String {
+  val now = Clock.System.now()
+  val diff = dueAt - now
+  return when {
+    diff < 1.minutes -> "now"
+    diff < 1.hours -> "${diff.inWholeMinutes}m"
+    diff < 1.days -> "${diff.inWholeHours}h"
+    else -> "${diff.inWholeDays}d"
+  }
+}

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/LaterRemindersSection.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/LaterRemindersSection.kt
@@ -28,17 +28,31 @@ import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 
 @Composable
+fun LaterSectionHeader() {
+  Text(
+    stringResource(MR.strings.later_section),
+    Modifier.padding(horizontal = DEFAULT_PADDING, vertical = DEFAULT_PADDING_HALF),
+    fontSize = 14.sp,
+    fontWeight = FontWeight.SemiBold,
+    color = MaterialTheme.colors.secondary,
+  )
+}
+
+@Composable
+fun LaterReminderListItem(
+  reminder: MessageReminder,
+  onOpen: () -> Unit,
+  onComplete: () -> Unit,
+) {
+  LaterReminderRow(reminder = reminder, onOpen = onOpen, onComplete = onComplete)
+}
+
+@Composable
 fun LaterRemindersSection(reminders: List<MessageReminder>) {
   if (reminders.isEmpty()) return
   val scope = rememberCoroutineScope()
   Column(Modifier.fillMaxWidth()) {
-    Text(
-      stringResource(MR.strings.later_section),
-      Modifier.padding(horizontal = DEFAULT_PADDING, vertical = DEFAULT_PADDING_HALF),
-      fontSize = 14.sp,
-      fontWeight = FontWeight.SemiBold,
-      color = MaterialTheme.colors.secondary,
-    )
+    LaterSectionHeader()
     reminders.forEach { reminder ->
       LaterReminderRow(
         reminder = reminder,

--- a/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
@@ -1129,6 +1129,19 @@
   <string name="app_check_for_updates_installed_successfully_desc">Please restart the app.</string>
   <string name="app_check_for_updates_canceled">Update download canceled</string>
   <string name="app_check_for_updates_button_remind_later">Remind later</string>
+
+  <!-- Message reminders (issue #7135) -->
+  <string name="remind_me">Remind me</string>
+  <string name="later_section">Later</string>
+  <string name="remind_in_1_hour">In 1 hour</string>
+  <string name="remind_in_3_hours">In 3 hours</string>
+  <string name="remind_tomorrow">Tomorrow</string>
+  <string name="remind_next_week">Next week</string>
+  <string name="reminder_overdue">Overdue</string>
+  <string name="mark_reminder_complete">Mark complete</string>
+  <string name="message_reminder_notification_title">Message reminder</string>
+  <string name="message_reminder_notification_body">You asked to be reminded about a message</string>
+
   <string name="app_check_for_updates_notice_title">Check for updates</string>
   <string name="app_check_for_updates_notice_desc">To be notified about the new releases, turn on periodic check for Stable or Beta versions.</string>
   <string name="app_check_for_updates_notice_disable">Disable</string>

--- a/apps/multiplatform/common/src/commonTest/kotlin/chat/simplex/app/MessageReminderPresetTest.kt
+++ b/apps/multiplatform/common/src/commonTest/kotlin/chat/simplex/app/MessageReminderPresetTest.kt
@@ -1,0 +1,39 @@
+package chat.simplex.app
+
+import chat.simplex.common.model.ReminderPreset
+import chat.simplex.common.model.dueAt
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.hours
+
+class MessageReminderPresetTest {
+  @Test
+  fun in1HourAddsOneHour() {
+    val now = Instant.parse("2026-03-29T12:00:00Z")
+    val due = ReminderPreset.In1Hour.dueAt(now, TimeZone.UTC)
+    assertEquals(now + 1.hours, due)
+  }
+
+  @Test
+  fun in3HoursAddsThreeHours() {
+    val now = Instant.parse("2026-03-29T12:00:00Z")
+    val due = ReminderPreset.In3Hours.dueAt(now, TimeZone.UTC)
+    assertEquals(now + 3.hours, due)
+  }
+
+  @Test
+  fun tomorrowIsNineAmNextCalendarDay() {
+    val now = Instant.parse("2026-03-29T15:30:00Z")
+    val due = ReminderPreset.Tomorrow.dueAt(now, TimeZone.UTC)
+    assertEquals(Instant.parse("2026-03-30T09:00:00Z"), due)
+  }
+
+  @Test
+  fun nextWeekIsNineAmNextMondayUtc() {
+    val now = Instant.parse("2026-03-29T12:00:00Z")
+    val due = ReminderPreset.NextWeek.dueAt(now, TimeZone.UTC)
+    assertEquals(Instant.parse("2026-03-30T09:00:00Z"), due)
+  }
+}

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/model/NtfManager.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/model/NtfManager.desktop.kt
@@ -17,6 +17,7 @@ import javax.imageio.ImageIO
 
 object NtfManager {
   private val prevNtfs = arrayListOf<Pair<Pair<Long, ChatId>, Slice>>()
+  private val prevReminderNtfs = mutableMapOf<String, Slice>()
   private val prevNtfsMutex: Mutex = Mutex()
 
   fun notifyCallInvitation(invitation: RcvCallInvitation): Boolean {
@@ -90,11 +91,29 @@ object NtfManager {
     withBGApi {
       prevNtfsMutex.withLock {
         prevNtfs.clear()
+        prevReminderNtfs.clear()
       }
     }
   }
 
-  fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String?, actions: List<Pair<NotificationAction, () -> Unit>>) {
+  fun cancelReminderNotification(reminderId: String) {
+    withBGApi {
+      prevNtfsMutex.withLock {
+        prevReminderNtfs.remove(reminderId)
+      }
+    }
+  }
+
+  fun displayNotification(
+    user: UserLike,
+    chatId: String,
+    displayName: String,
+    msgText: String,
+    image: String?,
+    actions: List<Pair<NotificationAction, () -> Unit>>,
+    reminderId: String? = null,
+    itemId: Long? = null,
+  ) {
     if (!user.showNotifications) return
     Log.d(TAG, "notifyMessageReceived $chatId")
     val previewMode = appPreferences.notificationPreviewMode.get()
@@ -106,8 +125,16 @@ object NtfManager {
       else -> base64ToBitmap(image)
     }
 
-    displayNotificationViaLib(user.userId, chatId, title, content, prepareIconPath(largeIcon), actions.map { it.first.name to it.second }) {
-      ntfManager.openChatAction(user.userId, chatId)
+    val libActions = actions.map { (action, handler) ->
+      val label = when (action) {
+        NotificationAction.ACCEPT_CONTACT_REQUEST -> generalGetString(MR.strings.accept)
+        NotificationAction.COMPLETE_MESSAGE_REMINDER -> generalGetString(MR.strings.mark_reminder_complete)
+      }
+      label to handler
+    }
+
+    displayNotificationViaLib(user.userId, chatId, title, content, prepareIconPath(largeIcon), libActions, reminderId) {
+      ntfManager.openChatAction(user.userId, chatId, itemId)
     }
   }
 
@@ -118,6 +145,7 @@ object NtfManager {
     text: String,
     iconPath: String?,
     actions: List<Pair<String, () -> Unit>>,
+    reminderId: String? = null,
     defaultAction: (() -> Unit)?
   ) {
     val builder = Toast.builder()
@@ -135,7 +163,12 @@ object NtfManager {
     try {
       withBGApi {
         prevNtfsMutex.withLock {
-          prevNtfs.add(Pair(userId, chatId) to builder.toast())
+          val slice = builder.toast()
+          if (reminderId != null) {
+            prevReminderNtfs[reminderId] = slice
+          } else {
+            prevNtfs.add(Pair(userId, chatId) to slice)
+          }
         }
       }
     } catch (e: Throwable) {

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/AppCommon.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/AppCommon.desktop.kt
@@ -24,7 +24,7 @@ fun initApp() {
     override fun hasNotificationsForChat(chatId: String): Boolean = chat.simplex.common.model.NtfManager.hasNotificationsForChat(chatId)
     override fun cancelNotificationsForChat(chatId: String) = chat.simplex.common.model.NtfManager.cancelNotificationsForChat(chatId)
     override fun cancelNotificationsForUser(userId: Long) = chat.simplex.common.model.NtfManager.cancelNotificationsForUser(userId)
-    override fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String?, actions: List<Pair<NotificationAction, () -> Unit>>) = chat.simplex.common.model.NtfManager.displayNotification(user, chatId, displayName, msgText, image, actions)
+    override fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String?, actions: List<Pair<NotificationAction, () -> Unit>>, reminderId: String?, itemId: Long?) = chat.simplex.common.model.NtfManager.displayNotification(user, chatId, displayName, msgText, image, actions, reminderId, itemId)
     override fun androidCreateNtfChannelsMaybeShowAlert() {}
     override fun cancelCallNotification() {}
     override fun cancelAllNotifications() = chat.simplex.common.model.NtfManager.cancelAllNotifications()

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/MessageReminderScheduler.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/MessageReminderScheduler.desktop.kt
@@ -1,0 +1,42 @@
+package chat.simplex.common.platform
+
+import chat.simplex.common.model.MessageReminder
+import chat.simplex.common.model.NtfManager
+import chat.simplex.common.views.helpers.withBGApi
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+
+actual object MessageReminderScheduler {
+  private val scope = CoroutineScope(Dispatchers.Default)
+  private val jobs = mutableMapOf<String, Job>()
+
+  actual fun schedule(reminder: MessageReminder) {
+    cancel(reminder.id)
+    val delayMs = reminder.dueAt.toEpochMilliseconds() - Clock.System.now().toEpochMilliseconds()
+    if (delayMs <= 0) {
+      withBGApi { ntfManager.notifyMessageReminder(reminder) }
+      return
+    }
+    jobs[reminder.id] = scope.launch {
+      delay(delayMs)
+      withBGApi { ntfManager.notifyMessageReminder(reminder) }
+    }
+  }
+
+  actual fun cancel(reminderId: String) {
+    jobs.remove(reminderId)?.cancel()
+  }
+
+  actual fun rescheduleAll(reminders: List<MessageReminder>) {
+    jobs.keys.toList().forEach { cancel(it) }
+    reminders.forEach { schedule(it) }
+  }
+
+  actual fun cancelNotification(reminderId: String) {
+    NtfManager.cancelReminderNotification(reminderId)
+  }
+}

--- a/apps/multiplatform/spec/client/chat-list.md
+++ b/apps/multiplatform/spec/client/chat-list.md
@@ -39,6 +39,9 @@ ChatListView
 |   |   |-- stickyHeader
 |   |   |   |-- ChatListSearchBar (search input + filter toggle)
 |   |   |   +-- TagsView          (preset + custom tag chips)
+|   |   |-- stickyHeader (when reminders present)
+|   |   |   +-- LaterSectionHeader ("Later")
+|   |   |-- LaterReminderListItem[] (incomplete reminders for current user)
 |   |   |-- ChatListNavLinkView[] (per-chat row items)
 |   |   +-- ChatListFeatureCards  (one-hand UI card, address card)
 |   +-- EmptyState text

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -15,6 +15,14 @@ We do not make code changes to improve code - any change must address a specific
 
 Please discuss the problem you want to solve and your detailed implementation plan with the project team prior to contributing, to avoid wasted time and additional changes. Acceptance of your contribution depends on your willingness and ability to iterate the proposed contribution to achieve the required quality level, coding style, test coverage, and alignment with user requirements as they are understood by the project team.
 
+## Contributor License Agreement (CLA)
+
+Pull requests require every commit author to sign the [Contributor License Agreement](https://github.com/simplex-chat/cla/blob/master/CLA.md). On the pull request, post a comment with exactly:
+
+`I have read the CLA Document and I hereby sign the CLA`
+
+If the **CLA Assistant** check does not update after signing, comment `recheck` on the same pull request. Signatures are stored in the [simplex-chat/cla](https://github.com/simplex-chat/cla) repository; this cannot be satisfied by changes in the application codebase alone.
+
 ## Follow project structure, coding style and approaches
 
 ./contributing/PROJECT.md has information about the structure of this `simplex-chat` repository.


### PR DESCRIPTION
# Message reminders (#7135)

**Branch:** `berserk/8e8629ef-c68e-4ec2-8a50-c9af37bc4104`  
**Commit:** `ee01e6ba67333a1c8a43391bdaf70f6eca0f3fa6` (pushed to origin)

## What changed

Client-local **message reminders** on KMP (Android + Desktop) and iOS:

- Context menu **Remind me** with presets: 1h, 3h, tomorrow, next week (`MessageReminder.kt`, `ReminderItemAction.kt`, iOS `ChatView.swift`).
- **Later** section on chat list for upcoming and overdue reminders; open chat + scroll to message; mark complete (`LaterRemindersSection.kt`, `ChatListView.kt`, iOS list).
- Scheduled local notifications at `dueAt` with deep link; **Mark complete** from notification actions (`NtfManager` + platform schedulers / `ReminderStore.swift`).
- Localized strings (MR + iOS).
- Unit tests for preset due-time math (`MessageReminderPresetTest.kt`).

No Haskell core changes — reminders persist and schedule per device.

## Verification

Gradle `:common:desktopTest` for preset tests was **not run** in the agent container (Android NDK license / SDK). After SDK setup per `apps/multiplatform/README.md`, run:

`./gradlew :common:desktopTest --tests chat.simplex.app.MessageReminderPresetTest --no-daemon`

## Follow-ups

Prune on deleted messages/chats; exact-alarm permissions on Android; desktop reminders while app running only; optional multi-device sync via future core API.

Full notes: `REPORT_7135.md` in repo root on this branch.

## Commit

ee01e6ba67333a1c8a43391bdaf70f6eca0f3fa6

## Branch

berserk/8e8629ef-c68e-4ec2-8a50-c9af37bc4104

Fixes #7135
