### PR TITLE
Add 5 message reaction emojis (🎉 🙏 👀 😮 🤔)

### DIFF
--- a/apps/ios/SimpleXChat/ChatTypes.swift
+++ b/apps/ios/SimpleXChat/ChatTypes.swift
@@ -4458,6 +4458,11 @@ public enum MREmojiChar: String, Codable, CaseIterable, Hashable {
     case heart = "❤"
     case launch = "🚀"
     case check = "✅"
+    case celebrate = "🎉"
+    case pray = "🙏"
+    case eyes = "👀"
+    case surprise = "😮"
+    case thinking = "🤔"
 }
 
 extension MsgReaction: Decodable {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
@@ -4067,7 +4067,12 @@ sealed class MsgReaction {
       MREmojiChar.Sad,
       MREmojiChar.Heart,
       MREmojiChar.Launch,
-      MREmojiChar.Check
+      MREmojiChar.Check,
+      MREmojiChar.Celebrate,
+      MREmojiChar.Pray,
+      MREmojiChar.Eyes,
+      MREmojiChar.Surprise,
+      MREmojiChar.Thinking
     ).map(::Emoji)
   }
 }
@@ -4124,7 +4129,12 @@ enum class MREmojiChar(val value: String) {
   @SerialName("😢") Sad("😢"),
   @SerialName("❤") Heart("❤"),
   @SerialName("🚀") Launch("🚀"),
-  @SerialName("✅") Check("✅");
+  @SerialName("✅") Check("✅"),
+  @SerialName("🎉") Celebrate("🎉"),
+  @SerialName("🙏") Pray("🙏"),
+  @SerialName("👀") Eyes("👀"),
+  @SerialName("😮") Surprise("😮"),
+  @SerialName("🤔") Thinking("🤔");
 }
 
 @Serializable

--- a/src/Simplex/Chat/Protocol.hs
+++ b/src/Simplex/Chat/Protocol.hs
@@ -569,7 +569,7 @@ instance FromJSON MREmojiChar where
 
 mrEmojiChar :: Char -> Either String MREmojiChar
 mrEmojiChar c
-  | c `elem` ("👍👎😀😂😢❤️🚀✅" :: String) = Right $ MREmojiChar c
+  | c `elem` ("👍👎😀😂😢❤️🚀✅🎉🙏👀😮🤔" :: String) = Right $ MREmojiChar c
   | otherwise = Left "bad emoji"
 
 data FileChunk = FileChunk {chunkNo :: Integer, chunkBytes :: ByteString} | FileChunkCancel


### PR DESCRIPTION
## What

Adds 5 message reactions — 🎉 (celebrate), 🙏 (thanks), 👀 (seen), 😮 (surprise), 🤔 (thinking) — bringing the reaction set to 13.

Discussed in #7171.

## Why

Several common, *distinct* reaction sentiments have no current equivalent, so users send a full message just to react. This fills those gaps while keeping the curated, low-clutter set.

## Changes

The reaction set is validated in the core and mirrored per client, so it's updated in three places to stay in sync:
- `src/Simplex/Chat/Protocol.hs` — `mrEmojiChar` allowlist (source of truth)
- `apps/ios/SimpleXChat/ChatTypes.swift` — `MREmojiChar` enum (iOS picker = `allCases`)
- `apps/multiplatform/common/.../model/ChatModel.kt` — `MREmojiChar` enum + `MsgReaction.supported` (Android/desktop picker)

All additions are single Unicode scalars, byte-consistent across the three files.

## Compatibility

Older clients render any unrecognised reaction via the existing `MRUnknown` fallback (no render, no crash) — same as today.

## Notes

Happy to trim the set to whatever the team prefers. Related: #4014.

🤖 Generated with [Claude Code](https://claude.com/claude-code)