### PR TITLE
fix #7067 NPE in UserPicker when currentUser is null

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/UserPicker.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/UserPicker.kt
@@ -220,7 +220,7 @@ fun UserPicker(
       UserPickerOptionRow(
         painterResource(MR.images.ic_qr_code),
         if (chatModel.userAddress.value != null) generalGetString(MR.strings.your_simplex_contact_address) else generalGetString(MR.strings.create_simplex_address),
-        showCustomModal { it, close -> UserAddressView(it, shareViaProfile = it.currentUser.value!!.addressShared, close = close) }, disabled = stopped
+        showCustomModal { it, close -> UserAddressView(it, shareViaProfile = it.currentUser.value?.addressShared ?: false, close = close) }, disabled = stopped
       )
       UserPickerOptionRow(
         painterResource(MR.images.ic_toggle_on),


### PR DESCRIPTION
### Fixes #7067

**Root cause:** `it.currentUser.value!!.addressShared` force-unwraps `currentUser` which is null on first launch on desktop (no profile created yet).

**Fix:** Replace `!!` with safe `?.` + `?: false`. When `currentUser` is null, `shareViaProfile` defaults to `false`.

`UserAddressView` already handles nullable `User?` correctly — the only issue was the force-unwrap in the calling code.

**Changed file:** `apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/UserPicker.kt:223`