### PR TITLE
core: fix CLI divide by zero in terminals reporting zero window size

### DIFF
--- a/src/Simplex/Chat/Terminal/Output.hs
+++ b/src/Simplex/Chat/Terminal/Output.hs
@@ -99,7 +99,7 @@ withChatTerm ChatTerminal {termDevice = TerminalDevice t} action = withTerm t $ 
 
 newChatTerminal :: WithTerminal t => t -> ChatOpts -> IO ChatTerminal
 newChatTerminal t opts = do
-  termSize <- withTerm t . runTerminalT $ getWindowSize
+  termSize <- fixZeroSize <$> (withTerm t . runTerminalT $ getWindowSize)
   let lastRow = height termSize - 1
   termState <- newTVarIO mkTermState
   liveMessageState <- newTVarIO Nothing
@@ -121,6 +121,11 @@ newChatTerminal t opts = do
         activeTo,
         currentRemoteUsers
       }
+  where
+    -- getWindowSize reports zero dimensions in non-TTY terminals (e.g. emacs eshell),
+    -- which caused "divide by zero" in line layout (see issue #5548)
+    fixZeroSize Size {height = h, width = w} = Size {height = nonZero 24 h, width = nonZero 80 w}
+    nonZero d n = if n > 0 then n else d
 
 mkTermState :: TerminalState
 mkTermState =


### PR DESCRIPTION
## Problem

The terminal CLI exits immediately with `simplex-chat: divide by zero` in terminals that report a window size of `0` — notably emacs `eshell`. Reported in #5548.

## Root cause

`newChatTerminal` (`src/Simplex/Chat/Terminal/Output.hs`) reads the terminal size once at startup via `getWindowSize`. In a terminal that reports `0` columns, that `0` is then used as a divisor in the line-layout helpers:

- `inputHeight`: `` ... `div` width + 1 ``
- `lineCount`: `` sLength s `div` width + 1 ``
- `positionRowColumn`: `` pos `div` wid ``

The first time the client lays out a line it evaluates `` n `div` 0 `` and the process dies.

## Fix

Normalize the reported size once at the source, so a `0` width/height falls back to a conventional 80×24 default instead of propagating a zero divisor. Since `termSize` is an immutable field read by all three division sites, a single guard at construction covers every path:

```haskell
termSize <- fixZeroSize <$> (withTerm t . runTerminalT $ getWindowSize)
...
where
  fixZeroSize Size {height = h, width = w} = Size {height = nonZero 24 h, width = nonZero 80 w}
  nonZero d n = if n > 0 then n else d
```

This both prevents the crash and renders usable output in such terminals, rather than only avoiding the exception.

## Testing

Reproduced and verified in a pseudo-terminal forced to a 0×0 window size (a real terminal reporting zero, matching the eshell condition):

- before the change: `simplex-chat: divide by zero` on first line layout
- after the change: the client starts, renders at the 80×24 fallback, and processes commands normally

## Notes / scope

- The window size is read only once at startup, so resizing a zero-reporting terminal afterwards is not picked up. This is pre-existing behavior and kept out of scope for this fix.
- Threat model: change is confined to local terminal rendering of the CLI; it touches no protocol, storage, or network code, introduces no new inputs, and has no remote attack surface.

Closes #5548
