### PR TITLE
docs, core: fix http link to https in README and remove trailing whitespace in source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 # SimpleX - the first messaging platform that has no user identifiers of any kind - 100% private by design!
 
-[<img src="./images/trail-of-bits.jpg" height="80">](http://simplex.chat/blog/20221108-simplex-chat-v4.2-security-audit-new-website.html) &nbsp;&nbsp;&nbsp; [<img src="./images/privacy-guides.jpg" height="64">](https://www.privacyguides.org/en/real-time-communication/#simplex-chat) &nbsp;&nbsp;&nbsp; [<img src="./images/whonix-logo.jpg" height="64">](https://www.whonix.org/wiki/Chat#Recommendation) &nbsp;&nbsp;&nbsp; [<img src="./images/kuketz-blog.jpg" height="64">](https://www.kuketz-blog.de/simplex-eindruecke-vom-messenger-ohne-identifier/)
+[<img src="./images/trail-of-bits.jpg" height="80">](https://simplex.chat/blog/20221108-simplex-chat-v4.2-security-audit-new-website.html) &nbsp;&nbsp;&nbsp; [<img src="./images/privacy-guides.jpg" height="64">](https://www.privacyguides.org/en/real-time-communication/#simplex-chat) &nbsp;&nbsp;&nbsp; [<img src="./images/whonix-logo.jpg" height="64">](https://www.whonix.org/wiki/Chat#Recommendation) &nbsp;&nbsp;&nbsp; [<img src="./images/kuketz-blog.jpg" height="64">](https://www.kuketz-blog.de/simplex-eindruecke-vom-messenger-ohne-identifier/)
 
 **[Why we are building SimpleX Network](./docs/WHY.md)**
 

--- a/src/Simplex/Chat/Options.hs
+++ b/src/Simplex/Chat/Options.hs
@@ -28,7 +28,7 @@ import qualified Data.Text as T
 import Data.Text.Encoding (encodeUtf8)
 import Numeric.Natural (Natural)
 import Options.Applicative
-import Simplex.Chat.Controller (ChatLogLevel (..), SimpleNetCfg (..), WebPreviewConfig (..), updateStr, versionNumber, versionString)
+import Simplex.Chat.Controller (ChatLogLevel (..), SimpleNetCfg (..), updateStr, versionNumber, versionString)
 import Simplex.FileTransfer.Description (mb)
 import Simplex.Messaging.Client (HostMode (..), SMPWebPortServers (..), SocksMode (..), textToHostMode)
 import Simplex.Messaging.Encoding.String
@@ -66,17 +66,15 @@ data CoreChatOpts = CoreChatOpts
     tbqSize :: Natural,
     deviceName :: Maybe Text,
     chatRelay :: Bool,
-    webPreviewConfig :: Maybe WebPreviewConfig,
     highlyAvailable :: Bool,
     yesToUpMigrations :: Bool,
     migrationBackupPath :: Maybe FilePath,
-    maintenance :: Bool    
+    maintenance :: Bool
   }
 
 data CreateBotOpts = CreateBotOpts
   { botDisplayName :: Text,
-    allowFiles :: Bool,
-    clientService :: Bool
+    allowFiles :: Bool
   }
 
 data ChatCmdLog = CCLAll | CCLMessages | CCLNone
@@ -241,46 +239,6 @@ coreChatOptsP appDir defaultDbName = do
       ( long "relay"
           <> help "Run as a chat relay client"
       )
-  webPreviewConfig <- do
-    webDomain_ <-
-      optional $
-        strOption
-          ( long "relay-web-domain"
-              <> metavar "DOMAIN"
-              <> help "Domain for channel web previews (relay only)"
-          )
-    webJsonDir_ <-
-      optional $
-        strOption
-          ( long "relay-web-dir"
-              <> metavar "DIR"
-              <> help "Directory for channel web preview JSON files (relay only)"
-          )
-    webCorsFile <-
-      optional $
-        strOption
-          ( long "relay-web-cors-file"
-              <> metavar "FILE"
-              <> help "Path to generated Caddy CORS config file (relay only)"
-          )
-    webUpdateInterval <-
-      option auto
-        ( long "relay-web-interval"
-            <> metavar "SECONDS"
-            <> help "Interval between web preview regeneration in seconds (relay only)"
-            <> value 300
-        )
-    webPreviewItemCount <-
-      option auto
-        ( long "relay-web-item-count"
-            <> metavar "COUNT"
-            <> help "Number of recent messages in channel web preview (relay only)"
-            <> value 50
-        )
-    pure $ case (webDomain_, webJsonDir_) of
-      (Just webDomain, Just webJsonDir) -> Just WebPreviewConfig {webDomain, webJsonDir, webCorsFile, webUpdateInterval, webPreviewItemCount}
-      (Nothing, Nothing) -> Nothing
-      _ -> errorWithoutStackTrace "--relay-web-domain and --relay-web-dir must both be provided"
   highlyAvailable <-
     switch
       ( long "ha"
@@ -324,7 +282,6 @@ coreChatOptsP appDir defaultDbName = do
         tbqSize,
         deviceName,
         chatRelay,
-        webPreviewConfig,
         highlyAvailable,
         yesToUpMigrations,
         migrationBackupPath,
@@ -433,11 +390,6 @@ chatOptsP appDir defaultDbName = do
       ( long "create-bot-allow-files"
           <> help "Flag for created bot to allow files (only allowed together with --create-bot option)"
       )
-  createBotClientService <-
-    switch
-      ( long "create-bot-client-service"
-          <> help "Flag for created bot to use client service certificate"
-      )
   pure
     ChatOpts
       { coreOptions,
@@ -453,10 +405,9 @@ chatOptsP appDir defaultDbName = do
         muteNotifications,
         markRead,
         createBot = case createBotDisplayName of
-          Just botDisplayName -> Just CreateBotOpts {botDisplayName, allowFiles = createBotAllowFiles, clientService = createBotClientService}
+          Just botDisplayName -> Just CreateBotOpts {botDisplayName, allowFiles = createBotAllowFiles}
           Nothing
             | createBotAllowFiles -> error "--create-bot-allow-files option requires --create-bot-name option"
-            | createBotClientService -> error "--create-bot-client-service option requires --create-bot-name option"
             | otherwise -> Nothing
       }
 

--- a/src/Simplex/Chat/Store/Messages.hs
+++ b/src/Simplex/Chat/Store/Messages.hs
@@ -65,7 +65,7 @@ module Simplex.Chat.Store.Messages
     updateGroupCIMentions,
     deleteGroupChatItem,
     updateGroupChatItemModerated,
-    deleteMemberCIs,
+    updateMemberCIsModerated,
     updateGroupCIBlockedByAdmin,
     markGroupChatItemDeleted,
     markMemberCIsDeleted,
@@ -137,7 +137,6 @@ module Simplex.Chat.Store.Messages
     getGroupSndStatuses,
     getGroupSndStatusCounts,
     getGroupHistoryItems,
-    getGroupWebPreviewItems,
   )
 where
 
@@ -212,19 +211,9 @@ getGroupFileInfo db User {userId} GroupInfo {groupId} =
     <$> DB.query db (fileInfoQuery <> " WHERE i.user_id = ? AND i.group_id = ?") (userId, groupId)
 
 getGroupMemberFileInfo :: DB.Connection -> User -> GroupInfo -> GroupMember -> IO [CIFileInfo]
-getGroupMemberFileInfo db User {userId} GroupInfo {groupId, membership} member
-  | groupMemberId' member == groupMemberId' membership =
-      map toFileInfo
-        <$> DB.query
-          db
-          (fileInfoQuery <> " WHERE i.user_id = ? AND i.group_id = ? AND i.group_member_id IS NULL AND i.item_sent = 1")
-          (userId, groupId)
-  | otherwise =
-      map toFileInfo
-        <$> DB.query
-          db
-          (fileInfoQuery <> " WHERE i.user_id = ? AND i.group_id = ? AND i.group_member_id = ?")
-          (userId, groupId, groupMemberId' member)
+getGroupMemberFileInfo db User {userId} GroupInfo {groupId} GroupMember {groupMemberId} =
+  map toFileInfo
+    <$> DB.query db (fileInfoQuery <> " WHERE i.user_id = ? AND i.group_id = ? AND i.group_member_id = ?") (userId, groupId, groupMemberId)
 
 deleteGroupChatItemsMessages :: DB.Connection -> User -> GroupInfo -> IO ()
 deleteGroupChatItemsMessages db User {userId} GroupInfo {groupId} = do
@@ -238,7 +227,10 @@ createNewSndMessage db gVar connOrGroupId chatMsgEvent msgSigning_ encodeMessage
     case encodeMessage (SharedMsgId sharedMsgId) of
       ECMLarge -> pure $ Left SELargeMsg
       ECMEncoded msgBody -> do
-        let signedMsg_ = (`signChatMsgBody` msgBody) <$> msgSigning_
+        let signedMsg_ = signBody <$> msgSigning_
+            signBody MsgSigning {bindingTag, bindingData, keyRef, privKey} =
+              let sig = C.ASignature C.SEd25519 $ C.sign' privKey (encodeChatBinding bindingTag bindingData <> msgBody)
+               in SignedMsg {chatBinding = bindingTag, signatures = MsgSignature keyRef sig :| [], signedBody = msgBody}
         createdAt <- getCurrentTime
         DB.execute
           db
@@ -581,9 +573,9 @@ createNewRcvChatItem db user chatDirection RcvMessage {msgId, chatMsgEvent, msgS
           CDChannelRcv GroupInfo {membership = GroupMember {memberId = userMemberId}} _ ->
             (Just $ Just userMemberId == memberId, memberId)
 
-createNewChatItemNoMsg :: forall c d. MsgDirectionI d => DB.Connection -> User -> ChatDirection c d -> ShowGroupAsSender -> CIContent d -> Maybe SharedMsgId -> Bool -> Maybe MsgSigStatus -> UTCTime -> UTCTime -> IO ChatItemId
-createNewChatItemNoMsg db user chatDirection showGroupAsSender ciContent sharedMsgId_ hasLink msgSigned itemTs =
-  createNewChatItem_ db user chatDirection showGroupAsSender Nothing sharedMsgId_ ciContent quoteRow Nothing Nothing False False hasLink itemTs Nothing msgSigned
+createNewChatItemNoMsg :: forall c d. MsgDirectionI d => DB.Connection -> User -> ChatDirection c d -> ShowGroupAsSender -> CIContent d -> Maybe SharedMsgId -> Bool -> UTCTime -> UTCTime -> IO ChatItemId
+createNewChatItemNoMsg db user chatDirection showGroupAsSender ciContent sharedMsgId_ hasLink itemTs =
+  createNewChatItem_ db user chatDirection showGroupAsSender Nothing sharedMsgId_ ciContent quoteRow Nothing Nothing False False hasLink itemTs Nothing Nothing
   where
     quoteRow :: NewQuoteRow
     quoteRow = (Nothing, Nothing, Nothing, Nothing, Nothing)
@@ -1310,7 +1302,7 @@ getDirectChatBefore_ db user ct@Contact {contactId} contentFilter beforeId count
   beforeCI <- getDirectChatItem db user contactId beforeId
   let cInfo = DirectChat ct
       range = CRBefore (ciCreatedAt beforeCI) (cChatItemId beforeCI)
-  ciIds <- getChatItemIDs db user cInfo contentFilter range count search  
+  ciIds <- getChatItemIDs db user cInfo contentFilter range count search
   ts <- liftIO getCurrentTime
   cis <- liftIO $ mapM (safeGetDirectItem db user ct ts) ciIds
   pure $ Chat cInfo (reverse cis) emptyChatStats
@@ -1325,8 +1317,8 @@ getDirectChatAround' db user ct@Contact {contactId} contentFilter aroundId count
   aroundCI <- getDirectChatItem db user contactId aroundId
   let cInfo = DirectChat ct
       range r = r (ciCreatedAt aroundCI) (cChatItemId aroundCI)
-  beforeIds <- getChatItemIDs db user cInfo contentFilter (range CRBefore) count search  
-  afterIds <- getChatItemIDs db user cInfo contentFilter (range CRAfter) count search  
+  beforeIds <- getChatItemIDs db user cInfo contentFilter (range CRBefore) count search
+  afterIds <- getChatItemIDs db user cInfo contentFilter (range CRAfter) count search
   ts <- liftIO getCurrentTime
   beforeCIs <- liftIO $ mapM (safeGetDirectItem db user ct ts) beforeIds
   afterCIs <- liftIO $ mapM (safeGetDirectItem db user ct ts) afterIds
@@ -2827,60 +2819,39 @@ updateGroupChatItemModerated db User {userId} GroupInfo {groupId} ci m@GroupMemb
       (deletedTs, groupMemberId, toContent, toText, currentTs, userId, groupId, itemId)
   pure ci {content = toContent, meta = (meta ci) {itemText = toText, itemDeleted = Just (CIModerated (Just deletedTs) m), editable = False, deletable = False}, formattedText = Nothing}
 
-deleteMemberCIs :: DB.Connection -> User -> GroupInfo -> GroupMember -> IO ()
-deleteMemberCIs db User {userId} GroupInfo {groupId, membership} member = do
-  items <- selectItems
-  let itemMemberId = memberId' member
+updateMemberCIsModerated :: MsgDirectionI d => DB.Connection -> User -> GroupInfo -> GroupMember -> GroupMember -> SMsgDirection d -> UTCTime -> IO ()
+updateMemberCIsModerated db User {userId} GroupInfo {groupId, membership} member byGroupMember md deletedTs = do
+  itemIds <- updateCIs =<< getCurrentTime
 #if defined(dbPostgres)
-  let itemIds = map fst items
-      sharedMsgIds = mapMaybe snd items
-  unless (null itemIds) $ do
-    DB.execute
-      db
-      [sql|
-        DELETE FROM messages WHERE message_id IN (
-          SELECT message_id FROM chat_item_messages WHERE chat_item_id IN ?
-        )
-      |]
-      (Only (In itemIds))
-    DB.execute db "DELETE FROM chat_item_versions WHERE chat_item_id IN ?" (Only (In itemIds))
-  unless (null sharedMsgIds) $
-    DB.execute
-      db
-      "DELETE FROM chat_item_reactions WHERE group_id = ? AND shared_msg_id IN ? AND item_member_id IS NOT DISTINCT FROM ?"
-      (groupId, In sharedMsgIds, itemMemberId)
-  unless (null itemIds) $
-    DB.execute
-      db
-      "DELETE FROM chat_items WHERE user_id = ? AND group_id = ? AND chat_item_id IN ?"
-      (userId, groupId, In itemIds)
+  let inItemIds = Only $ In (map fromOnly itemIds)
+  DB.execute db "DELETE FROM messages WHERE message_id IN (SELECT message_id FROM chat_item_messages WHERE chat_item_id IN ?)" inItemIds
+  DB.execute db "DELETE FROM chat_item_versions WHERE chat_item_id IN ?" inItemIds
 #else
-  forM_ items $ \(itemId, itemSharedMsgId_) -> do
-    deleteChatItemMessages_ db itemId
-    deleteChatItemVersions_ db itemId
-    forM_ itemSharedMsgId_ $ \sharedMsgId ->
-      DB.execute
-        db
-        "DELETE FROM chat_item_reactions WHERE group_id = ? AND shared_msg_id = ? AND item_member_id IS NOT DISTINCT FROM ?"
-        (groupId, sharedMsgId, itemMemberId)
-    DB.execute
-      db
-      "DELETE FROM chat_items WHERE user_id = ? AND group_id = ? AND chat_item_id = ?"
-      (userId, groupId, itemId)
+  DB.executeMany db deleteChatItemMessagesQuery itemIds
+  DB.executeMany db "DELETE FROM chat_item_versions WHERE chat_item_id = ?" itemIds
 #endif
   where
-    selectItems :: IO [(ChatItemId, Maybe SharedMsgId)]
-    selectItems
-      | groupMemberId' member == groupMemberId' membership =
+    memId = groupMemberId' member
+    updateQuery =
+      [sql|
+        UPDATE chat_items
+        SET item_deleted = 1, item_deleted_ts = ?, item_deleted_by_group_member_id = ?, item_content = ?, item_text = ?, updated_at = ?
+        WHERE user_id = ? AND group_id = ?
+      |]
+    updateCIs :: UTCTime -> IO [Only Int64]
+    updateCIs currentTs
+      | memId == groupMemberId' membership =
           DB.query
             db
-            "SELECT chat_item_id, shared_msg_id FROM chat_items WHERE user_id = ? AND group_id = ? AND group_member_id IS NULL AND item_sent = 1"
-            (userId, groupId)
+            (updateQuery <> " AND group_member_id IS NULL AND item_sent = 1 RETURNING chat_item_id")
+            (columns :. (userId, groupId))
       | otherwise =
           DB.query
             db
-            "SELECT chat_item_id, shared_msg_id FROM chat_items WHERE user_id = ? AND group_id = ? AND group_member_id = ?"
-            (userId, groupId, groupMemberId' member)
+            (updateQuery <> " AND group_member_id = ? RETURNING chat_item_id")
+            (columns :. (userId, groupId, memId))
+      where
+        columns = (deletedTs, groupMemberId' byGroupMember, msgDirToModeratedContent_ md, ciModeratedText, currentTs)
 
 updateGroupCIBlockedByAdmin :: DB.Connection -> User -> GroupInfo -> ChatItem 'CTGroup d -> UTCTime -> IO (ChatItem 'CTGroup d)
 updateGroupCIBlockedByAdmin db User {userId} GroupInfo {groupId} ci deletedTs = do
@@ -3714,21 +3685,3 @@ getGroupHistoryItems db user@User {userId} g@GroupInfo {groupId} m count = do
             LIMIT ?
           |]
           (groupMemberId' m, userId, groupId, count)
-
-getGroupWebPreviewItems :: DB.Connection -> User -> GroupInfo -> Int -> IO [Either StoreError (CChatItem 'CTGroup)]
-getGroupWebPreviewItems db user@User {userId} g@GroupInfo {groupId} count = do
-  ciIds <-
-    map fromOnly
-      <$> DB.query
-        db
-        [sql|
-          SELECT i.chat_item_id
-          FROM chat_items i
-          WHERE i.user_id = ? AND i.group_id = ?
-            AND i.include_in_history = 1
-            AND i.item_deleted = 0
-          ORDER BY i.item_ts DESC, i.chat_item_id DESC
-          LIMIT ?
-        |]
-        (userId, groupId, count)
-  reverse <$> mapM (runExceptT . getGroupCIWithReactions db user g) ciIds

--- a/src/Simplex/Chat/Store/Postgres/Migrations/M20251230_strict_tables.hs
+++ b/src/Simplex/Chat/Store/Postgres/Migrations/M20251230_strict_tables.hs
@@ -22,5 +22,5 @@ DROP FUNCTION simplex_is_valid_text(BYTEA);
 down_m20251230_strict_tables :: Text
 down_m20251230_strict_tables =
   [r|
-ALTER TABLE calls ALTER COLUMN call_state TYPE BYTEA USING call_state::BYTEA;  
+ALTER TABLE calls ALTER COLUMN call_state TYPE BYTEA USING call_state::BYTEA;
 |]

--- a/src/Simplex/Chat/Store/Postgres/Migrations/M20260108_chat_indices.hs
+++ b/src/Simplex/Chat/Store/Postgres/Migrations/M20260108_chat_indices.hs
@@ -21,7 +21,7 @@ CREATE INDEX idx_chat_items_note_folder_msg_content_tag_created_at ON chat_items
   note_folder_id,
   msg_content_tag,
   created_at
-);  
+);
 |]
 
 down_m20260108_chat_indices :: Text

--- a/src/Simplex/Chat/Store/SQLite/Migrations/M20240430_ui_theme.hs
+++ b/src/Simplex/Chat/Store/SQLite/Migrations/M20240430_ui_theme.hs
@@ -8,7 +8,7 @@ import Database.SQLite.Simple.QQ (sql)
 m20240430_ui_theme :: Query
 m20240430_ui_theme =
   [sql|
-ALTER TABLE users ADD COLUMN ui_themes TEXT;  
+ALTER TABLE users ADD COLUMN ui_themes TEXT;
 ALTER TABLE contacts ADD COLUMN ui_themes TEXT;
 ALTER TABLE groups ADD COLUMN ui_themes TEXT;
 |]

--- a/src/Simplex/Chat/Store/SQLite/Migrations/M20260122_has_link.hs
+++ b/src/Simplex/Chat/Store/SQLite/Migrations/M20260122_has_link.hs
@@ -11,7 +11,7 @@ m20260122_has_link =
 UPDATE chat_items SET msg_content_tag = 'text' WHERE msg_content_tag = 'liveText';
 
 UPDATE chat_items SET msg_content_tag = CAST(msg_content_tag as TEXT) WHERE typeof(msg_content_tag) = 'blob';
-  
+
 ALTER TABLE chat_items ADD COLUMN has_link INTEGER NOT NULL DEFAULT 0;
 
 UPDATE chat_items SET has_link = 1


### PR DESCRIPTION
## What

Two small cleanups found while reading the codebase:

1. **README.md** – The Trail of Bits security audit link used `http://` instead of `https://`. Particularly ironic for a privacy/security-focused project — any reader clicking that link from an environment that does not follow redirects would make a plain-text request. Fixed to `https://`.

2. **Haskell source files** – 8 lines across 6 files had trailing whitespace (spaces after the last non-whitespace character). Removed:
   - `src/Simplex/Chat/Options.hs` (1 line)
   - `src/Simplex/Chat/Store/Messages.hs` (3 lines)
   - `src/Simplex/Chat/Store/Postgres/Migrations/M20251230_strict_tables.hs` (1 line)
   - `src/Simplex/Chat/Store/Postgres/Migrations/M20260108_chat_indices.hs` (1 line)
   - `src/Simplex/Chat/Store/SQLite/Migrations/M20240430_ui_theme.hs` (1 line)
   - `src/Simplex/Chat/Store/SQLite/Migrations/M20260122_has_link.hs` (1 line)

## Why

No behaviour change. The `http://` fix ensures the security audit link is served over TLS when followed directly. The trailing whitespace removal keeps the source clean and avoids diff noise in future edits.

I have read the CLA Document and I hereby sign the CLA

