### PR TITLE
docs: fix broken relative links in Czech and Polish READMEs

### DIFF
--- a/docs/lang/cs/README.md
+++ b/docs/lang/cs/README.md
@@ -1,6 +1,6 @@
-| Aktualizováno 07.02.2023 | Jazyky: CZ, [EN](/docs/README.md), [FR](/docs/lang/fr/README.md), [PL](/docs/lang/pl/README.md) |
+| Aktualizováno 07.02.2023 | Jazyky: CZ, [EN](/README.md), [FR](/docs/lang/fr/README.md), [PL](/docs/lang/pl/README.md) |
 
-<img src="images/simplex-chat-logo.svg" alt="SimpleX logo" width="100%">
+<img src="/images/simplex-chat-logo.svg" alt="SimpleX logo" width="100%">
 
 # SimpleX - první platforma pro zasílání zpráv, která neobsahuje žádné identifikační údaje uživatelů - 100% soukromá!
 
@@ -116,7 +116,7 @@ curl -o- https://raw.githubusercontent.com/simplex-chat/simplex-chat/stable/inst
 
 Po instalaci chatovacího klienta jednoduše spusťte `simplex-chat` z terminálu.
 
-![simplex-chat](./images/connection.gif)
+![simplex-chat](/images/connection.gif)
 
 Více informací o [instalaci a používání terminálové aplikace](./CLI.md).
 
@@ -164,8 +164,8 @@ Plánujeme brzy přidat:
 Můžete:
 
 - použít knihovnu SimpleX Chat k integraci funkcí chatu do svých mobilních aplikací.
-- vytvářet chatovací boty a služby v jazyce Haskell - viz [simple](./apps/simplex-bot/) a více [advanced chat bot example](./apps/simplex-bot-advanced/).
-- vytvářet chatovací boty a služby v libovolném jazyce se spuštěným terminálem SimpleX Chat CLI jako lokálním serverem WebSocket. Viz [TypeScript SimpleX Chat client](./packages/simplex-chat-client/) a [JavaScript chat bot example](./packages/simplex-chat-client/typescript/examples/squaring-bot.js).
+- vytvářet chatovací boty a služby v jazyce Haskell - viz [simple](/apps/simplex-bot/) a více [advanced chat bot example](/apps/simplex-bot-advanced/).
+- vytvářet chatovací boty a služby v libovolném jazyce se spuštěným terminálem SimpleX Chat CLI jako lokálním serverem WebSocket. Viz [TypeScript SimpleX Chat client](/packages/simplex-chat-client/) a [JavaScript chat bot example](/packages/simplex-chat-client/typescript/examples/squaring-bot.js).
 - spustit [simplex-chat terminal CLI](./CLI.md) pro provádění jednotlivých příkazů chatu, např. pro odesílání zpráv v rámci provádění shellových skriptů.
 
 Pokud uvažujete o vývoji s platformou SimpleX, obraťte se na nás pro případné rady a podporu.
@@ -304,7 +304,7 @@ Nikdy jsme neposkytli ani jsme nebyli požádáni o přístup k našim serverům
 
 Nezaznamenáváme IP adresy uživatelů a na našich serverech neprovádíme žádnou korelaci provozu. Pokud je pro vás bezpečnost na úrovni přenosu kritická, musíte pro přístup k serverům pro zasílání zpráv používat Tor nebo jinou podobnou síť. Klientské aplikace budeme vylepšovat, abychom omezili možnosti korelace provozu.
 
-Více informací naleznete v [Podmínky a zásady ochrany osobních údajů](./PRIVACY.md).
+Více informací naleznete v [Podmínky a zásady ochrany osobních údajů](/PRIVACY.md).
 
 ## Bezpečnostní kontakt
 
@@ -314,7 +314,7 @@ Jakákoli zjištění možných útoků korelace provozu umožňujících korelo
 
 ## Licence
 
-[AGPL v3](./LICENSE)
+[AGPL v3](/LICENSE)
 
 [<img src="https://github.com/simplex-chat/.github/blob/master/profile/images/apple_store.svg" alt="Aplikace iOS" height="42">](https://apps.apple.com/us/app/simplex-chat/id1605771084)
 &nbsp;

--- a/docs/lang/pl/README.md
+++ b/docs/lang/pl/README.md
@@ -6,11 +6,11 @@
 
 | 30/03/2023 | PL, [EN](/README.md), [FR](/docs/lang/fr/README.md), [CZ](/docs/lang/cs/README.md) |
 
-<img src="images/simplex-chat-logo.svg" alt="SimpleX logo" width="100%">
+<img src="/images/simplex-chat-logo.svg" alt="SimpleX logo" width="100%">
 
 # SimpleX - pierwszy komunikator bez jakichkolwiek identyfikatorów użytkowników - w 100% prywatny z założenia!
 
-[<img src="./images/trail-of-bits.jpg" height="100">](http://simplex.chat/blog/20221108-simplex-chat-v4.2-security-audit-new-website.html) &nbsp;&nbsp;&nbsp; [<img src="./images/privacy-guides.jpg" height="80">](https://www.privacyguides.org/en/real-time-communication/#simplex-chat) &nbsp;&nbsp;&nbsp; [<img src="./images/kuketz-blog.jpg" height="80">](https://www.kuketz-blog.de/simplex-eindruecke-vom-messenger-ohne-identifier/)
+[<img src="/images/trail-of-bits.jpg" height="100">](http://simplex.chat/blog/20221108-simplex-chat-v4.2-security-audit-new-website.html) &nbsp;&nbsp;&nbsp; [<img src="/images/privacy-guides.jpg" height="80">](https://www.privacyguides.org/en/real-time-communication/#simplex-chat) &nbsp;&nbsp;&nbsp; [<img src="/images/kuketz-blog.jpg" height="80">](https://www.kuketz-blog.de/simplex-eindruecke-vom-messenger-ohne-identifier/)
 
 ## Witamy w SimpleX Chat!
 
@@ -263,7 +263,7 @@ curl -o- https://raw.githubusercontent.com/simplex-chat/simplex-chat/stable/inst
 
 Po pobraniu klienta czatu można go uruchomić za pomocą polecenia `simplex-chat`.
 
-![simplex-chat](./images/connection.gif)
+![simplex-chat](/images/connection.gif)
 
 Przeczytaj więcej o [instalowaniu i używaniu terminalowej wersji czatu](./CLI.md).
 
@@ -317,8 +317,8 @@ Planujemy dodać:
 Możesz:
 
 - korzystać z biblioteki SimpleX Chat w celu zintegrowania funkcji czatu z aplikacjami mobilnymi.
-- tworzyć boty i usługi czatu w języku Haskell - zobacz [prosty](./apps/simplex-bot/) i bardziej [zaawansowany przykład bota czatu](./apps/simplex-bot-advanced/).
-- tworzenie chat botów i usług w dowolnym języku z wykorzystaniem terminala CLI SimpleX Chat jako lokalnego serwera WebSocket. Zobacz [TypeScript SimpleX Chat client](./packages/simplex-chat-client/) i [JavaScript chat bot example](./packages/simplex-chat-client/typescript/examples/squaring-bot.js).
+- tworzyć boty i usługi czatu w języku Haskell - zobacz [prosty](/apps/simplex-bot/) i bardziej [zaawansowany przykład bota czatu](/apps/simplex-bot-advanced/).
+- tworzenie chat botów i usług w dowolnym języku z wykorzystaniem terminala CLI SimpleX Chat jako lokalnego serwera WebSocket. Zobacz [TypeScript SimpleX Chat client](/packages/simplex-chat-client/) i [JavaScript chat bot example](/packages/simplex-chat-client/typescript/examples/squaring-bot.js).
 - uruchomić [simplex-chat w terminal ](./CLI.md), aby wykonywać poszczególne polecenia czatu, np. wysyłać wiadomości w ramach wykonywania skryptu powłoki.
 
 Jeśli chcesz rozwijać platformę SimpleX, skontaktuj się z nami, aby uzyskać porady i wsparcie.
@@ -409,7 +409,7 @@ Nigdy nie udostępnialiśmy ani nie byliśmy proszeni o dostęp do naszych serwe
 
 Nie rejestrujemy adresów IP użytkowników i nie przeprowadzamy żadnej korelacji ruchu na naszych serwerach. Jeśli bezpieczeństwo na poziomie transportu jest krytyczne, musisz użyć Tor lub innej podobnej sieci, aby uzyskać dostęp do serwerów wiadomości. Będziemy ulepszać aplikacje klienckie, aby zmniejszyć możliwości korelacji ruchu.
 
-Więcej informacji można znaleźć w [Warunkach i polityce prywatności](./PRIVACY.md).
+Więcej informacji można znaleźć w [Warunkach i polityce prywatności](/PRIVACY.md).
 
 ## Kontakt w sprawie bezpieczeństwa
 
@@ -419,7 +419,7 @@ Prosimy o traktowanie wszelkich ustaleń dotyczących możliwych ataków korelac
 
 ## Licencja
 
-[AGPL v3](./LICENSE)
+[AGPL v3](/LICENSE)
 
 [<img src="https://github.com/simplex-chat/.github/blob/master/profile/images/apple_store.svg" alt="iOS app" height="42">](https://apps.apple.com/us/app/simplex-chat/id1605771084)
 &nbsp;


### PR DESCRIPTION
## Summary
The Czech (`docs/lang/cs/README.md`) and Polish (`docs/lang/pl/README.md`) translated READMEs contain relative links that 404 on GitHub. They were copied from the root `README.md` but kept its `./`-relative paths, even though the translated files live two directories deeper under `docs/lang/<locale>/`. This switches them to root-absolute paths, matching the form the French README (`docs/lang/fr/README.md`) already uses for the same links.

## Problem
A `./images/...` (or bare `images/...`) link in `docs/lang/cs/README.md` resolves to `docs/lang/cs/images/...`, which does not exist — there is no `docs/lang/cs/images/` directory; the assets live at the repo-root `images/`. The same applies to `./apps/...`, `./packages/...`, `./PRIVACY.md`, `./LICENSE`, and the Czech language switcher's `[EN](/docs/README.md)` (there is no `docs/README.md`; the English README is at `/README.md`).

For example, in `docs/lang/cs/README.md`:

```md
| ... CZ, [EN](/docs/README.md), [FR](...), [PL](...) |     <!-- /docs/README.md does not exist -->
<img src="images/simplex-chat-logo.svg" ...>               <!-- -> docs/lang/cs/images/... (missing) -->
![simplex-chat](./images/connection.gif)                   <!-- -> docs/lang/cs/images/... (missing) -->
... [simple](./apps/simplex-bot/) ...                      <!-- -> docs/lang/cs/apps/... (missing) -->
[AGPL v3](./LICENSE)                                       <!-- -> docs/lang/cs/LICENSE (missing) -->
```

The French README already links these correctly, e.g. `docs/lang/fr/README.md`:

```md
| 30/03/2023 | FR, [EN](/README.md), [CZ](...), [PL](...) |
![simplex-chat](/images/connection.gif)
... [simple](/apps/simplex-bot/) ...
[AGPL v3](/LICENSE)
```

## Solution
Rewrite the broken links in the cs and pl READMEs to root-absolute paths so they resolve correctly on GitHub, mirroring the French translation:
- `cs`: language-switcher `[EN](/docs/README.md)` -> `[EN](/README.md)`, plus `./images|apps|packages|PRIVACY.md|LICENSE` and the bare `images/` logo `src` -> `/...`.
- `pl`: `./images|apps|packages|PRIVACY.md|LICENSE`, the bare `images/` logo `src`, and the three audit-badge `<img src="./images/*.jpg">` -> `/...`.

Same-directory links such as `./CLI.md` (which correctly point to the locale's own `docs/lang/<locale>/CLI.md`) are intentionally left unchanged. No prose or logic changes.

## Out of scope
- The bare `<img src="images/simplex-chat-logo.svg">` and `<img src="./images/*.jpg">` badge tags are *also* broken in `docs/lang/fr/README.md` (the markdown links there were fixed, but these HTML `<img>` tags were missed). I left the French file untouched to keep this PR focused on cs/pl; happy to send a follow-up for fr if useful.

## Test plan
- [x] Verified every target exists at the repo root via the `master` git tree (`images/connection.gif`, `images/simplex-chat-logo.svg`, `images/{trail-of-bits,privacy-guides,kuketz-blog}.jpg`, `apps/simplex-bot{,-advanced}`, `packages/simplex-chat-client[/typescript/examples/squaring-bot.js]`, `PRIVACY.md`, `LICENSE`, `README.md`).
- [x] Re-scanned both edited files: no remaining relative links resolve to a non-existent path; `./CLI.md` (same-dir) preserved.
- [ ] Maintainer to confirm the links render on GitHub.

## Related
- `docs/lang/fr/README.md` — the already-correct reference translation this PR mirrors.

Made with [Cursor](https://cursor.com)