### PR TITLE
SIMPLEX theme: darker chat list and fainter dividers

### DIFF
--- a/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/views/chatlist/ChatListNavLinkView.android.kt
+++ b/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/views/chatlist/ChatListNavLinkView.android.kt
@@ -8,6 +8,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import chat.simplex.common.platform.onRightClick
+import chat.simplex.common.ui.theme.CurrentColors
+import chat.simplex.common.ui.theme.DefaultTheme
+import chat.simplex.common.ui.theme.oklch
 import chat.simplex.common.views.helpers.*
 
 @Composable
@@ -38,5 +41,11 @@ actual fun ChatListNavLinkLayout(
       DefaultDropdownMenu(showMenu, dropdownMenuItems = dropdownMenuItems)
     }
   }
-  Divider(Modifier.padding(horizontal = 8.dp))
+  // SIMPLEX uses a flat slightly-lighter-than-bg divider; other themes get Material default Divider color.
+  val activeThemeBase = CurrentColors.collectAsState().value.base
+  if (activeThemeBase == DefaultTheme.SIMPLEX) {
+    Divider(Modifier.padding(horizontal = 8.dp), color = oklch(0.2104f, 0.0407f, 276.40f)) // sRGB #131729
+  } else {
+    Divider(Modifier.padding(horizontal = 8.dp))
+  }
 }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/ui/theme/Theme.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/ui/theme/Theme.kt
@@ -645,6 +645,12 @@ fun themedBackgroundBrush(): Brush = Brush.linearGradient(
   Offset(Float.POSITIVE_INFINITY, 0f)
 )
 
+// Hairline dividers: SIMPLEX wants them fainter over its dark panels; every other
+// theme keeps Material's default (onSurface at 0.12 alpha), unchanged.
+@Composable
+fun dividerColor(): Color =
+  MaterialTheme.colors.onSurface.copy(alpha = if (CurrentColors.value.base == DefaultTheme.SIMPLEX) 0.05f else 0.12f)
+
 val DEFAULT_PADDING = 20.dp
 val DEFAULT_ONBOARDING_HORIZONTAL_PADDING = 25.dp
 val DEFAULT_SPACE_AFTER_ICON = 4.dp

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatInfoView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatInfoView.kt
@@ -1062,7 +1062,7 @@ fun InfoViewActionButton(
             icon,
             contentDescription = null,
             Modifier.size(22.dp * fontSizeSqrtMultiplier),
-            tint = if (disabledLook) MaterialTheme.colors.secondary else MaterialTheme.colors.onPrimary
+            tint = if (disabledLook) MaterialTheme.colors.secondary else if (CurrentColors.value.base == DefaultTheme.SIMPLEX) Color.White else MaterialTheme.colors.onPrimary
           )
         }
       }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
@@ -60,7 +60,7 @@ data class ItemSeparation(val timestamp: Boolean, val largeGap: Boolean, val dat
 @Composable
 fun ConnectInProgressView(s: String) {
   Surface(color = MaterialTheme.colors.background) {
-    Divider()
+    Divider(color = dividerColor())
     Row(
       Modifier
         .height(60.dp)
@@ -1713,7 +1713,7 @@ private fun SupportChatsCountToolbar(
         }
       }
     }
-    Divider(Modifier.align(Alignment.BottomStart))
+    Divider(Modifier.align(Alignment.BottomStart), color = dividerColor())
   }
 }
 

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ComposeView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ComposeView.kt
@@ -1637,7 +1637,7 @@ fun ComposeView(
     }
 
     Surface(color = MaterialTheme.colors.background, contentColor = MaterialTheme.colors.onBackground) {
-      Divider()
+      Divider(color = dividerColor())
       if (chat.chatInfo is ChatInfo.Group && chat.chatInfo.groupInfo.nextConnectPrepared) {
         if (chat.chatInfo.groupInfo.businessChat == null) {
           val isChannel = chat.chatInfo.groupInfo.useRelays
@@ -1656,7 +1656,7 @@ fun ComposeView(
       } else if (nextSendGrpInv.value) {
         Column {
           ContextSendMessageToConnect(generalGetString(MR.strings.compose_send_direct_message_to_connect))
-          Divider()
+          Divider(color = dividerColor())
           Row(Modifier.padding(end = 8.dp), verticalAlignment = Alignment.Bottom) {
             AttachmentAndCommandsButtons()
             SendMsgView_(

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
@@ -198,7 +198,7 @@ fun ChatListView(chatModel: ChatModel, userPickerState: MutableStateFlow<Animate
   }
   val searchText = rememberSaveable(stateSaver = TextFieldValue.Saver) { mutableStateOf(TextFieldValue("")) }
   val listState = rememberLazyListState(lazyListState.first, lazyListState.second)
-  Box(Modifier.fillMaxSize()) {
+  Box(Modifier.fillMaxSize().let { if (CurrentColors.value.base == DefaultTheme.SIMPLEX) it.background(oklch(0.1648f, 0.0358f, 276.77f)) else it }) {
     if (oneHandUI.value) {
       ChatListWithLoadingScreen(searchText, listState)
       Column(Modifier.align(Alignment.BottomCenter)) {
@@ -820,7 +820,7 @@ private fun ChatListSearchBar(listState: LazyListState, searchText: MutableState
       }
     }
     val oneHandUI = remember { appPrefs.oneHandUI.state }
-    Divider(Modifier.align(if (oneHandUI.value) Alignment.TopStart else Alignment.BottomStart))
+    Divider(Modifier.align(if (oneHandUI.value) Alignment.TopStart else Alignment.BottomStart), color = dividerColor())
   }
 }
 
@@ -949,7 +949,7 @@ private fun BoxScope.ChatList(searchText: MutableState<TextFieldValue>, listStat
         ) {
         if (oneHandUI.value) {
           Column(Modifier.consumeWindowInsets(WindowInsets.navigationBars).consumeWindowInsets(PaddingValues(bottom = AppBarHeight))) {
-            Divider()
+            Divider(color = dividerColor())
             TagsView(searchText)
             ChatListSearchBar(listState, searchText, searchShowingSimplexLink, searchChatFilteredBySimplexLink)
             Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.ime))
@@ -957,7 +957,7 @@ private fun BoxScope.ChatList(searchText: MutableState<TextFieldValue>, listStat
         } else {
           ChatListSearchBar(listState, searchText, searchShowingSimplexLink, searchChatFilteredBySimplexLink)
           TagsView(searchText)
-          Divider()
+          Divider(color = dividerColor())
         }
       }
     }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
@@ -198,7 +198,8 @@ fun ChatListView(chatModel: ChatModel, userPickerState: MutableStateFlow<Animate
   }
   val searchText = rememberSaveable(stateSaver = TextFieldValue.Saver) { mutableStateOf(TextFieldValue("")) }
   val listState = rememberLazyListState(lazyListState.first, lazyListState.second)
-  Box(Modifier.fillMaxSize().let { if (CurrentColors.value.base == DefaultTheme.SIMPLEX) it.background(oklch(0.1648f, 0.0358f, 276.77f)) else it }) {
+  val activeThemeBase = CurrentColors.collectAsState().value.base
+  Box(Modifier.fillMaxSize().let { if (activeThemeBase == DefaultTheme.SIMPLEX) it.background(oklch(0.1648f, 0.0358f, 276.77f)) else it }) {
     if (oneHandUI.value) {
       ChatListWithLoadingScreen(searchText, listState)
       Column(Modifier.align(Alignment.BottomCenter)) {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/DefaultTopAppBar.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/DefaultTopAppBar.kt
@@ -170,10 +170,11 @@ private fun BoxScope.AppBarDivider(onTop: Boolean, fixedAlpha: Boolean, connecti
         .align(if (onTop) Alignment.BottomStart else Alignment.TopStart)
         .graphicsLayer {
           alpha = if (!onTop || fixedAlpha) 1f else topTitleAlpha(false, connection, 1f)
-        }
+        },
+      color = dividerColor()
     )
   } else {
-    Divider(Modifier.align(if (onTop) Alignment.BottomStart else Alignment.TopStart))
+    Divider(Modifier.align(if (onTop) Alignment.BottomStart else Alignment.TopStart), color = dividerColor())
   }
 }
 

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/views/chatlist/ChatListNavLinkView.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/views/chatlist/ChatListNavLinkView.desktop.kt
@@ -12,6 +12,9 @@ import androidx.compose.ui.node.DelegatableNode
 import androidx.compose.ui.node.DrawModifierNode
 import androidx.compose.ui.unit.dp
 import chat.simplex.common.platform.onRightClick
+import chat.simplex.common.ui.theme.CurrentColors
+import chat.simplex.common.ui.theme.DefaultTheme
+import chat.simplex.common.ui.theme.oklch
 import chat.simplex.common.views.helpers.*
 
 object NoIndication : IndicationNodeFactory {
@@ -58,7 +61,13 @@ actual fun ChatListNavLinkLayout(
       }
     }
   }
-  if (selectedChat.value || nextChatSelected.value) {
+  val activeThemeBase = CurrentColors.collectAsState().value.base
+  // SIMPLEX uses a flat slightly-lighter-than-bg divider; other themes get the Material default.
+  if (activeThemeBase == DefaultTheme.SIMPLEX) {
+    val simplexDividerColor = oklch(0.2104f, 0.0407f, 276.40f) // sRGB #131729
+    if (selectedChat.value || nextChatSelected.value) Divider(color = simplexDividerColor)
+    else Divider(Modifier.padding(horizontal = 8.dp), color = simplexDividerColor)
+  } else if (selectedChat.value || nextChatSelected.value) {
     Divider()
   } else {
     Divider(Modifier.padding(horizontal = 8.dp))


### PR DESCRIPTION
On the SIMPLEX theme the chat list now sits on a darker panel, and the hairline dividers across the app — chat list, chat, message input and top bar — are fainter, matching the theme's dark, low-contrast look. Every other theme is unchanged.
