### PR TITLE
ios, android, desktop: show member labels in groups

### DIFF
--- a/apps/ios/Shared/Views/Chat/Group/ChannelMembersView.swift
+++ b/apps/ios/Shared/Views/Chat/Group/ChannelMembersView.swift
@@ -59,12 +59,19 @@ struct ChannelMembersView: View {
                 .font(.caption).baselineOffset(2).kerning(-2)
                 .foregroundColor(theme.colors.secondary) + nameText
             : nameText
+        let shortDescr = member.shortDescr?.trimmingCharacters(in: .whitespacesAndNewlines)
         let row = HStack {
             MemberProfileImage(member, size: 38)
                 .padding(.trailing, 2)
             VStack(alignment: .leading) {
                 NameWithBadge(displayName, member.nameBadge)
                     .lineLimit(1)
+                if let shortDescr = shortDescr, shortDescr != "" {
+                    Text(shortDescr)
+                        .font(.caption)
+                        .foregroundColor(theme.colors.secondary)
+                        .lineLimit(1)
+                }
                 if user {
                     Text("you")
                         .font(.caption)

--- a/apps/ios/Shared/Views/Chat/Group/GroupChatInfoView.swift
+++ b/apps/ios/Shared/Views/Chat/Group/GroupChatInfoView.swift
@@ -508,8 +508,15 @@ struct GroupChatInfoView: View {
                 // TODO server connection status
                 VStack(alignment: .leading) {
                     let t = Text(member.chatViewName).foregroundColor(member.memberIncognito ? .indigo : theme.colors.onBackground)
+                    let shortDescr = member.shortDescr?.trimmingCharacters(in: .whitespacesAndNewlines)
                     NameWithBadge((member.verified ? memberVerifiedShield + t : t), member.nameBadge)
                         .lineLimit(1)
+                    if let shortDescr = shortDescr, shortDescr != "" {
+                        Text(shortDescr)
+                            .lineLimit(1)
+                            .font(.caption)
+                            .foregroundColor(theme.colors.secondary)
+                    }
                     (user ? Text ("you: ") + Text(member.memberStatus.shortText) : Text(memberConnStatus(member)))
                         .lineLimit(1)
                         .font(.caption)

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupChatInfoView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupChatInfoView.kt
@@ -1095,6 +1095,7 @@ fun MemberRow(member: GroupMember, user: Boolean = false, infoPage: Boolean = tr
       MemberProfileImage(size = MEMBER_ROW_AVATAR_SIZE, member, async = true)
       Spacer(Modifier.width(DEFAULT_PADDING_HALF))
       Column {
+        val shortDescr = member.shortDescr?.trim().orEmpty()
         Row(verticalAlignment = Alignment.CenterVertically) {
           if (member.verified) {
             MemberVerifiedShield()
@@ -1104,6 +1105,16 @@ fun MemberRow(member: GroupMember, user: Boolean = false, infoPage: Boolean = tr
             member.nameBadge,
             maxLines = 1, overflow = TextOverflow.Ellipsis,
             color = if (member.memberIncognito) Indigo else Color.Unspecified
+          )
+        }
+
+        if (shortDescr.isNotEmpty()) {
+          Text(
+            shortDescr,
+            color = MaterialTheme.colors.secondary,
+            fontSize = 12.sp,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
           )
         }
 


### PR DESCRIPTION
## Summary
- show each group member profile `shortDescr` as a one-line label in Android/Desktop group member rows
- show the same one-line label in iOS group and channel member rows
- leave existing member detail description rendering unchanged

Fixes #7178

## Tests
- `git diff --check`
- `./gradlew :common:compileKotlinMetadata --dry-run` (fails during configuration: Android SDK location is not configured via `ANDROID_HOME` or `apps/multiplatform/local.properties`)
- `xcodebuild -list -project apps/ios/SimpleX.xcodeproj`
- `xcodebuild -project apps/ios/SimpleX.xcodeproj -scheme "SimpleX (iOS)" -configuration Debug -sdk iphonesimulator -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build` (interrupted after package targets and `SimpleXChat` compilation began; only pre-existing Swift warnings were observed before interruption)