### PR TITLE
Reply to messages from notifications [android, desktop, iOS] 

### DIFF
--- a/apps/ios/Shared/Model/NtfManager.swift
+++ b/apps/ios/Shared/Model/NtfManager.swift
@@ -15,6 +15,7 @@ import SimpleXChat
 let ntfActionAcceptContact = "NTF_ACT_ACCEPT_CONTACT"
 let ntfActionAcceptCall = "NTF_ACT_ACCEPT_CALL"
 let ntfActionRejectCall = "NTF_ACT_REJECT_CALL"
+let ntfActionReply = "NTF_ACT_REPLY"
 
 private let ntfTimeInterval: TimeInterval = 1
 
@@ -39,8 +40,13 @@ class NtfManager: NSObject, UNUserNotificationCenterDelegate, ObservableObject {
     // Handle notification when app is in background
     func userNotificationCenter(_ center: UNUserNotificationCenter,
                                 didReceive response: UNNotificationResponse,
-                                withCompletionHandler handler: () -> Void) {
+                                withCompletionHandler handler: @escaping () -> Void) {
         logger.debug("NtfManager.userNotificationCenter: didReceive")
+        // quick reply is delivered to the app (not the NSE); sendReplyFromNotification calls handler() itself
+        if response.actionIdentifier == ntfActionReply {
+            sendReplyFromNotification(response, handler)
+            return
+        }
         if appStateGroupDefault.get() == .active {
             processNotificationResponse(response)
         } else {
@@ -84,6 +90,44 @@ class NtfManager: NSObject, UNUserNotificationCenterDelegate, ObservableObject {
         }
     }
 
+    // a non-foreground reply action launches the app in the background; take the core like the share
+    // extension does (ShareModel.send), send, and finish under a background task
+    func sendReplyFromNotification(_ response: UNNotificationResponse, _ handler: @escaping () -> Void) {
+        let content = response.notification.request.content
+        guard let textResponse = response as? UNTextInputNotificationResponse,
+              let chatId = content.targetContentIdentifier,
+              !textResponse.userText.isEmpty
+        else {
+            handler()
+            return
+        }
+        let text = textResponse.userText
+        let userId = content.userInfo["userId"] as? Int64
+        // finish() runs the handler and ends the bg task once; it is also the expiration handler, so it always runs
+        let finish = beginBGTask(handler)
+        if !ChatModel.shared.chatInitialized {
+            initChatAndMigrate()
+        }
+        startChatAndActivate {
+            Task {
+                if let userId = userId, userId != ChatModel.shared.currentUser?.userId {
+                    await MainActor.run { changeActiveUser(userId, viewPwd: nil) }
+                }
+                if let chat = ChatModel.shared.getChat(chatId),
+                   chat.chatInfo.chatType == .direct || chat.chatInfo.chatType == .group,
+                   chat.chatInfo.sendMsgEnabled {
+                    _ = await apiSendMessages(
+                        type: chat.chatInfo.chatType,
+                        id: chat.chatInfo.apiId,
+                        scope: chat.chatInfo.groupChatScope(),
+                        composedMessages: [ComposedMessage(msgContent: .text(text))]
+                    )
+                }
+                finish()
+            }
+        }
+    }
+
     private func ntfCallAction(_ content: UNNotificationContent, _ action: String) -> (ChatId, NtfCallAction)? {
         if content.categoryIdentifier == ntfCategoryCallInvitation,
            let chatId = content.userInfo["chatId"] as? String {
@@ -108,7 +152,7 @@ class NtfManager: NSObject, UNUserNotificationCenterDelegate, ObservableObject {
         let model = ChatModel.shared
         if UIApplication.shared.applicationState == .active {
             switch content.categoryIdentifier {
-            case ntfCategoryMessageReceived:
+            case ntfCategoryMessageReceived, ntfCategoryMessageReceivedReply:
                 let recent = recentInTheSameChat(content)
                 let userId = content.userInfo["userId"] as? Int64
                 if let userId = userId, let user = model.getUser(userId), !user.showNotifications {
@@ -177,6 +221,20 @@ class NtfManager: NSObject, UNUserNotificationCenterDelegate, ObservableObject {
             UNNotificationCategory(
                 identifier: ntfCategoryMessageReceived,
                 actions: [],
+                intentIdentifiers: [],
+                hiddenPreviewsBodyPlaceholder: NSLocalizedString("New message", comment: "notification")
+            ),
+            UNNotificationCategory(
+                identifier: ntfCategoryMessageReceivedReply,
+                actions: [
+                    UNTextInputNotificationAction(
+                        identifier: ntfActionReply,
+                        title: NSLocalizedString("Reply", comment: "notification action"),
+                        options: [.authenticationRequired],
+                        textInputButtonTitle: NSLocalizedString("Send", comment: "notification reply button"),
+                        textInputPlaceholder: NSLocalizedString("Message", comment: "notification reply placeholder")
+                    )
+                ],
                 intentIdentifiers: [],
                 hiddenPreviewsBodyPlaceholder: NSLocalizedString("New message", comment: "notification")
             ),

--- a/apps/ios/Shared/Views/UserSettings/NotificationsView.swift
+++ b/apps/ios/Shared/Views/UserSettings/NotificationsView.swift
@@ -17,6 +17,9 @@ struct NotificationsView: View {
     @State private var legacyDatabase = dbContainerGroupDefault.get() == .documents
     @State private var testing = false
     @State private var testedSuccess: Bool? = nil
+    @AppStorage(GROUP_DEFAULT_NTF_QUICK_REPLY, store: groupDefaults) private var ntfQuickReply = true
+    @AppStorage(GROUP_DEFAULT_NTF_QUICK_REPLY_WHEN_LOCKED, store: groupDefaults) private var ntfQuickReplyWhenLocked = false
+    @AppStorage(DEFAULT_PERFORM_LA) private var prefPerformLA = false
 
     var body: some View {
         ZStack {
@@ -77,6 +80,21 @@ struct NotificationsView: View {
                         .font(.callout)
                         .padding(.top, 1)
                 }
+            }
+
+            Section {
+                Toggle("Reply from notifications", isOn: $ntfQuickReply)
+                if ntfQuickReply && prefPerformLA {
+                    Toggle("Allow when locked", isOn: $ntfQuickReplyWhenLocked)
+                }
+            } header: {
+                Text("Quick reply")
+                    .foregroundColor(theme.colors.secondary)
+            } footer: {
+                Text("Reply to messages directly from notifications, without opening the app.")
+                    .foregroundColor(theme.colors.secondary)
+                    .font(.callout)
+                    .padding(.top, 1)
             }
         }
         .disabled(legacyDatabase)

--- a/apps/ios/SimpleXChat/AppGroup.swift
+++ b/apps/ios/SimpleXChat/AppGroup.swift
@@ -22,6 +22,8 @@ public let GROUP_DEFAULT_CHAT_LAST_BACKGROUND_RUN = "chatLastBackgroundRun"
 let GROUP_DEFAULT_NTF_PREVIEW_MODE = "ntfPreviewMode"
 public let GROUP_DEFAULT_NTF_ENABLE_LOCAL = "ntfEnableLocal" // no longer used
 public let GROUP_DEFAULT_NTF_ENABLE_PERIODIC = "ntfEnablePeriodic" // no longer used
+public let GROUP_DEFAULT_NTF_QUICK_REPLY = "ntfQuickReply"
+public let GROUP_DEFAULT_NTF_QUICK_REPLY_WHEN_LOCKED = "ntfQuickReplyWhenLocked"
 // replaces DEFAULT_PERFORM_LA
 let GROUP_DEFAULT_APP_LOCAL_AUTH_ENABLED = "appLocalAuthEnabled"
 public let GROUP_DEFAULT_ALLOW_SHARE_EXTENSION = "allowShareExtension"
@@ -73,6 +75,8 @@ public let groupDefaults = UserDefaults(suiteName: APP_GROUP_NAME)!
 public let groupAppDefaults: [String: Any] = [
     GROUP_DEFAULT_NTF_ENABLE_LOCAL: false,
     GROUP_DEFAULT_NTF_ENABLE_PERIODIC: false,
+    GROUP_DEFAULT_NTF_QUICK_REPLY: true,
+    GROUP_DEFAULT_NTF_QUICK_REPLY_WHEN_LOCKED: false,
     GROUP_DEFAULT_NETWORK_USE_ONION_HOSTS: OnionHosts.no.rawValue,
     GROUP_DEFAULT_NETWORK_SESSION_MODE: TransportSessionMode.session.rawValue,
     GROUP_DEFAULT_NETWORK_SMP_PROXY_MODE: SMPProxyMode.unknown.rawValue,
@@ -219,6 +223,10 @@ public let ntfPreviewModeGroupDefault = EnumDefault<NotificationPreviewMode>(
     forKey: GROUP_DEFAULT_NTF_PREVIEW_MODE,
     withDefault: .message
 )
+
+public let ntfQuickReplyGroupDefault = BoolDefault(defaults: groupDefaults, forKey: GROUP_DEFAULT_NTF_QUICK_REPLY)
+
+public let ntfQuickReplyWhenLockedGroupDefault = BoolDefault(defaults: groupDefaults, forKey: GROUP_DEFAULT_NTF_QUICK_REPLY_WHEN_LOCKED)
 
 public let incognitoGroupDefault = BoolDefault(defaults: groupDefaults, forKey: GROUP_DEFAULT_INCOGNITO)
 

--- a/apps/ios/SimpleXChat/Notifications.swift
+++ b/apps/ios/SimpleXChat/Notifications.swift
@@ -14,6 +14,7 @@ import SwiftUI
 public let ntfCategoryContactRequest = "NTF_CAT_CONTACT_REQUEST"
 public let ntfCategoryContactConnected = "NTF_CAT_CONTACT_CONNECTED"
 public let ntfCategoryMessageReceived = "NTF_CAT_MESSAGE_RECEIVED"
+public let ntfCategoryMessageReceivedReply = "NTF_CAT_MESSAGE_RECEIVED_REPLY"
 public let ntfCategoryCallInvitation = "NTF_CAT_CALL_INVITATION"
 public let ntfCategoryConnectionEvent = "NTF_CAT_CONNECTION_EVENT"
 public let ntfCategoryManyEvents = "NTF_CAT_MANY_EVENTS"
@@ -71,8 +72,15 @@ public func createMessageReceivedNtf(_ user: any UserLike, _ cInfo: ChatInfo, _ 
     } else {
         title = previewMode == .hidden ? contactHidden : "\(cInfo.chatViewName):"
     }
+    // offer inline reply only for a sendable direct/group chat with preview shown and quick reply on,
+    // and (when app-locked) reply-when-locked on
+    let quickReply = ntfQuickReplyGroupDefault.get()
+        && previewMode != .hidden
+        && (cInfo.chatType == .direct || cInfo.chatType == .group)
+        && cInfo.sendMsgEnabled
+        && (!appLocalAuthEnabledGroupDefault.get() || ntfQuickReplyWhenLockedGroupDefault.get())
     return createNotification(
-        categoryIdentifier: ntfCategoryMessageReceived,
+        categoryIdentifier: quickReply ? ntfCategoryMessageReceivedReply : ntfCategoryMessageReceived,
         title: title,
         body: previewMode == .message ? hideSecrets(cItem, isChannel: cInfo.isChannel) : NSLocalizedString("new message", comment: "notification"),
         targetContentIdentifier: cInfo.id,

--- a/apps/multiplatform/android/build.gradle.kts
+++ b/apps/multiplatform/android/build.gradle.kts
@@ -11,6 +11,13 @@ plugins {
 android {
     compileSdk = 35
 
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+            isReturnDefaultValues = true
+        }
+    }
+
     defaultConfig {
         applicationId = "chat.simplex.app"
         namespace = "chat.simplex.app"
@@ -151,6 +158,7 @@ dependencies {
     //implementation("androidx.compose.ui:ui-util:$compose_version")
 
     testImplementation("junit:junit:4.13.2")
+    testImplementation("org.robolectric:robolectric:4.14.1")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
     //androidTestImplementation("androidx.compose.ui:ui-test-junit4:$compose_version")

--- a/apps/multiplatform/android/src/main/java/chat/simplex/app/SimplexApp.kt
+++ b/apps/multiplatform/android/src/main/java/chat/simplex/app/SimplexApp.kt
@@ -192,7 +192,7 @@ class SimplexApp: Application(), LifecycleEventObserver {
       override fun hasNotificationsForChat(chatId: String): Boolean = NtfManager.hasNotificationsForChat(chatId)
       override fun cancelNotificationsForChat(chatId: String) = NtfManager.cancelNotificationsForChat(chatId)
       override fun cancelNotificationsForUser(userId: Long) = NtfManager.cancelNotificationsForUser(userId)
-      override fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String?, actions: List<Pair<NotificationAction, () -> Unit>>) = NtfManager.displayNotification(user, chatId, displayName, msgText, image, actions.map { it.first })
+      override fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String?, actions: List<Pair<NotificationAction, () -> Unit>>, canReply: Boolean) = NtfManager.displayNotification(user, chatId, displayName, msgText, image, actions.map { it.first }, canReply)
       override fun androidCreateNtfChannelsMaybeShowAlert() = NtfManager.createNtfChannelsMaybeShowAlert()
       override fun cancelCallNotification() = NtfManager.cancelCallNotification()
       override fun cancelAllNotifications() = NtfManager.cancelAllNotifications()

--- a/apps/multiplatform/android/src/main/java/chat/simplex/app/model/NtfManager.android.kt
+++ b/apps/multiplatform/android/src/main/java/chat/simplex/app/model/NtfManager.android.kt
@@ -12,6 +12,9 @@ import android.net.Uri
 import android.view.Display
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.core.app.*
+import androidx.core.app.Person
+import androidx.core.app.RemoteInput
+import androidx.core.graphics.drawable.IconCompat
 import chat.simplex.app.*
 import chat.simplex.app.TAG
 import chat.simplex.app.views.call.CallActivity
@@ -38,6 +41,9 @@ object NtfManager {
   const val CallNotificationId: Int = -1
   private const val UserIdKey: String = "userId"
   private const val ChatIdKey: String = "chatId"
+  private const val ReplyAction: String = "chat.simplex.app.NTF_REPLY"
+  private const val DismissAction: String = "chat.simplex.app.NTF_DISMISS"
+  private const val ReplyTextKey: String = "chat.simplex.app.NTF_REPLY_TEXT"
   private val appPreferences: AppPreferences = ChatController.appPrefs
   private val context: Context
     get() = SimplexApp.context
@@ -51,6 +57,15 @@ object NtfManager {
   // (UserId, ChatId) -> Time
   private var prevNtfTime = mutableMapOf<Pair<Long, ChatId>, Long>()
   private val msgNtfTimeoutMs = 30000L
+
+  // Per-chat conversation history for MessagingStyle re-rendering (also shows the sent reply).
+  // API 26-27 can't reliably extract MessagingStyle from a posted notification, so we keep our own.
+  private data class NtfMessage(val text: String, val time: Long, val fromSelf: Boolean)
+  private class ConversationNtf(val userId: Long, var displayName: String, var image: String?) {
+    val messages = ArrayDeque<NtfMessage>()
+  }
+  private const val maxNtfMessages = 8
+  private val conversations = java.util.concurrent.ConcurrentHashMap<ChatId, ConversationNtf>()
 
   init {
     if (areNotificationsEnabledInSystem()) createNtfChannelsMaybeShowAlert()
@@ -75,6 +90,7 @@ object NtfManager {
   fun cancelNotificationsForChat(chatId: String) {
     val key = prevNtfTime.keys.firstOrNull { it.second == chatId }
     prevNtfTime.remove(key)
+    conversations.remove(chatId)
     manager.cancel(chatId.hashCode())
     val msgNtfs = manager.activeNotifications.filter { ntf ->
       ntf.notification.channelId == MessageChannel
@@ -90,6 +106,7 @@ object NtfManager {
       prevNtfTime.remove(it)
       manager.cancel(it.second.hashCode())
     }
+    conversations.entries.removeAll { it.value.userId == userId }
     val msgNtfs = manager.activeNotifications.filter { ntf ->
       ntf.notification.channelId == MessageChannel
     }
@@ -99,7 +116,7 @@ object NtfManager {
     }
   }
 
-  fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String? = null, actions: List<NotificationAction> = emptyList()) {
+  fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String? = null, actions: List<NotificationAction> = emptyList(), canReply: Boolean = false) {
     if (!user.showNotifications) return
     Log.d(TAG, "notifyMessageReceived $chatId")
     val now = Clock.System.now().toEpochMilliseconds()
@@ -108,36 +125,48 @@ object NtfManager {
     val previewMode = appPreferences.notificationPreviewMode.get()
     val title = if (previewMode == NotificationPreviewMode.HIDDEN.name) generalGetString(MR.strings.notification_preview_somebody) else displayName
     val content = if (previewMode != NotificationPreviewMode.MESSAGE.name) generalGetString(MR.strings.notification_preview_new_message) else msgText
-    val largeIcon = when {
-      actions.isEmpty() -> null
-      image == null || previewMode == NotificationPreviewMode.HIDDEN.name -> BitmapFactory.decodeResource(context.resources, R.drawable.icon)
-      else -> base64ToBitmap(image).asAndroidBitmap()
-    }
+
     val builder = NotificationCompat.Builder(context, MessageChannel)
-      .setContentTitle(title)
-      .setContentText(content)
       .setPriority(NotificationCompat.PRIORITY_HIGH)
       .setGroup(MessageGroup)
       .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)
       .setSmallIcon(R.drawable.ntf_icon)
-      .setLargeIcon(largeIcon)
       .setColor(0x88FFFF)
       .setAutoCancel(true)
-      .setVibrate(if (actions.isEmpty()) null else longArrayOf(0, 250, 250, 250))
       .setContentIntent(chatPendingIntent(OpenChatAction, user.userId, chatId))
-      .setSilent(if (actions.isEmpty()) recentNotification else false)
 
-    for (action in actions) {
-      val flags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-      val actionIntent = Intent(SimplexApp.context, NtfActionReceiver::class.java)
-      actionIntent.action = action.name
-      actionIntent.putExtra(UserIdKey, user.userId)
-      actionIntent.putExtra(ChatIdKey, chatId)
-      val actionPendingIntent: PendingIntent = PendingIntent.getBroadcast(SimplexApp.context, 0, actionIntent, flags)
-      val actionButton = when (action) {
-        NotificationAction.ACCEPT_CONTACT_REQUEST -> generalGetString(MR.strings.accept)
+    if (canReply) {
+      // Inline reply: render the conversation as MessagingStyle and attach a RemoteInput reply action.
+      val convo = updateConversation(user.userId, chatId, title, image, content, now, fromSelf = false)
+      builder
+        .setStyle(messagingStyle(user.userId, chatId, convo))
+        .addAction(replyAction(user.userId, chatId))
+        .setDeleteIntent(dismissPendingIntent(chatId))
+        .setSilent(recentNotification)
+    } else {
+      val largeIcon = when {
+        actions.isEmpty() -> null
+        image == null || previewMode == NotificationPreviewMode.HIDDEN.name -> BitmapFactory.decodeResource(context.resources, R.drawable.icon)
+        else -> base64ToBitmap(image).asAndroidBitmap()
       }
-      builder.addAction(0, actionButton, actionPendingIntent)
+      builder
+        .setContentTitle(title)
+        .setContentText(content)
+        .setLargeIcon(largeIcon)
+        .setVibrate(if (actions.isEmpty()) null else longArrayOf(0, 250, 250, 250))
+        .setSilent(if (actions.isEmpty()) recentNotification else false)
+      for (action in actions) {
+        val flags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        val actionIntent = Intent(SimplexApp.context, NtfActionReceiver::class.java)
+        actionIntent.action = action.name
+        actionIntent.putExtra(UserIdKey, user.userId)
+        actionIntent.putExtra(ChatIdKey, chatId)
+        val actionPendingIntent: PendingIntent = PendingIntent.getBroadcast(SimplexApp.context, 0, actionIntent, flags)
+        val actionButton = when (action) {
+          NotificationAction.ACCEPT_CONTACT_REQUEST -> generalGetString(MR.strings.accept)
+        }
+        builder.addAction(0, actionButton, actionPendingIntent)
+      }
     }
     val summary = NotificationCompat.Builder(context, MessageChannel)
       .setSmallIcon(R.drawable.ntf_icon)
@@ -155,6 +184,111 @@ object NtfManager {
         notify(0, summary)
       }
     }
+  }
+
+  private fun updateConversation(userId: Long, chatId: ChatId, displayName: String, image: String?, text: String, time: Long, fromSelf: Boolean): ConversationNtf {
+    val convo = conversations.computeIfAbsent(chatId) { ConversationNtf(userId, displayName, image) }
+    synchronized(convo) {
+      convo.displayName = displayName
+      convo.image = image
+      convo.messages.addLast(NtfMessage(text, time, fromSelf))
+      while (convo.messages.size > maxNtfMessages) convo.messages.removeFirst()
+    }
+    return convo
+  }
+
+  private fun messagingStyle(userId: Long, chatId: ChatId, convo: ConversationNtf): NotificationCompat.MessagingStyle {
+    val self = Person.Builder()
+      .setName(generalGetString(MR.strings.notification_reply_you))
+      .setKey("self_$userId")
+      .build()
+    val hidePreview = appPreferences.notificationPreviewMode.get() == NotificationPreviewMode.HIDDEN.name
+    val senderIcon = convo.image
+      ?.takeIf { !hidePreview }
+      ?.let { runCatching { IconCompat.createWithBitmap(base64ToBitmap(it).asAndroidBitmap()) }.getOrNull() }
+    val sender = Person.Builder()
+      .setName(convo.displayName)
+      .setKey(chatId)
+      .apply { if (senderIcon != null) setIcon(senderIcon) }
+      .build()
+    val style = NotificationCompat.MessagingStyle(self)
+    synchronized(convo) {
+      convo.messages.forEach { m ->
+        style.addMessage(NotificationCompat.MessagingStyle.Message(m.text, m.time, if (m.fromSelf) null else sender))
+      }
+    }
+    return style
+  }
+
+  private fun replyAction(userId: Long, chatId: ChatId): NotificationCompat.Action {
+    val remoteInput = RemoteInput.Builder(ReplyTextKey)
+      .setLabel(generalGetString(MR.strings.notification_reply_hint))
+      .build()
+    val intent = Intent(SimplexApp.context, NtfActionReceiver::class.java)
+      .setAction(ReplyAction)
+      .putExtra(UserIdKey, userId)
+      .putExtra(ChatIdKey, chatId)
+    // FLAG_MUTABLE is required so the system can write the RemoteInput reply text into the intent.
+    // The target is an explicit, non-exported receiver, so a mutable PendingIntent is safe here.
+    val pendingIntent = PendingIntent.getBroadcast(
+      SimplexApp.context, chatId.hashCode(), intent,
+      PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+    )
+    return NotificationCompat.Action.Builder(R.drawable.ntf_icon, generalGetString(MR.strings.notification_reply_action), pendingIntent)
+      .addRemoteInput(remoteInput)
+      .setSemanticAction(NotificationCompat.Action.SEMANTIC_ACTION_REPLY)
+      .setShowsUserInterface(false)
+      .setAllowGeneratedReplies(true)
+      // require device unlock before delivering the reply on a locked device (API 31+, no-op below)
+      .setAuthenticationRequired(true)
+      .build()
+  }
+
+  private fun dismissPendingIntent(chatId: ChatId): PendingIntent {
+    val intent = Intent(SimplexApp.context, NtfActionReceiver::class.java)
+      .setAction(DismissAction)
+      .putExtra(ChatIdKey, chatId)
+    return PendingIntent.getBroadcast(
+      SimplexApp.context, "d:$chatId".hashCode(), intent,
+      PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+    )
+  }
+
+  // Re-posting the conversation notification under the same id clears the system inline-reply
+  // "Sending…" progress state. Built entirely from convo (the per-chat id is user-independent).
+  private fun postConversationNotification(chatId: ChatId, convo: ConversationNtf) {
+    val builder = NotificationCompat.Builder(context, MessageChannel)
+      .setPriority(NotificationCompat.PRIORITY_HIGH)
+      .setGroup(MessageGroup)
+      .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)
+      .setSmallIcon(R.drawable.ntf_icon)
+      .setColor(0x88FFFF)
+      .setAutoCancel(true)
+      .setOnlyAlertOnce(true)
+      .setSilent(true)
+      .setContentIntent(chatPendingIntent(OpenChatAction, convo.userId, chatId))
+      .setDeleteIntent(dismissPendingIntent(chatId))
+      .setStyle(messagingStyle(convo.userId, chatId, convo))
+      .addAction(replyAction(convo.userId, chatId))
+    with(NotificationManagerCompat.from(context)) {
+      if (ActivityCompat.checkSelfPermission(SimplexApp.context, android.Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) {
+        notify(chatId.hashCode(), builder.build())
+      }
+    }
+  }
+
+  fun onReplySent(chatId: ChatId, text: String) {
+    val convo = conversations[chatId] ?: return
+    val now = Clock.System.now().toEpochMilliseconds()
+    updateConversation(convo.userId, chatId, convo.displayName, convo.image, text, now, fromSelf = true)
+    postConversationNotification(chatId, convo)
+  }
+
+  fun onReplyFailed(chatId: ChatId) {
+    Log.e(TAG, "ntf reply failed for $chatId")
+    // Re-post without the failed text so the inline-reply progress state is cleared, then notify the user.
+    conversations[chatId]?.let { postConversationNotification(chatId, it) }
+    showMessage(generalGetString(MR.strings.notification_reply_failed_title), generalGetString(MR.strings.notification_reply_failed_desc))
   }
 
   fun notifyCallInvitation(invitation: RcvCallInvitation): Boolean {
@@ -314,6 +448,23 @@ object NtfManager {
       val chatId = intent?.getStringExtra(ChatIdKey) ?: return
       val m = SimplexApp.context.chatModel
       when (intent.action) {
+        ReplyAction -> {
+          val text = RemoteInput.getResultsFromIntent(intent)?.getCharSequence(ReplyTextKey)?.toString()
+          if (text.isNullOrBlank()) return
+          val pending = goAsync()
+          withBGApi {
+            try {
+              if (sendNtfReply(rhId = null, userId = userId, chatId = chatId, text = text)) onReplySent(chatId, text)
+              else onReplyFailed(chatId)
+            } catch (e: Throwable) {
+              Log.e(TAG, "ntf reply error: ${e.stackTraceToString()}")
+              onReplyFailed(chatId)
+            } finally {
+              pending.finish()
+            }
+          }
+        }
+        DismissAction -> conversations.remove(chatId)
         NotificationAction.ACCEPT_CONTACT_REQUEST.name -> ntfManager.acceptContactRequestAction(userId, incognito = false, chatId)
         RejectCallAction -> {
           val invitation = m.callInvitations[chatId]

--- a/apps/multiplatform/android/src/test/java/chat/simplex/app/NtfReplyRemoteInputTest.kt
+++ b/apps/multiplatform/android/src/test/java/chat/simplex/app/NtfReplyRemoteInputTest.kt
@@ -1,0 +1,65 @@
+package chat.simplex.app
+
+import android.app.Application
+import android.app.PendingIntent
+import android.content.Intent
+import android.os.Bundle
+import androidx.core.app.NotificationCompat
+import androidx.core.app.RemoteInput
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * Robolectric (JVM) contract test for the notification quick-reply RemoteInput mechanism.
+ *
+ * NtfManager itself can't be exercised here: it is an `object` whose init reads SimplexApp.context,
+ * which is only set after SimplexApp.onCreate -> initHaskell() loads the native core. So this test
+ * reproduces the reply-action construction the impl uses (NtfManager.android.kt: replyAction) and
+ * asserts the contract the receiver relies on — a mutable PendingIntent plus a RemoteInput keyed by
+ * the reply key whose typed result round-trips via getResultsFromIntent. The full displayNotification
+ * / NtfActionReceiver path is verified by the on-device runbook.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [34])
+class NtfReplyRemoteInputTest {
+  // must match NtfManager.ReplyTextKey
+  private val replyKey = "chat.simplex.app.NTF_REPLY_TEXT"
+
+  @Test
+  fun replyActionExposesRemoteInputAndRoundTripsTypedText() {
+    val ctx = RuntimeEnvironment.getApplication()
+    val intent = Intent(ctx, Application::class.java)
+      .setAction("chat.simplex.app.NTF_REPLY")
+      .putExtra("userId", 7L)
+      .putExtra("chatId", "@123")
+    val pendingIntent = PendingIntent.getBroadcast(
+      ctx, "@123".hashCode(), intent,
+      PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+    )
+    val remoteInput = RemoteInput.Builder(replyKey).setLabel("Message").build()
+    val action = NotificationCompat.Action.Builder(0, "Reply", pendingIntent)
+      .addRemoteInput(remoteInput)
+      .setSemanticAction(NotificationCompat.Action.SEMANTIC_ACTION_REPLY)
+      .setAllowGeneratedReplies(true)
+      .build()
+
+    // the action exposes exactly one RemoteInput, keyed by the reply key, tagged as a reply (Wear/Auto)
+    assertEquals(1, action.remoteInputs?.size)
+    assertEquals(replyKey, action.remoteInputs!![0].resultKey)
+    assertEquals(NotificationCompat.Action.SEMANTIC_ACTION_REPLY, action.semanticAction)
+
+    // the system writes the typed reply into the action's intent; the receiver reads it back by key
+    val results = Bundle().apply { putCharSequence(replyKey, "hello there") }
+    RemoteInput.addResultsToIntent(arrayOf(remoteInput), intent, results)
+    val extracted = RemoteInput.getResultsFromIntent(intent)
+    assertNotNull(extracted)
+    assertEquals("hello there", extracted!!.getCharSequence(replyKey)?.toString())
+    assertEquals("@123", intent.getStringExtra("chatId"))
+    assertEquals(7L, intent.getLongExtra("userId", -1L))
+  }
+}

--- a/apps/multiplatform/common/build.gradle.kts
+++ b/apps/multiplatform/common/build.gradle.kts
@@ -144,7 +144,8 @@ kotlin {
         }
         // For jSystemThemeDetector only
         implementation("net.java.dev.jna:jna-platform:5.14.0")
-        implementation("com.sshtools:two-slices:0.9.1")
+        // two-slices 0.9.7 adds ToastBuilder.input(...) for inline notification reply
+        implementation("com.sshtools:two-slices:0.9.7")
         implementation("org.slf4j:slf4j-simple:2.0.12")
         implementation("uk.co.caprica:vlcj:4.8.3")
         implementation("net.java.dev.jna:jna:5.14.0")

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
@@ -108,6 +108,8 @@ class AppPreferences {
   )  { NotificationsMode.values().firstOrNull { it.name == this } }
   val closeBehavior: SharedPreference<CloseBehavior> = mkSafeEnumPreference(SHARED_PREFS_DESKTOP_CLOSE_BEHAVIOR, CloseBehavior.default)
   val notificationPreviewMode = mkStrPreference(SHARED_PREFS_NOTIFICATION_PREVIEW_MODE, NotificationPreviewMode.default.name)
+  val ntfQuickReply = mkBoolPreference(SHARED_PREFS_NTF_QUICK_REPLY, true)
+  val ntfQuickReplyWhenLocked = mkBoolPreference(SHARED_PREFS_NTF_QUICK_REPLY_WHEN_LOCKED, false)
   val canAskToEnableNotifications = mkBoolPreference(SHARED_PREFS_CAN_ASK_TO_ENABLE_NOTIFICATIONS, true)
   val backgroundServiceNoticeShown = mkBoolPreference(SHARED_PREFS_SERVICE_NOTICE_SHOWN, false)
   val backgroundServiceBatteryNoticeShown = mkBoolPreference(SHARED_PREFS_SERVICE_BATTERY_NOTICE_SHOWN, false)
@@ -383,6 +385,8 @@ class AppPreferences {
     private const val SHARED_PREFS_RUN_SERVICE_IN_BACKGROUND = "RunServiceInBackground"
     private const val SHARED_PREFS_NOTIFICATIONS_MODE = "NotificationsMode"
     private const val SHARED_PREFS_NOTIFICATION_PREVIEW_MODE = "NotificationPreviewMode"
+    private const val SHARED_PREFS_NTF_QUICK_REPLY = "NtfQuickReply"
+    private const val SHARED_PREFS_NTF_QUICK_REPLY_WHEN_LOCKED = "NtfQuickReplyWhenLocked"
     private const val SHARED_PREFS_CAN_ASK_TO_ENABLE_NOTIFICATIONS = "CanAskToEnableNotifications"
     private const val SHARED_PREFS_SERVICE_NOTICE_SHOWN = "BackgroundServiceNoticeShown"
     private const val SHARED_PREFS_SERVICE_BATTERY_NOTICE_SHOWN = "BackgroundServiceBatteryNoticeShown"

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/platform/NtfManager.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/platform/NtfManager.kt
@@ -44,7 +44,13 @@ abstract class NtfManager {
               chatModel.chatId.value != cInfo.id ||
               chatModel.remoteHostId() != rhId)
     ) {
-      displayNotification(user = user, chatId = cInfo.id, displayName = cInfo.displayName, msgText = hideSecrets(cItem, cInfo.isChannel))
+      val replyAllowed = ntfReplyAllowed(
+        quickReplyEnabled = appPreferences.ntfQuickReply.get(),
+        appLockEnabled = appPreferences.performLA.get(),
+        allowWhenLocked = appPreferences.ntfQuickReplyWhenLocked.get()
+      )
+      val canReply = rhId == null && shouldOfferReply(replyAllowed, appPreferences.notificationPreviewMode.get(), cInfo)
+      displayNotification(user = user, chatId = cInfo.id, displayName = cInfo.displayName, msgText = hideSecrets(cItem, cInfo.isChannel), canReply = canReply)
     }
   }
 
@@ -99,14 +105,14 @@ abstract class NtfManager {
   abstract fun hasNotificationsForChat(chatId: String): Boolean
   abstract fun cancelNotificationsForChat(chatId: String)
   abstract fun cancelNotificationsForUser(userId: Long)
-  abstract fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String? = null, actions: List<Pair<NotificationAction, () -> Unit>> = emptyList())
+  abstract fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String? = null, actions: List<Pair<NotificationAction, () -> Unit>> = emptyList(), canReply: Boolean = false)
   abstract fun cancelCallNotification()
   abstract fun cancelAllNotifications()
   abstract fun showMessage(title: String, text: String)
   // Android only
   abstract fun androidCreateNtfChannelsMaybeShowAlert()
 
-  private suspend fun awaitChatStartedIfNeeded(chatModel: ChatModel, timeout: Long = 30_000) {
+  internal suspend fun awaitChatStartedIfNeeded(chatModel: ChatModel, timeout: Long = 30_000) {
     // Still decrypting database
     if (chatModel.chatRunning.value == null) {
       val step = 50L

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/platform/NtfReply.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/platform/NtfReply.kt
@@ -1,0 +1,55 @@
+package chat.simplex.common.platform
+
+import chat.simplex.common.model.*
+
+// Parses a stored notification chatId ("@123", "#45", "*7") into chat type + numeric api id.
+fun chatIdToChatTypeAndId(chatId: String): Pair<ChatType, Long>? {
+  val type = ChatType.values()
+    .filter { it.type.isNotEmpty() }
+    .sortedByDescending { it.type.length } // match "<@" before "@"
+    .firstOrNull { chatId.startsWith(it.type) } ?: return null
+  val id = chatId.removePrefix(type.type).toLongOrNull() ?: return null
+  return type to id
+}
+
+fun ntfReplyAllowed(quickReplyEnabled: Boolean, appLockEnabled: Boolean, allowWhenLocked: Boolean): Boolean =
+  quickReplyEnabled && (!appLockEnabled || allowWhenLocked)
+
+fun shouldOfferReply(replyAllowed: Boolean, previewModeName: String?, cInfo: ChatInfo): Boolean =
+  replyAllowed &&
+    previewModeName != NotificationPreviewMode.HIDDEN.name &&
+    (cInfo is ChatInfo.Direct || cInfo is ChatInfo.Group) &&
+    cInfo.sendMsgEnabled
+
+// Sends a plain-text reply to the chat identified by a notification's chatId.
+// Returns true on success. rhId is null (local host) for now.
+suspend fun sendNtfReply(rhId: Long?, userId: Long?, chatId: String, text: String): Boolean {
+  if (text.isBlank()) return false
+  val m = chatModel
+  // the reply may be delivered to a freshly cold-started process (after OOM kill / non-instant mode);
+  // wait for the chat controller before sending, as openChatAction does.
+  ntfManager.awaitChatStartedIfNeeded(m)
+  if (userId != null && userId != m.currentUser.value?.userId && m.currentUser.value != null) {
+    m.controller.changeActiveUser(rhId, userId, null)
+  }
+  val cInfo = m.getChat(chatId)?.chatInfo
+  if (cInfo != null && !cInfo.sendMsgEnabled) return false
+  val typeAndId = when {
+    cInfo != null -> cInfo.chatType to cInfo.apiId
+    else -> chatIdToChatTypeAndId(chatId) ?: return false
+  }
+  val composed = ComposedMessage(
+    fileSource = null,
+    quotedItemId = null,
+    msgContent = MsgContent.MCText(text),
+    mentions = emptyMap()
+  )
+  val sent = m.controller.apiSendMessages(
+    rh = rhId,
+    type = typeAndId.first,
+    id = typeAndId.second,
+    scope = null,
+    composedMessages = listOf(composed)
+  )
+  return !sent.isNullOrEmpty()
+}

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/NotificationsSettingsView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/NotificationsSettingsView.kt
@@ -1,6 +1,7 @@
 package chat.simplex.common.views.usersettings
 
 import SectionBottomSpacer
+import SectionDividerSpaced
 import SectionTextFooter
 import SectionView
 import SectionViewSelectable
@@ -40,6 +41,9 @@ fun NotificationsSettingsLayout(
   showNotificationsMode: () -> Unit,
 ) {
   val modes = remember { notificationModes() }
+  val appPrefs = ChatController.appPrefs
+  val performLA = remember { appPrefs.performLA.state }
+  val quickReply = remember { appPrefs.ntfQuickReply.state }
 
   ColumnWithScrollBar {
     AppBarTitle(stringResource(MR.strings.notifications))
@@ -58,6 +62,14 @@ fun NotificationsSettingsLayout(
     if (platform.androidIsXiaomiDevice() && (notificationsMode.value == NotificationsMode.PERIODIC || notificationsMode.value == NotificationsMode.SERVICE)) {
       SectionTextFooter(annotatedStringResource(MR.strings.xiaomi_ignore_battery_optimization))
     }
+    SectionDividerSpaced()
+    SectionView(null) {
+      SettingsPreferenceItem(null, stringResource(MR.strings.ntf_quick_reply), appPrefs.ntfQuickReply)
+      if (performLA.value && quickReply.value) {
+        SettingsPreferenceItem(null, stringResource(MR.strings.ntf_quick_reply_when_locked), appPrefs.ntfQuickReplyWhenLocked)
+      }
+    }
+    SectionTextFooter(stringResource(MR.strings.ntf_quick_reply_desc))
     SectionBottomSpacer()
   }
 }

--- a/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
+++ b/apps/multiplatform/common/src/commonMain/resources/MR/base/strings.xml
@@ -303,6 +303,14 @@
   <string name="notification_display_mode_hidden_desc">Hide contact and message</string>
   <string name="notification_preview_somebody">Contact hidden:</string>
   <string name="notification_preview_new_message">new message</string>
+  <string name="notification_reply_action">Reply</string>
+  <string name="notification_reply_hint">Message</string>
+  <string name="notification_reply_you">you</string>
+  <string name="notification_reply_failed_title">Could not send reply</string>
+  <string name="notification_reply_failed_desc">Open the app to try again.</string>
+  <string name="ntf_quick_reply">Reply from notifications</string>
+  <string name="ntf_quick_reply_when_locked">Allow when locked</string>
+  <string name="ntf_quick_reply_desc">Reply to messages directly from the notification without opening the app.</string>
   <string name="notification_new_contact_request">New contact request</string>
   <string name="notification_contact_connected">Connected</string>
   <string name="error_showing_desktop_notification">Error showing notification, contact developers.</string>

--- a/apps/multiplatform/common/src/commonTest/kotlin/chat/simplex/app/NtfReplyTest.kt
+++ b/apps/multiplatform/common/src/commonTest/kotlin/chat/simplex/app/NtfReplyTest.kt
@@ -1,0 +1,52 @@
+package chat.simplex.app
+
+import chat.simplex.common.model.ChatInfo
+import chat.simplex.common.model.ChatType
+import chat.simplex.common.model.NotificationPreviewMode
+import chat.simplex.common.platform.chatIdToChatTypeAndId
+import chat.simplex.common.platform.ntfReplyAllowed
+import chat.simplex.common.platform.shouldOfferReply
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class NtfReplyTest {
+  @Test
+  fun testChatIdParsing() {
+    assertEquals(ChatType.Direct to 123L, chatIdToChatTypeAndId("@123"))
+    assertEquals(ChatType.Group to 45L, chatIdToChatTypeAndId("#45"))
+    assertEquals(ChatType.Local to 7L, chatIdToChatTypeAndId("*7"))
+    assertNull(chatIdToChatTypeAndId("@"))      // no numeric id
+    assertNull(chatIdToChatTypeAndId("@abc"))   // non-numeric id
+    assertNull(chatIdToChatTypeAndId("123"))    // no type prefix
+  }
+
+  @Test
+  fun testNtfReplyAllowed() {
+    // lock off: follows quickReply flag
+    assertTrue(ntfReplyAllowed(quickReplyEnabled = true, appLockEnabled = false, allowWhenLocked = false))
+    assertFalse(ntfReplyAllowed(quickReplyEnabled = false, appLockEnabled = false, allowWhenLocked = false))
+    // lock on: requires opt-in
+    assertFalse(ntfReplyAllowed(quickReplyEnabled = true, appLockEnabled = true, allowWhenLocked = false))
+    assertTrue(ntfReplyAllowed(quickReplyEnabled = true, appLockEnabled = true, allowWhenLocked = true))
+    // master flag off always wins
+    assertFalse(ntfReplyAllowed(quickReplyEnabled = false, appLockEnabled = true, allowWhenLocked = true))
+  }
+
+  @Test
+  fun testShouldOfferReply() {
+    val direct = ChatInfo.Direct.sampleData       // writable direct chat fixture
+    val group = ChatInfo.Group.sampleData         // writable group chat fixture
+    val request = ChatInfo.ContactRequest.sampleData
+    val msg = NotificationPreviewMode.MESSAGE.name
+    val hidden = NotificationPreviewMode.HIDDEN.name
+
+    assertTrue(shouldOfferReply(replyAllowed = true, previewModeName = msg, cInfo = direct))
+    assertTrue(shouldOfferReply(replyAllowed = true, previewModeName = msg, cInfo = group))
+    assertFalse(shouldOfferReply(replyAllowed = false, previewModeName = msg, cInfo = direct))   // gate: setting
+    assertFalse(shouldOfferReply(replyAllowed = true, previewModeName = hidden, cInfo = direct)) // gate: preview
+    assertFalse(shouldOfferReply(replyAllowed = true, previewModeName = msg, cInfo = request))   // gate: type
+  }
+}

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/model/NtfManager.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/model/NtfManager.desktop.kt
@@ -94,19 +94,19 @@ object NtfManager {
     }
   }
 
-  fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String?, actions: List<Pair<NotificationAction, () -> Unit>>) {
+  fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String?, actions: List<Pair<NotificationAction, () -> Unit>>, canReply: Boolean = false) {
     if (!user.showNotifications) return
     Log.d(TAG, "notifyMessageReceived $chatId")
     val previewMode = appPreferences.notificationPreviewMode.get()
     val title = if (previewMode == NotificationPreviewMode.HIDDEN.name) generalGetString(MR.strings.notification_preview_somebody) else displayName
     val content = if (previewMode != NotificationPreviewMode.MESSAGE.name) generalGetString(MR.strings.notification_preview_new_message) else msgText
     val largeIcon = when {
-      actions.isEmpty() -> null
+      actions.isEmpty() && !canReply -> null
       image == null || previewMode == NotificationPreviewMode.HIDDEN.name -> MR.images.icon_foreground_common.image.toComposeImageBitmap()
       else -> base64ToBitmap(image)
     }
 
-    displayNotificationViaLib(user.userId, chatId, title, content, prepareIconPath(largeIcon), actions.map { it.first.name to it.second }) {
+    displayNotificationViaLib(user.userId, chatId, title, content, prepareIconPath(largeIcon), actions.map { it.first.name to it.second }, canReply) {
       ntfManager.openChatAction(user.userId, chatId)
     }
   }
@@ -118,6 +118,7 @@ object NtfManager {
     text: String,
     iconPath: String?,
     actions: List<Pair<String, () -> Unit>>,
+    canReply: Boolean = false,
     defaultAction: (() -> Unit)?
   ) {
     val builder = Toast.builder()
@@ -131,6 +132,17 @@ object NtfManager {
     }
     actions.forEach {
       builder.action(it.first, it.second)
+    }
+    if (canReply) {
+      val replyLabel = generalGetString(MR.strings.notification_reply_action)
+      if (ToasterFactory.getFactory().toaster().capabilities().contains(Capability.INPUT)) {
+        builder.input("reply", replyLabel, generalGetString(MR.strings.notification_reply_hint)) { replyText ->
+          withBGApi { sendNtfReply(rhId = null, userId = userId, chatId = chatId, text = replyText) }
+        }
+      } else {
+        // no inline input on this backend: fall back to opening the chat to reply
+        builder.action("reply", replyLabel) { ntfManager.openChatAction(userId, chatId) }
+      }
     }
     try {
       withBGApi {

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/AppCommon.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/AppCommon.desktop.kt
@@ -24,7 +24,7 @@ fun initApp() {
     override fun hasNotificationsForChat(chatId: String): Boolean = chat.simplex.common.model.NtfManager.hasNotificationsForChat(chatId)
     override fun cancelNotificationsForChat(chatId: String) = chat.simplex.common.model.NtfManager.cancelNotificationsForChat(chatId)
     override fun cancelNotificationsForUser(userId: Long) = chat.simplex.common.model.NtfManager.cancelNotificationsForUser(userId)
-    override fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String?, actions: List<Pair<NotificationAction, () -> Unit>>) = chat.simplex.common.model.NtfManager.displayNotification(user, chatId, displayName, msgText, image, actions)
+    override fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String?, actions: List<Pair<NotificationAction, () -> Unit>>, canReply: Boolean) = chat.simplex.common.model.NtfManager.displayNotification(user, chatId, displayName, msgText, image, actions, canReply)
     override fun androidCreateNtfChannelsMaybeShowAlert() {}
     override fun cancelCallNotification() {}
     override fun cancelAllNotifications() = chat.simplex.common.model.NtfManager.cancelAllNotifications()


### PR DESCRIPTION
Closes #2437 

Adds an inline "Reply" action to new message notifications so you can answer without opening the app (like Signal). Useful in general and especially on smartwatches.

Android's message notifications now use MessagingStyle with a RemoteInput reply action. 

Desktop uses the `two-slices` inline reply (input()) where the notification backend supports it, and falls back to focusing the window and chat where it doesn't. I added this capability in two-slices recentlt: https://github.com/sshtools/two-slices/pull/8

iOS adds a `UNTextInputNotificationAction` to the message category. The NSE can't send, so the typed reply is handled by the app launched in the background.

New "Reply from notifications" setting in notification settings. It's on by default; when app lock (SimpleX Lock / passcode) is enabled, replying from notifications is off unless you turn on "Allow when locked".
