### PR TITLE
feat: expand message reaction emoji set (🎉 🙏 👀 😮 🤔)

### DIFF
--- a/apps/ios/SimpleXChat/ChatTypes.swift
+++ b/apps/ios/SimpleXChat/ChatTypes.swift
@@ -4458,6 +4458,11 @@ public enum MREmojiChar: String, Codable, CaseIterable, Hashable {
     case heart = "❤"
     case launch = "🚀"
     case check = "✅"
+    case celebrate = "🎉"
+    case thanks = "🙏"
+    case eyes = "👀"
+    case surprise = "😮"
+    case thinking = "🤔"
 }
 
 extension MsgReaction: Decodable {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
@@ -4067,7 +4067,12 @@ sealed class MsgReaction {
       MREmojiChar.Sad,
       MREmojiChar.Heart,
       MREmojiChar.Launch,
-      MREmojiChar.Check
+      MREmojiChar.Check,
+      MREmojiChar.Celebrate,
+      MREmojiChar.Thanks,
+      MREmojiChar.Eyes,
+      MREmojiChar.Surprise,
+      MREmojiChar.Thinking
     ).map(::Emoji)
   }
 }
@@ -4124,7 +4129,12 @@ enum class MREmojiChar(val value: String) {
   @SerialName("😢") Sad("😢"),
   @SerialName("❤") Heart("❤"),
   @SerialName("🚀") Launch("🚀"),
-  @SerialName("✅") Check("✅");
+  @SerialName("✅") Check("✅"),
+  @SerialName("🎉") Celebrate("🎉"),
+  @SerialName("🙏") Thanks("🙏"),
+  @SerialName("👀") Eyes("👀"),
+  @SerialName("😮") Surprise("😮"),
+  @SerialName("🤔") Thinking("🤔");
 }
 
 @Serializable

--- a/src/Simplex/Chat/Protocol.hs
+++ b/src/Simplex/Chat/Protocol.hs
@@ -569,7 +569,7 @@ instance FromJSON MREmojiChar where
 
 mrEmojiChar :: Char -> Either String MREmojiChar
 mrEmojiChar c
-  | c `elem` ("👍👎😀😂😢❤️🚀✅" :: String) = Right $ MREmojiChar c
+  | c `elem` ("👍👎😀😂😢❤️🚀✅🎉🙏👀😮🤔" :: String) = Right $ MREmojiChar c
   | otherwise = Left "bad emoji"
 
 data FileChunk = FileChunk {chunkNo :: Integer, chunkBytes :: ByteString} | FileChunkCancel


### PR DESCRIPTION
## Summary

Expands the curated message reaction emoji set from 8 to 13 by adding five
commonly requested reactions that have no current equivalent.

Closes #7171

## New reactions added

| Emoji | Name | Sentiment |
|-------|------|-----------|
| 🎉 | Celebrate | Celebrating good news / a milestone |
| 🙏 | Thanks | Gratitude / acknowledgment |
| 👀 | Eyes | Seen / I'm watching / noted |
| 😮 | Surprise | Surprised / shocked |
| 🤔 | Thinking | Unsure / questioning |

## Changes

All three platform locations are updated in sync, as required:

- **`src/Simplex/Chat/Protocol.hs`** — added 5 new chars to the `mrEmojiChar` allowlist
- **`apps/ios/SimpleXChat/ChatTypes.swift`** — added 5 cases to the `MREmojiChar` enum (iOS picker uses `allCases` so they appear automatically)
- **`apps/multiplatform/common/.../ChatModel.kt`** — added 5 entries to `MREmojiChar` enum + appended to `MsgReaction.supported` (drives the Android/desktop picker)

## Backward compatibility

Older clients receiving any of these new reactions fall back to the existing
`MRUnknown` path — no crash, no render — identical to today's behaviour for
any unrecognised reaction. No migration or schema change required.

## Notes

All 5 emojis are single Unicode scalars with no variation-selector / ZWJ
sequences, consistent with the existing emoji set.

This is the minimal curated-set approach discussed in #7171, keeping the
low-clutter philosophy intact while filling clear sentiment gaps.
