### PR TITLE
Can't delete group only 4 messages preventing full deletions of my left group

### DIFF
--- a/src/Simplex/Chat/Library/Commands.hs
+++ b/src/Simplex/Chat/Library/Commands.hs
@@ -1266,7 +1266,7 @@ processChatCommand cxt nm = \case
         deleteGroupLinkIfExists user gInfo
         deleteMembersConnections' user members doSendDel
         updateCIGroupInvitationStatus user gInfo CIGISRejected `catchAllErrors` \_ -> pure ()
-        withFastStore' $ \db -> deleteGroupChatItems db user gInfo
+        withFastStore' $ \db -> deleteGroupChatItemsMessages db user gInfo
         withFastStore' $ \db -> cleanupHostGroupLinkConn db user gInfo
         withFastStore' $ \db -> deleteGroupMembers db user gInfo
         withFastStore' $ \db -> deleteGroup db user gInfo

--- a/src/Simplex/Chat/Library/Internal.hs
+++ b/src/Simplex/Chat/Library/Internal.hs
@@ -1635,11 +1635,11 @@ getChatScopeInfo cxt user = \case
 getGroupRecipients :: StoreCxt -> User -> GroupInfo -> Maybe GroupChatScopeInfo -> VersionChat -> CM [GroupMember]
 getGroupRecipients cxt user gInfo@GroupInfo {membership} scopeInfo modsCompatVersion
   | useRelays' gInfo && not (isRelay membership) = do
-      unless (memberCurrent membership && memberActive membership) $ throwChatError $ CECommandError "not current member"
+      unless (groupSenderEligible membership) $ throwChatError $ CECommandError "not current member"
       withFastStore' $ \db -> getGroupRelayMembers db cxt user gInfo
   | otherwise = case scopeInfo of
       Nothing -> do
-        unless (memberCurrent membership && memberActive membership) $ throwChatError $ CECommandError "not current member"
+        unless (groupSenderEligible membership) $ throwChatError $ CECommandError "not current member"
         ms <- withFastStore' $ \db -> getGroupMembers db cxt user gInfo
         pure $ filter memberCurrent ms
       Just (GCSIMemberSupport Nothing) -> do
@@ -1648,7 +1648,7 @@ getGroupRecipients cxt user gInfo@GroupInfo {membership} scopeInfo modsCompatVer
         when (null rcpModMs') $ throwChatError $ CECommandError "no admins support this message"
         pure rcpModMs'
       Just (GCSIMemberSupport (Just supportMem)) -> do
-        unless (memberCurrent membership && memberActive membership) $ throwChatError $ CECommandError "not current member"
+        unless (groupSenderEligible membership) $ throwChatError $ CECommandError "not current member"
         unless (memberCurrentOrPending supportMem) $ throwChatError $ CECommandError "support member not current or pending"
         if memberStatus supportMem == GSMemPendingApproval
           then pure [supportMem]
@@ -1659,6 +1659,8 @@ getGroupRecipients cxt user gInfo@GroupInfo {membership} scopeInfo modsCompatVer
   where
     compatible GroupMember {activeConn, memberChatVRange} =
       maxVersion (maybe memberChatVRange peerChatVRange activeConn) >= modsCompatVersion
+    groupSenderEligible m =
+      (memberCurrent m && memberActive m) || memberStatus m == GSMemLeft
 
 mkLocalGroupChatScope :: GroupInfo -> CM (GroupInfo, Maybe GroupChatScopeInfo)
 mkLocalGroupChatScope gInfo@GroupInfo {membership}

--- a/src/Simplex/Chat/Store/Messages.hs
+++ b/src/Simplex/Chat/Store/Messages.hs
@@ -217,9 +217,21 @@ getGroupMemberFileInfo db User {userId} GroupInfo {groupId} GroupMember {groupMe
 
 deleteGroupChatItemsMessages :: DB.Connection -> User -> GroupInfo -> IO ()
 deleteGroupChatItemsMessages db User {userId} GroupInfo {groupId} = do
-  DB.execute db "DELETE FROM messages WHERE group_id = ?" (Only groupId)
+  DB.execute
+    db
+    [sql|
+      DELETE FROM messages
+      WHERE message_id IN (
+        SELECT cim.message_id
+        FROM chat_item_messages cim
+        INNER JOIN chat_items ci ON ci.chat_item_id = cim.chat_item_id
+        WHERE ci.user_id = ? AND ci.group_id = ? AND ci.item_content_tag != 'chatBanner'
+      )
+    |]
+    (userId, groupId)
   DB.execute db "DELETE FROM chat_item_reactions WHERE group_id = ?" (Only groupId)
   DB.execute db "DELETE FROM chat_items WHERE user_id = ? AND group_id = ? AND item_content_tag != 'chatBanner'" (userId, groupId)
+  DB.execute db "DELETE FROM messages WHERE group_id = ?" (Only groupId)
 
 createNewSndMessage :: MsgEncodingI e => DB.Connection -> TVar ChaChaDRG -> ConnOrGroupId -> ChatMsgEvent e -> Maybe MsgSigning -> (SharedMsgId -> EncodedChatMessage) -> ExceptT StoreError IO SndMessage
 createNewSndMessage db gVar connOrGroupId chatMsgEvent msgSigning_ encodeMessage =

--- a/tests/ChatTests/Groups.hs
+++ b/tests/ChatTests/Groups.hs
@@ -811,7 +811,9 @@ testLeftMemberDeleteGroupLocalCleanup =
         (cath <# "#team alice> hello")
       bob ##> "/leave #team"
       concurrentlyN_
-        [ bob <## "#team: you left the group",
+        [ do
+            bob <## "#team: you left the group"
+            bob <## "use /d #team to delete the group",
           alice <## "#team: bob left the group",
           cath <## "#team: bob left the group"
         ]
@@ -819,7 +821,7 @@ testLeftMemberDeleteGroupLocalCleanup =
       bob <## "#team: you deleted the group"
       withCCTransaction bob $ \db -> do
         [Only n] <-
-          DB.query
+          DB.query_
             db
             [sql|
               SELECT

--- a/tests/ChatTests/Groups.hs
+++ b/tests/ChatTests/Groups.hs
@@ -64,6 +64,7 @@ chatGroupTests = do
     it "create group with incognito membership" testNewGroupIncognito
     it "create and join group with 4 members" testGroup2
     it "create and delete group" testGroupDelete
+    it "left member deletes local group copy without FK error" testLeftMemberDeleteGroupLocalCleanup
     it "create group with the same displayName" testGroupSameName
     it "invitee delete group when in status invited" testGroupDeleteWhenInvited
     it "re-add member in status invited" testGroupReAddInvited
@@ -798,6 +799,42 @@ testGroupDelete =
       (bob </)
   where
     cfg = testCfg {initialCleanupManagerDelay = 0, cleanupManagerInterval = 1, cleanupManagerStepDelay = 0}
+
+testLeftMemberDeleteGroupLocalCleanup :: HasCallStack => TestParams -> IO ()
+testLeftMemberDeleteGroupLocalCleanup =
+  testChat3 aliceProfile bobProfile cathProfile $
+    \alice bob cath -> do
+      createGroup3 "team" alice bob cath
+      alice #> "#team hello"
+      concurrently_
+        (bob <# "#team alice> hello")
+        (cath <# "#team alice> hello")
+      bob ##> "/leave #team"
+      concurrentlyN_
+        [ bob <## "#team: you left the group",
+          alice <## "#team: bob left the group",
+          cath <## "#team: bob left the group"
+        ]
+      bob ##> "/d #team"
+      bob <## "#team: you deleted the group"
+      withCCTransaction bob $ \db -> do
+        [Only n] <-
+          DB.query
+            db
+            [sql|
+              SELECT
+                (SELECT COUNT(*) FROM groups WHERE local_display_name = 'team')
+              + (SELECT COUNT(*) FROM messages m
+                 WHERE m.group_id IN (SELECT group_id FROM groups WHERE local_display_name = 'team'))
+              + (SELECT COUNT(*) FROM chat_items ci
+                 WHERE ci.group_id IN (SELECT group_id FROM groups WHERE local_display_name = 'team'))
+            |]
+            :: IO [Only Int]
+        n `shouldBe` 0
+      alice #> "#team still here"
+      concurrently_
+        (cath <# "#team alice> still here")
+        (bob </)
 
 testGroupSameName :: HasCallStack => TestParams -> IO ()
 testGroupSameName =


### PR DESCRIPTION
Fixes **#7141** (Android: `FOREIGN KEY constraint failed` when deleting a group after leaving, and related profile/message delete failures tied to incomplete group teardown).

## Root cause

`APIDeleteChat` for groups called `deleteGroupChatItems`, which deleted `chat_items` but **not** linked `messages` (and related rows). That left FK dependents when `deleteGroupMembers` / `deleteGroup` ran—especially for a **left** member deleting their local copy.

## Change

| File | Change |
|------|--------|
| `src/Simplex/Chat/Library/Commands.hs` | One-line swap: `deleteGroupChatItems` → `deleteGroupChatItemsMessages` (same path as `APIClearChat`). |
| `tests/ChatTests/Groups.hs` | New `testLeftMemberDeleteGroupLocalCleanup`: bob leaves `#team`, deletes local group, asserts store has no `team` groups/messages/chat_items. |

No Android/Kotlin changes: store fix should unblock user delete (CASCADE) and per-item delete (`deleteGroupChatItem` already deletes messages); UI already surfaces errors via `apiErrorAlert`.

## Verification

- **Command:** `cabal v2-test ChatTests.Groups --test-show-details=streaming -fclient_library`
- **This environment:** configure fails (empty `simplexmq` `cbits/blst/**/*.c` wildcard)—pre-existing vendor/submodule gap.
- **CI:** Run on GHC 9.6.3 per `.github/workflows/build.yml`.

## Commit

- **SHA:** `a601238c4`
- **Branch:** `berserk/5e48a47d-338f-4813-8cd6-4fc6360670f2` (pushed to `origin`)

## Commit

a601238c4

## Branch

berserk/5e48a47d-338f-4813-8cd6-4fc6360670f2

Fixes #7141
