### PR TITLE
core, android, desktop, ios: make links with non-ASCII characters clickable

### DIFF
--- a/apps/ios/Shared/Views/Chat/ChatItem/CILinkView.swift
+++ b/apps/ios/Shared/Views/Chat/ChatItem/CILinkView.swift
@@ -103,11 +103,20 @@ func showInvalidLinkAlert(_ uri: String, error: String? = nil) {
 
 func sanitizeUri(_ s: String) -> (url: (uri: URL, sanitizedUri: URL?)?, error: String?) {
     let parsed = parseSanitizeUri(s, safe: false)
-    return if let uri = URL(string: s), let uriInfo = parsed?.uriInfo {
-        (url: (uri: uri, sanitizedUri: uriInfo.sanitized.flatMap { URL(string: $0) }), error: nil)
+    return if let uri = urlForOpening(s), let uriInfo = parsed?.uriInfo {
+        (url: (uri: uri, sanitizedUri: uriInfo.sanitized.flatMap { urlForOpening($0) }), error: nil)
     } else {
         (url: nil, error: parsed?.parseError)
     }
+}
+
+// non-ASCII characters make a link an IRI, not a URI; on iOS < 17 URL(string:) rejects it.
+// Percent-encode the non-ASCII octets (RFC 3987) as a fallback. Identity for ASCII input.
+private func urlForOpening(_ s: String) -> URL? {
+    if let url = URL(string: s) { return url }
+    var allowed = CharacterSet()
+    allowed.insert(charactersIn: UnicodeScalar(UInt8(0)) ... UnicodeScalar(UInt8(127)))
+    return s.addingPercentEncoding(withAllowedCharacters: allowed).flatMap { URL(string: $0) }
 }
 
 struct LargeLinkPreview_Previews: PreviewProvider {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/TextItemView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/TextItemView.kt
@@ -525,13 +525,26 @@ fun openBrowserAlert(uri: String, uriHandler: UriHandler) {
 
 fun safeOpenUri(uri: String, uriHandler: UriHandler) {
   try {
-    uriHandler.openUri(uri)
+    uriHandler.openUri(encodeUriNonAscii(uri))
   } catch (e: Exception) {
     // It can happen, for example, when you click on a text 0.00001 but don't have any app that can catch
     // `tel:` scheme in url installed on a device (no phone app or contacts, maybe)
     Log.e(TAG, "Open url: ${e.stackTraceToString()}")
     showInvalidLinkAlert(uri, error = e.message)
   }
+}
+
+// non-ASCII characters make a link an IRI, not a URI; percent-encode the non-ASCII octets (RFC 3987)
+// so the link opens with strict URL parsers (e.g. java.net.URI on desktop). Identity for ASCII input.
+private fun encodeUriNonAscii(uri: String): String {
+  if (uri.all { it.code < 0x80 }) return uri
+  val hex = "0123456789ABCDEF"
+  val sb = StringBuilder()
+  for (b in uri.toByteArray(Charsets.UTF_8)) {
+    val i = b.toInt() and 0xFF
+    if (i < 0x80) sb.append(i.toChar()) else sb.append('%').append(hex[i shr 4]).append(hex[i and 0xF])
+  }
+  return sb.toString()
 }
 
 fun showInvalidLinkAlert(uri: String, error: String? = null) {

--- a/src/Simplex/Chat/Markdown.hs
+++ b/src/Simplex/Chat/Markdown.hs
@@ -371,8 +371,22 @@ markdownP = mconcat <$> A.many' fragmentP
     strEncodeText :: StrEncoding a => a -> Text
     strEncodeText = safeDecodeUtf8 . strEncode
 
+-- non-ASCII characters (e.g. in the path) make a link an IRI, not a URI, and uri-bytestring rejects them.
+-- percent-encoding non-ASCII octets converts the IRI to an equivalent URI (RFC 3987) so the link is recognized.
+percentEncodeNonAscii :: ByteString -> ByteString
+percentEncodeNonAscii = B.concatMap enc
+  where
+    enc c
+      | isAscii c = B.singleton c
+      | otherwise = B.pack ['%', hexDigit hi, hexDigit lo]
+      where
+        n = fromEnum c
+        hi = n `div` 16
+        lo = n `mod` 16
+    hexDigit d = "0123456789ABCDEF" `B.index` d
+
 parseUri :: ByteString -> Either Text U.URI
-parseUri s = case U.parseURI U.laxURIParserOptions s of
+parseUri s = case U.parseURI U.laxURIParserOptions (percentEncodeNonAscii s) of
   Left e -> Left $ "Invalid URI: " <> tshow e
   Right uri@U.URI {uriScheme = U.Scheme sch, uriAuthority}
     | sch /= "http" && sch /= "https" -> Left $ "Unsupported URI scheme: " <> safeDecodeUtf8 sch

--- a/tests/MarkdownTests.hs
+++ b/tests/MarkdownTests.hs
@@ -241,6 +241,13 @@ textWithUri = describe "text with Uri" do
     "example.academy" <==> uri "example.academy"
     "this is example.com" <==> "this is " <> uri "example.com"
     "x.com" <==> uri "x.com"
+    -- non-ASCII (IRI) links, see https://github.com/simplex-chat/simplex-chat/issues/7188
+    "https://www.aljazeera.net/sukoon/2018/1/22/مجموعة-السوائل-طريقك-إلى-نظرية-باومان"
+      <==> uri "https://www.aljazeera.net/sukoon/2018/1/22/مجموعة-السوائل-طريقك-إلى-نظرية-باومان"
+    "https://ru.wikipedia.org/wiki/Витамин" <==> uri "https://ru.wikipedia.org/wiki/Витамин"
+    "this is https://example.com/страница now" <==> "this is " <> uri "https://example.com/страница" <> " now"
+    "https://example.com/страница." <==> uri "https://example.com/страница" <> "."
+    "https://example.com/page#раздел" <==> uri "https://example.com/page#раздел"
   it "ignored as markdown" do
     "_https://simplex.chat" <==> "_https://simplex.chat"
     "this is _https://simplex.chat" <==> "this is _https://simplex.chat"
@@ -276,6 +283,7 @@ textWithHyperlink = describe "text with HyperLink without link text" do
     "For details [click here](https://example.com)" <==> "For details " <> web "click here" "https://example.com" "[click here](https://example.com)"
     "[example.com](https://example.com)" <==> web "example.com" "https://example.com" "[example.com](https://example.com)"
     "[example.com/page](https://example.com/page)" <==> web "example.com/page" "https://example.com/page" "[example.com/page](https://example.com/page)"
+    "[страница](https://example.com/страница)" <==> web "страница" "https://example.com/страница" "[страница](https://example.com/страница)"
     ("[Connect to me](" <> addr <> ")") <==> Markdown (simplexLinkFormat XLContact addr' ["smp6.simplex.im"] (Just "Connect to me")) ("[Connect to me](" <> addr <> ")")
   it "potentially spoofed link" do
     "[https://example.com](https://another.com)" <==> "[https://example.com](https://another.com)"


### PR DESCRIPTION
Fixes #7188.

