### PR TITLE
fix: use single-pane layout on narrow desktop windows

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/App.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/App.kt
@@ -164,12 +164,16 @@ fun MainScreen() {
             }
           }
           SetupClipboardListener()
-          if (appPlatform.isAndroid) {
-            AndroidWrapInCallLayout {
+          BoxWithConstraints {
+            if (appPlatform.isAndroid) {
+              AndroidWrapInCallLayout {
+                AndroidScreen(userPickerState)
+              }
+            } else if (maxWidth < 600.dp) {
               AndroidScreen(userPickerState)
+            } else {
+              DesktopScreen(userPickerState)
             }
-          } else {
-            DesktopScreen(userPickerState)
           }
         }
       }


### PR DESCRIPTION
## Summary
Fixes broken UI scaling on small-display Linux devices (e.g. phones running postmarketOS). The desktop app always used `DesktopScreen`'s fixed two/three-column layout with a hardcoded 388.dp chat-list column, regardless of actual window width — resulting in either an unusable 50/50 split or a barely-tappable chat list on narrow screens.

Fixes #7191

## Changes
- In `App.kt`, wrapped the screen-selection logic in `BoxWithConstraints` to read the current window width
- Changed the layout condition from `appPlatform.isAndroid` to `appPlatform.isAndroid || maxWidth < 600.dp`, so narrow desktop windows now fall back to `AndroidScreen`'s responsive single-pane layout instead of `DesktopScreen`
- No changes to `AndroidScreen` or `DesktopScreen` internals — only which one gets selected based on window width

## Testing
- Ran the Linux desktop build in a window resized below 600.dp width — chat list and chat view now stack in a single pane with proper animated transitions, instead of splitting into tiny side-by-side columns
- Resized the window back above 600.dp — confirmed `DesktopScreen`'s normal multi-column layout still renders correctly
- Verified on actual Android build that behavior is unchanged (still always uses `AndroidScreen`)