### PR TITLE
docs: add Python SDK and bot ecosystem entries

### DIFF
--- a/bots/README.md
+++ b/bots/README.md
@@ -205,3 +205,4 @@ If you have to run your bot on another machine, you need to secure access to bot
 - [Moderation bot](https://github.com/NCalex42/simplex-bot) (Java)
 - [Matterbridge bot](https://github.com/UnkwUsr/matterbridge-simplex) (JavaScript)
 - [Nodify](https://nodify.ie) (Low-Code)
+- [simplex-mcp-server](https://github.com/JnanaSrota/simplex-mcp-server) - MCP server for SimpleX Chat, letting any LLM send and list contacts (uses simplex-chat-py).

--- a/bots/README.md
+++ b/bots/README.md
@@ -205,3 +205,4 @@ If you have to run your bot on another machine, you need to secure access to bot
 - [Moderation bot](https://github.com/NCalex42/simplex-bot) (Java)
 - [Matterbridge bot](https://github.com/UnkwUsr/matterbridge-simplex) (JavaScript)
 - [Nodify](https://nodify.ie) (Low-Code)
+- [simplex-ai-bot](https://github.com/JnanaSrota/simplex-ai-bot) - AI assistant bot powered by Groq, with per-contact history and /reset.

--- a/bots/README.md
+++ b/bots/README.md
@@ -205,3 +205,4 @@ If you have to run your bot on another machine, you need to secure access to bot
 - [Moderation bot](https://github.com/NCalex42/simplex-bot) (Java)
 - [Matterbridge bot](https://github.com/UnkwUsr/matterbridge-simplex) (JavaScript)
 - [Nodify](https://nodify.ie) (Low-Code)
+- [simplex-chat-py](https://pypi.org/project/simplex-chat-py/) — Python SDK for the SimpleX Chat bot API with examples and unit tests.


### PR DESCRIPTION
Adds community Python ecosystem projects to bots/README.md.

Included:
- simplex-chat-py — Python SDK for the SimpleX Chat bot API.
- simplex-mcp-server — MCP server for SimpleX Chat built on simplex-chat-py.
- simplex-ai-bot — AI assistant bot using Groq with per-contact history.

Adding these per the README note that community bots and SDKs are welcome.