### PR TITLE
Convert oklch() colors to Display P3 color space

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/ui/theme/Color.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/ui/theme/Color.kt
@@ -10,7 +10,7 @@ import kotlin.math.sin
 
 fun oklch(L: Float, C: Float, H: Float, alpha: Float = 1f): Color {
   val hRad = H * (Math.PI.toFloat() / 180f)
-  return Color(L, C * cos(hRad), C * sin(hRad), alpha, ColorSpaces.Oklab)
+  return Color(L, C * cos(hRad), C * sin(hRad), alpha, ColorSpaces.Oklab).convert(ColorSpaces.DisplayP3)
 }
 
 val Indigo = Color(0xFF9966FF)


### PR DESCRIPTION
oklch() currently builds colors in the Oklab color space, which gets clamped to sRGB when rendered — so saturated colors lose vibrancy on wide-gamut (P3) screens. This appends .convert(ColorSpaces.DisplayP3) so they render at full gamut where the display supports it.

This is your existing color-space fix that isn't on master yet — bringing it in as the base for the upcoming SIMPLEX theme changes. Single line, cherry-picked from the original commit.