### PR TITLE
Cannot import SimpleX database on any new machine across Mac OS, Linux distros

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
@@ -1010,7 +1010,9 @@ object ChatController {
   suspend fun apiImportArchive(config: ArchiveConfig): List<ArchiveError> {
     val r = sendCmd(null, CC.ApiImportArchive(config))
     if (r is API.Result && r.res is CR.ArchiveImported) return r.res.archiveErrors
-    throw Exception("failed to import archive: ${r.responseType} ${r.details}")
+    val errMsg = "failed to import archive: ${r.responseType} ${r.details}"
+    Log.e(TAG, "apiImportArchive error: $errMsg")
+    throw Exception(errMsg)
   }
 
   suspend fun apiDeleteStorage() {
@@ -1979,8 +1981,9 @@ object ChatController {
     return if (r is API.Result && r.res is CR.SndStandaloneFileCreated) {
       r.res.fileTransferMeta to null
     } else {
-      Log.e(TAG, "uploadStandaloneFile error: $r")
-      null to r.toString()
+      val errMsg = apiResponseErrorMessage(r)
+      Log.e(TAG, "uploadStandaloneFile error: $errMsg")
+      null to errMsg
     }
   }
 
@@ -1989,18 +1992,27 @@ object ChatController {
     return if (r is API.Result && r.res is CR.RcvStandaloneFileCreated) {
       r.res.rcvFileTransfer to null
     } else {
-      Log.e(TAG, "downloadStandaloneFile error: $r")
-      null to r.toString()
+      val errMsg = apiResponseErrorMessage(r)
+      Log.e(TAG, "downloadStandaloneFile error: $errMsg")
+      null to errMsg
     }
   }
 
-  suspend fun standaloneFileInfo(url: String, ctrl: ChatCtrl? = null): MigrationFileLinkData? {
+  suspend fun standaloneFileInfo(url: String, ctrl: ChatCtrl? = null): Pair<MigrationFileLinkData?, String?> {
     val r = sendCmd(null, CC.ApiStandaloneFileInfo(url), ctrl)
     return if (r is API.Result && r.res is CR.StandaloneFileInfo) {
-      r.res.fileMeta
+      val meta = r.res.fileMeta
+      if (meta != null) {
+        meta to null
+      } else {
+        val errMsg = apiResponseErrorMessage(r, "missing file metadata")
+        Log.e(TAG, "standaloneFileInfo error: $errMsg")
+        null to errMsg
+      }
     } else {
-      Log.e(TAG, "standaloneFileInfo error: $r")
-      null
+      val errMsg = apiResponseErrorMessage(r)
+      Log.e(TAG, "standaloneFileInfo error: $errMsg")
+      null to errMsg
     }
   }
 
@@ -2654,10 +2666,14 @@ object ChatController {
   }
 
   private fun apiErrorAlert(method: String, title: String, r: API) {
-    val errMsg = "${r.responseType}: ${r.details}"
+    val errMsg = apiResponseErrorMessage(r)
     Log.e(TAG, "$method bad response: $errMsg")
     AlertManager.shared.showAlertMsg(title, errMsg)
   }
+
+  fun apiResponseErrorMessage(r: API, fallback: String? = null): String =
+    if (r is API.Error) r.err.string
+    else fallback ?: "${r.responseType}: ${r.details}"
 
   // Spec: spec/api.md#processReceivedMsg
   private suspend fun processReceivedMsg(msg: API) {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/platform/Files.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/platform/Files.kt
@@ -80,6 +80,22 @@ fun copyBytesToFile(bytes: ByteArrayInputStream, to: URI, finally: () -> Unit) {
 
 fun getMigrationTempFilesDirectory(): File = File(dataDir, "migration_temp_files")
 
+/** Copy a user-selected archive URI into [destDir]; returns absolute path or null on failure. */
+fun copyArchiveFromUri(importedArchiveURI: URI, destDir: File): String? {
+  return try {
+    val inputStream = importedArchiveURI.inputStream() ?: return null
+    destDir.mkdirs()
+    val archiveName = getFileName(importedArchiveURI) ?: "simplex-chat-import.zip"
+    val destFile = File(destDir, archiveName)
+    Files.copy(inputStream, destFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
+    destFile.absolutePath
+  } catch (e: Exception) {
+    Log.e(TAG, "copyArchiveFromUri error: ${e.stackTraceToString()}")
+    AlertManager.shared.showAlertMsg(generalGetString(MR.strings.error_saving_database), e.message ?: e.toString())
+    null
+  }
+}
+
 fun getAppFilePath(fileName: String): String {
   val rh = chatModel.currentRemoteHost.value
   val s = File.separator

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/database/DatabaseView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/database/DatabaseView.kt
@@ -705,25 +705,8 @@ suspend fun importArchive(
   return false
 }
 
-private fun saveArchiveFromURI(importedArchiveURI: URI): String? {
-  return try {
-    val inputStream = importedArchiveURI.inputStream()
-    val archiveName = getFileName(importedArchiveURI)
-    if (inputStream != null && archiveName != null) {
-      val archivePath = "$databaseExportDir${File.separator}$archiveName"
-      val destFile = File(archivePath)
-      Files.copy(inputStream, destFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
-      archivePath
-    } else {
-      Log.e(TAG, "saveArchiveFromURI null inputStream")
-      null
-    }
-  } catch (e: Exception) {
-    AlertManager.shared.showAlertMsg(generalGetString(MR.strings.error_saving_database), e.stackTraceToString())
-    Log.e(TAG, "saveArchiveFromURI error: ${e.stackTraceToString()}")
-    null
-  }
-}
+private fun saveArchiveFromURI(importedArchiveURI: URI): String? =
+  copyArchiveFromUri(importedArchiveURI, databaseExportDir)
 
 private fun deleteChatAlert(onConfirm: () -> Unit) {
   AlertManager.shared.showAlertDialog(

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/migration/MigrateFromDevice.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/migration/MigrateFromDevice.kt
@@ -69,14 +69,8 @@ data class MigrationFileLinkData(
   fun addToLink(link: String) = link + "&data=" + URLEncoder.encode(jsonShort.encodeToString(this), "UTF-8")
 
   companion object {
-    suspend fun readFromLink(link: String): MigrationFileLinkData? =
-      try {
-        // val data = link.substringAfter("&data=").substringBefore("&")
-        // json.decodeFromString(URLDecoder.decode(data, "UTF-8"))
-        controller.standaloneFileInfo(link)
-      } catch (e: Exception) {
-        null
-      }
+    suspend fun readFromLink(link: String): Pair<MigrationFileLinkData?, String?> =
+      controller.standaloneFileInfo(link)
   }
 }
 

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/migration/MigrateToDevice.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/migration/MigrateToDevice.kt
@@ -40,6 +40,8 @@ import java.text.SimpleDateFormat
 import java.util.*
 import kotlin.math.max
 
+private const val MIGRATION_DOWNLOAD_TIMEOUT_MS = 3_600_000L
+
 @Serializable
 sealed class MigrationToDeviceState {
   @Serializable @SerialName("onion") data class Onion(val link: String, val socksProxy: String?, val networkProxy: NetworkProxy?, val hostMode: HostMode, val requiredHostMode: Boolean): MigrationToDeviceState()
@@ -215,7 +217,7 @@ private fun MutableState<MigrationToState?>.PasteOrScanLinkView(close: () -> Uni
       SectionSpacer()
 
       SectionView(stringResource(MR.strings.chat_archive).uppercase()) {
-        ArchiveImportView(progressIndicator, close)
+        ArchiveImportFromFileView(progressIndicator, close)
       }
     }
     if (progressIndicator.value)
@@ -235,19 +237,17 @@ private fun MutableState<MigrationToState?>.PasteLinkView() {
 }
 
 @Composable
-private fun ArchiveImportView(progressIndicator: MutableState<Boolean>, close: () -> Unit) {
+private fun MutableState<MigrationToState?>.ArchiveImportFromFileView(progressIndicator: MutableState<Boolean>, close: () -> Unit) {
+  val migrationState = this
   val importArchiveLauncher = rememberFileChooserLauncher(true) { to: URI? ->
     if (to != null) {
       withLongRunningApi {
-        val success = importArchive(to, mutableStateOf(0 to 0), progressIndicator, true)
-        if (success) {
-          startChat(
-            chatModel,
-            mutableStateOf(Clock.System.now()),
-            chatModel.chatDbChanged,
-            progressIndicator
-          )
-          hideView(close)
+        progressIndicator.value = true
+        val archivePath = copyArchiveFromUri(to, getMigrationTempFilesDirectory())
+        progressIndicator.value = false
+        if (archivePath != null) {
+          val netCfg = getNetCfg()
+          migrationState.state = MigrationToState.ArchiveImport(archivePath, netCfg, null)
         }
       }
     }
@@ -349,7 +349,17 @@ private fun MutableState<MigrationToState?>.LinkDownloadingView(
     ProgressView()
   }
   LaunchedEffect(Unit) {
-    startDownloading(0, ctrl, user, tempDatabaseFile, chatReceiver, link, archivePath, netCfg, networkProxy)
+    val timedOut = withTimeoutOrNull(MIGRATION_DOWNLOAD_TIMEOUT_MS) {
+      startDownloading(0, ctrl, user, tempDatabaseFile, chatReceiver, link, archivePath, netCfg, networkProxy)
+    }
+    if (timedOut == null && value is MigrationToState.LinkDownloading) {
+      chatReceiver.value?.stopAndCleanUp()
+      AlertManager.shared.showAlertMsg(
+        generalGetString(MR.strings.migrate_to_device_download_failed),
+        generalGetString(MR.strings.migrate_to_device_try_again)
+      )
+      state = MigrationToState.DownloadFailed(0, link, archivePath, netCfg, networkProxy)
+    }
   }
 }
 
@@ -605,13 +615,15 @@ private fun MutableState<MigrationToState?>.startDownloading(
               MigrationToDeviceState.save(MigrationToDeviceState.ArchiveImport(File(archivePath).name, netCfg, networkProxy))
             }
           }
-          r is CR.RcvFileError -> {
+          r is CR.RcvFileError || r is CR.RcvFileCancelled -> {
             AlertManager.shared.showAlertMsg(
               generalGetString(MR.strings.migrate_to_device_download_failed),
               generalGetString(MR.strings.migrate_to_device_file_delete_or_link_invalid)
             )
             state = MigrationToState.DownloadFailed(totalBytes, link, archivePath, netCfg, networkProxy)
           }
+          r is CR.RcvFileWarning -> Log.w(TAG, "MigrateToDevice download warning: ${r.agentError.string}")
+          r is CR.RcvStandaloneFileCreated -> Log.d(TAG, "MigrateToDevice: standalone file download started")
           msg is API.Error -> {
             val text = if (msg.err is ChatError.ChatErrorChat && msg.err.errorType is ChatErrorType.NoRcvFileUser) {
               generalGetString(MR.strings.migrate_to_device_file_delete_or_link_invalid)
@@ -654,7 +666,7 @@ private fun MutableState<MigrationToState?>.importArchive(archivePath: String, n
       controller.apiDeleteStorage()
       wallpapersDir.mkdirs()
       try {
-        val config = ArchiveConfig(archivePath, parentTempDirectory = databaseExportDir.toString())
+        val config = ArchiveConfig(archivePath, parentTempDirectory = getMigrationTempFilesDirectory().absolutePath)
         val archiveErrors = controller.apiImportArchive(config)
         if (archiveErrors.isNotEmpty()) {
           showArchiveImportedWithErrorsAlert(archiveErrors)
@@ -663,11 +675,11 @@ private fun MutableState<MigrationToState?>.importArchive(archivePath: String, n
         MigrationToDeviceState.save(MigrationToDeviceState.Passphrase(netCfg, networkProxy))
       } catch (e: Exception) {
         state = MigrationToState.ArchiveImportFailed(archivePath, netCfg, networkProxy)
-        AlertManager.shared.showAlertMsg (generalGetString(MR.strings.error_importing_database), e.stackTraceToString())
+        AlertManager.shared.showAlertMsg(generalGetString(MR.strings.error_importing_database), e.message ?: e.toString())
       }
     } catch (e: Exception) {
       state = MigrationToState.ArchiveImportFailed(archivePath, netCfg, networkProxy)
-      AlertManager.shared.showAlertMsg (generalGetString(MR.strings.error_deleting_database), e.stackTraceToString())
+      AlertManager.shared.showAlertMsg(generalGetString(MR.strings.error_deleting_database), e.message ?: e.toString())
     }
   }
 }
@@ -737,7 +749,7 @@ private suspend fun MutableState<MigrationToState?>.cleanUpOnBack(chatReceiver: 
   chatModel.migrationState.value = null
 }
 
-private fun strHasSimplexFileLink(text: String): Boolean =
+internal fun strHasSimplexFileLink(text: String): Boolean =
   text.startsWith("simplex:/file") || text.startsWith("https://simplex.chat/file")
 
 private fun fileForTemporaryDatabase(): File =

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/migration/MigrateToDevice.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/migration/MigrateToDevice.kt
@@ -522,9 +522,16 @@ private fun ProgressView() {
 
 private suspend fun MutableState<MigrationToState?>.checkUserLink(link: String): Boolean {
   return if (strHasSimplexFileLink(link.trim())) {
-    val data = MigrationFileLinkData.readFromLink(link)
-    val hasProxyConfigured = data?.networkConfig?.hasProxyConfigured() ?: false
-    val networkConfig = data?.networkConfig?.transformToPlatformSupported()
+    val (data, linkError) = MigrationFileLinkData.readFromLink(link)
+    if (data == null) {
+      AlertManager.shared.showAlertMsg(
+        title = generalGetString(MR.strings.invalid_file_link),
+        text = linkError ?: generalGetString(MR.strings.the_text_you_pasted_is_not_a_link)
+      )
+      return false
+    }
+    val hasProxyConfigured = data.networkConfig?.hasProxyConfigured() ?: false
+    val networkConfig = data.networkConfig?.transformToPlatformSupported()
     // If any of iOS or Android had onion enabled, show onion screen
     if (hasProxyConfigured && networkConfig?.hostMode != null && networkConfig.requiredHostMode != null) {
       state = MigrationToState.Onion(link.trim(), networkConfig.legacySocksProxy, networkConfig.networkProxy, networkConfig.hostMode, networkConfig.requiredHostMode)
@@ -606,15 +613,16 @@ private fun MutableState<MigrationToState?>.startDownloading(
             state = MigrationToState.DownloadFailed(totalBytes, link, archivePath, netCfg, networkProxy)
           }
           msg is API.Error -> {
-            if (msg.err is ChatError.ChatErrorChat && msg.err.errorType is ChatErrorType.NoRcvFileUser) {
-              AlertManager.shared.showAlertMsg(
-                generalGetString(MR.strings.migrate_to_device_download_failed),
-                generalGetString(MR.strings.migrate_to_device_file_delete_or_link_invalid)
-              )
-              state = MigrationToState.DownloadFailed(totalBytes, link, archivePath, netCfg, networkProxy)
+            val text = if (msg.err is ChatError.ChatErrorChat && msg.err.errorType is ChatErrorType.NoRcvFileUser) {
+              generalGetString(MR.strings.migrate_to_device_file_delete_or_link_invalid)
             } else {
-              Log.d(TAG, "unsupported error: ${msg.responseType}, ${json.encodeToString(msg.err)}")
+              ChatController.apiResponseErrorMessage(msg)
             }
+            AlertManager.shared.showAlertMsg(
+              generalGetString(MR.strings.migrate_to_device_download_failed),
+              text
+            )
+            state = MigrationToState.DownloadFailed(totalBytes, link, archivePath, netCfg, networkProxy)
           }
           else -> Log.d(TAG, "unsupported event: ${msg.responseType}")
         }
@@ -624,9 +632,14 @@ private fun MutableState<MigrationToState?>.startDownloading(
     val (res, error) = controller.downloadStandaloneFile(user, link, CryptoFile.plain(File(archivePath).path), ctrl)
     if (res == null) {
       state = MigrationToState.DownloadFailed(totalBytes, link, archivePath, netCfg, networkProxy)
+      val text = when {
+        error == null -> generalGetString(MR.strings.migrate_to_device_file_delete_or_link_invalid)
+        error.contains("noRcvFileUser") -> generalGetString(MR.strings.migrate_to_device_file_delete_or_link_invalid)
+        else -> error
+      }
       AlertManager.shared.showAlertMsg(
         generalGetString(MR.strings.migrate_to_device_error_downloading_archive),
-        error
+        text
       )
     }
   }

--- a/apps/multiplatform/common/src/commonTest/kotlin/chat/simplex/common/views/migration/MigrationLinkTest.kt
+++ b/apps/multiplatform/common/src/commonTest/kotlin/chat/simplex/common/views/migration/MigrationLinkTest.kt
@@ -1,0 +1,15 @@
+package chat.simplex.common.views.migration
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MigrationLinkTest {
+  @Test
+  fun strHasSimplexFileLink_acceptsSimplexAndHttpsPrefixes() {
+    assertTrue(strHasSimplexFileLink("simplex:/file/test"))
+    assertTrue(strHasSimplexFileLink("https://simplex.chat/file/test"))
+    assertFalse(strHasSimplexFileLink("https://example.com/file"))
+    assertFalse(strHasSimplexFileLink("not a link"))
+  }
+}

--- a/src/Simplex/Chat/Archive.hs
+++ b/src/Simplex/Chat/Archive.hs
@@ -72,7 +72,7 @@ exportArchive cfg@ArchiveConfig {archivePath, disableCompression} =
 importArchive :: ArchiveConfig -> CM' [ArchiveError]
 importArchive cfg@ArchiveConfig {archivePath} =
   (`E.catch` archiveImportFatal) $ withTempDir cfg "simplex-chat." $ \dir -> do
-    liftIO $ unpackArchive archivePath dir
+    liftIO $ Z.withArchive archivePath $ Z.unpackInto dir
     validateArchiveContents dir
     fs@StorageFiles {chatStore, agentStore, filesPath, assetsPath} <- storageFiles
     liftIO $ closeDBStore `withStores` fs
@@ -100,10 +100,6 @@ importArchive cfg@ArchiveConfig {archivePath} =
           `E.catch` \(e :: E.SomeException) -> pure [AEImport $ show e]
       _ -> pure []
 
-unpackArchive :: FilePath -> FilePath -> IO ()
-unpackArchive archivePath dir =
-  Z.withArchive archivePath $ Z.unpackInto dir
-
 validateArchiveContents :: FilePath -> CM' ()
 validateArchiveContents dir = do
   forM_ [archiveChatDbFile, archiveAgentDbFile] $ \f -> do
@@ -123,13 +119,11 @@ throwArchiveImportFatal msg = throwIO $ ChatError $ CEException msg
 
 archiveImportErrorMessage :: E.SomeException -> String
 archiveImportErrorMessage e =
-  let s = show e
-   in if | "does not exist" `isInfixOf` s || "not found" `isInfixOf` s -> "archive file not found"
-         | "not a zip" `isInfixOf` s || ("invalid" `isInfixOf` s && "zip" `isInfixOf` s) -> "archive is invalid or corrupt"
-         | "CRC" `isInfixOf` s || "corrupt" `isInfixOf` s || "truncated" `isInfixOf` s -> "archive is invalid or corrupt"
-         | otherwise -> "archive import failed: " <> s
-  where
-    isInfixOf needle haystack = needle `T.isInfixOf` T.pack haystack
+  let s = T.pack $ show e
+   in if | "does not exist" `T.isInfixOf` s || "not found" `T.isInfixOf` s -> "archive file not found"
+         | "not a zip" `T.isInfixOf` s || ("invalid" `T.isInfixOf` s && "zip" `T.isInfixOf` s) -> "archive is invalid or corrupt"
+         | "CRC" `T.isInfixOf` s || "corrupt" `T.isInfixOf` s || "truncated" `T.isInfixOf` s -> "archive is invalid or corrupt"
+         | otherwise -> "archive import failed: " <> T.unpack s
 
 withTempDir :: ArchiveConfig -> (String -> (FilePath -> CM' a) -> CM' a)
 withTempDir cfg = case parentTempDirectory (cfg :: ArchiveConfig) of

--- a/src/Simplex/Chat/Archive.hs
+++ b/src/Simplex/Chat/Archive.hs
@@ -71,18 +71,26 @@ exportArchive cfg@ArchiveConfig {archivePath, disableCompression} =
 
 importArchive :: ArchiveConfig -> CM' [ArchiveError]
 importArchive cfg@ArchiveConfig {archivePath} =
-  withTempDir cfg "simplex-chat." $ \dir -> do
-    Z.withArchive archivePath $ Z.unpackInto dir
+  (`E.catch` archiveImportFatal) $ withTempDir cfg "simplex-chat." $ \dir -> do
+    liftIO $ unpackArchive archivePath dir
+    validateArchiveContents dir
     fs@StorageFiles {chatStore, agentStore, filesPath, assetsPath} <- storageFiles
     liftIO $ closeDBStore `withStores` fs
     backup `withDBs` fs
-    copyFile (dir </> archiveChatDbFile) $ dbFilePath chatStore
-    copyFile (dir </> archiveAgentDbFile) $ dbFilePath agentStore
+    copyArchiveDbs dir fs
     errs <- copyFiles (dir </> archiveFilesFolder) filesPath
     errs' <- copyFiles (dir </> archiveAssetsFolder </> wallpapersFolder) ((</> wallpapersFolder) <$> assetsPath)
     pure $ errs <> errs'
   where
     backup f = whenM (doesFileExist f) $ copyFile f $ f <> ".bak"
+    copyArchiveDbs dir fs@StorageFiles {chatStore, agentStore} =
+      liftIO $
+        copyFile (dir </> archiveChatDbFile) (dbFilePath chatStore)
+          >> copyFile (dir </> archiveAgentDbFile) (dbFilePath agentStore)
+          `E.catch` \(e :: E.SomeException) -> restoreDbs fs >> E.throwIO e
+    restoreDbs fs = restore `withDBs` fs
+      where
+        restore f = whenM (doesFileExist $ f <> ".bak") $ copyFile (f <> ".bak") f
     copyFiles fromDir = \case
       Just fp ->
         ifM
@@ -91,6 +99,37 @@ importArchive cfg@ArchiveConfig {archivePath} =
           (pure [])
           `E.catch` \(e :: E.SomeException) -> pure [AEImport $ show e]
       _ -> pure []
+
+unpackArchive :: FilePath -> FilePath -> IO ()
+unpackArchive archivePath dir =
+  Z.withArchive archivePath $ Z.unpackInto dir
+
+validateArchiveContents :: FilePath -> CM' ()
+validateArchiveContents dir = do
+  forM_ [archiveChatDbFile, archiveAgentDbFile] $ \f -> do
+    let path = dir </> f
+    exists <- liftIO $ doesFileExist path
+    unless exists . liftIO . throwArchiveImportFatal $
+      "archive is missing required file: " <> f
+
+archiveImportFatal :: E.SomeException -> CM' [ArchiveError]
+archiveImportFatal e =
+  case E.fromException e of
+    Just (ChatError (CEException msg)) -> liftIO $ throwIO $ ChatError $ CEException msg
+    _ -> liftIO . throwArchiveImportFatal $ archiveImportErrorMessage e
+
+throwArchiveImportFatal :: String -> IO a
+throwArchiveImportFatal msg = throwIO $ ChatError $ CEException msg
+
+archiveImportErrorMessage :: E.SomeException -> String
+archiveImportErrorMessage e =
+  let s = show e
+   in if | "does not exist" `isInfixOf` s || "not found" `isInfixOf` s -> "archive file not found"
+         | "not a zip" `isInfixOf` s || ("invalid" `isInfixOf` s && "zip" `isInfixOf` s) -> "archive is invalid or corrupt"
+         | "CRC" `isInfixOf` s || "corrupt" `isInfixOf` s || "truncated" `isInfixOf` s -> "archive is invalid or corrupt"
+         | otherwise -> "archive import failed: " <> s
+  where
+    isInfixOf needle haystack = needle `T.isInfixOf` T.pack haystack
 
 withTempDir :: ArchiveConfig -> (String -> (FilePath -> CM' a) -> CM' a)
 withTempDir cfg = case parentTempDirectory (cfg :: ArchiveConfig) of

--- a/tests/ChatTests/Direct.hs
+++ b/tests/ChatTests/Direct.hs
@@ -40,11 +40,12 @@ import Simplex.Messaging.Server.Env.STM hiding (subscriptions)
 import Simplex.Messaging.Transport
 import Simplex.Messaging.Util (safeDecodeUtf8)
 import Simplex.Messaging.Version
-import System.Directory (copyFile, doesDirectoryExist, doesFileExist)
+import System.Directory (copyFile, createDirectoryIfMissing, doesDirectoryExist, doesFileExist)
 import Test.Hspec hiding (it)
 #if defined(dbPostgres)
 import Database.PostgreSQL.Simple (Only (..))
 #else
+import Codec.Archive.Zip (addEntryToArchive, emptyArchive, fromArchive)
 import Database.SQLite.Simple (Only (..))
 import Simplex.Chat.Options.DB
 import System.FilePath ((</>))
@@ -103,6 +104,8 @@ chatDirectTests = do
   describe "maintenance mode" $ do
     it "start/stop/export/import chat" testMaintenanceMode
     it "export/import chat with files" testMaintenanceModeWithFiles
+    it "reject corrupt archive import" testMaintenanceModeImportCorruptArchive
+    it "reject archive missing required database files" testMaintenanceModeImportArchiveMissingDbs
     it "encrypt/decrypt database" testDatabaseEncryption
 #endif
   describe "connections synchronization" $ do
@@ -1440,6 +1443,35 @@ testMaintenanceModeWithFiles ps = withXFTPServer $ do
       B.readFile "./tests/tmp/alice_files/test.jpg" `shouldReturn` src
     -- works after full restart
     withTestChat ps "alice" $ \alice -> testChatWorking alice bob
+
+testMaintenanceModeImportCorruptArchive :: HasCallStack => TestParams -> IO ()
+testMaintenanceModeImportCorruptArchive ps =
+  withNewTestChatOpts ps testOpts {coreOptions = testCoreOpts {maintenance = True}} "alice" aliceProfile $ \alice -> do
+    alice ##> "/_start"
+    alice <## "chat started"
+    createDirectoryIfMissing True "./tests/tmp"
+    B.writeFile "./tests/tmp/corrupt-chat.zip" "not a zip archive"
+    alice ##> "/_stop"
+    alice <## "chat stopped"
+    alice ##> "/_db import {\"archivePath\": \"./tests/tmp/corrupt-chat.zip\"}"
+    alice <### [Predicate $ \l -> "error: exception:" `isPrefixOf` l && ("archive is invalid or corrupt" `isInfixOf` l || "archive import failed" `isInfixOf` l)]
+    alice ##> "/_start"
+    alice <## "chat started"
+
+testMaintenanceModeImportArchiveMissingDbs :: HasCallStack => TestParams -> IO ()
+testMaintenanceModeImportArchiveMissingDbs ps =
+  withNewTestChatOpts ps testOpts {coreOptions = testCoreOpts {maintenance = True}} "alice" aliceProfile $ \alice -> do
+    alice ##> "/_start"
+    alice <## "chat started"
+    createDirectoryIfMissing True "./tests/tmp"
+    let archive = addEntryToArchive emptyArchive "readme.txt" B.empty
+    B.writeFile "./tests/tmp/empty-chat.zip" . LB.toStrict $ fromArchive archive
+    alice ##> "/_stop"
+    alice <## "chat stopped"
+    alice ##> "/_db import {\"archivePath\": \"./tests/tmp/empty-chat.zip\"}"
+    alice <### [Predicate $ \l -> "error: exception:" `isPrefixOf` l && "archive is missing required file" `isInfixOf` l]
+    alice ##> "/_start"
+    alice <## "chat started"
 
 #if !defined(dbPostgres)
 testDatabaseEncryption :: HasCallStack => TestParams -> IO ()


### PR DESCRIPTION
# #7138 — Migrate from another device

**Branch:** `berserk/be867602-1779-4f36-bf89-6c2edce149dc`  
**Commits:** `0c80622a2` (Haskell archive validation + tests), `c26554ac5` (KMP migration reliability + shared URI copy + review tidy)

## Problem

On new installs (Flatpak/Linux/Mac), **Migrate from another device** could hang indefinitely on XFTP link import or mishandle **Import Archive File** on the same screen (wrong temp dir, bypassed migration flow).

## Fix

- **Link import:** 1h timeout, handle `RcvFileCancelled`, keep existing invalid/deleted link alerts.
- **File import on migration UI:** Copy archive to `dataDir/migration_temp_files`, enter `ArchiveImport` state (same as post-download path); `apiImportArchive` parent temp aligned with migration dirs.
- **Shared** `copyArchiveFromUri` for DatabaseView and migration.
- **Archive.hs:** inline unpack + clearer corrupt/not-found messages (with prior validation commit).
- **Test:** `MigrationLinkTest` for link prefix detection.

## Verify locally

```bash
cabal test simplex-chat-test --test-options='-p Maintenance'
./gradlew :common:desktopTest --tests chat.simplex.common.views.migration.MigrationLinkTest
```

Manual: invalid link → alert; small zip on migration screen → passphrase, no spinner hang.

## Commit

c26554ac5

## Branch

berserk/be867602-1779-4f36-bf89-6c2edce149dc

Fixes #7138
