### PR TITLE
core: don't re-approve directory channels on stale publicGroupId

### DIFF
--- a/plans/2026-07-06-fix-directory-name-reapproval.md
+++ b/plans/2026-07-06-fix-directory-name-reapproval.md
@@ -74,6 +74,19 @@ is permanent → `groupUpdated` true every cycle → re-approval on repeat.
 is merely the *occasion* (the owner republishing the link) that surfaces the
 pre-existing `publicGroupId` staleness.
 
+The claim's round-trip fidelity — the one field that *changes* when a name is
+added, hence the last assumption behind the elimination — was verified: `ToField
+SimplexDomain = decodeLatin1 . strEncode` and `FromField = strDecode . encodeUtf8`
+(`simplexmq SimplexName.hs:127-129`); domains are ASCII, so the stored value is
+`strDecode (strEncode d)`, which equals `d` for a canonical (lower-cased) domain,
+and the link's domain is already canonical (it arrives via `StrJSON`/`strDecode`).
+Because the name sets `group_domain`, `toPublicGroupAccess` returns `Just` (not the
+degenerate empty-access→`Nothing` at `Shared.hs:726`), so the claim reconstructs
+equal. So every field except `publicGroupId` provably converges — the elimination
+is airtight, not "assuming fidelity". (The empty-access→`Nothing` degeneracy at
+`Shared.hs:726` is a separate latent asymmetry, unreachable here since a claim makes
+the access non-empty; out of scope.)
+
 ## 4. The fix (core, minimal): compare *content*, ignoring immutable identity
 
 `publicGroupId` is immutable cryptographic identity (`sha256(genesis root key)`,

--- a/plans/2026-07-06-fix-directory-name-reapproval.md
+++ b/plans/2026-07-06-fix-directory-name-reapproval.md
@@ -1,185 +1,168 @@
 # Fix: SimpleX directory re-approves a channel every 30 min after a blockchain name is added
 
-Status: proposed — **fix gated on a diagnostic step (see §5); root-cause delta not yet observed**
+Status: proposed — **root cause deduced from code (see §3); fix in core**
 Branch: `nd/fix-directory-names`
 Base: `origin/master` (`b38015c7b`)
 
+> This supersedes two earlier drafts of this plan that blamed the domain claim/proof.
+> Deep investigation showed that was a **red herring** — the claim/proof round-trips
+> and converges. The real non-convergent field is **`publicGroupId`**. See §3.
+
 ## 1. Problem
 
-After an owner adds a SimpleX name (blockchain domain claim) to a public
-channel, the SimpleX Directory service asks the owner to re-approve the channel
-**every 30 minutes, indefinitely**, with no changes on the owner's side. The
-channel keeps flipping to "hidden until approved."
+After an owner adds a SimpleX name (blockchain domain claim) to a public channel,
+the SimpleX Directory service asks the owner to re-approve the channel **every
+30 minutes, indefinitely**, with no changes on the owner's side. The channel keeps
+flipping to "hidden until approved."
 
-## 2. What is confirmed (facts, file:line)
+## 2. Confirmed trigger (facts, file:line)
 
-1. **The 30-min cadence is the directory's link-check timer.** `linkCheckInterval`
+1. **30-min cadence = the directory's link-check timer.** `linkCheckInterval`
    defaults to **1800 s** (`apps/simplex-directory-service/src/Directory/Options.hs:181`);
-   `linkCheckThread_` sleeps that long and enqueues a `DEGroupLinkCheck` for every
-   non-removed registered group (`.../Directory/Service.hs:199-211`).
+   `linkCheckThread_` sleeps that interval and enqueues a `DEGroupLinkCheck` for
+   every non-removed registered group (`.../Directory/Service.hs:199-211`).
+2. **`deGroupLinkCheck` re-approves iff `groupUpdated` is true** —
+   `when groupUpdated $ reapprove …` (`Service.hs:824`), flipping `GRSActive →
+   GRSPendingApproval` and re-sending for admin approval (`:843-854`).
+3. **`groupUpdated` is a whole-profile byte inequality** — the `Bool` returned by
+   `updateGroupFromLinkData`: `profileChanged = p /= groupProfile`
+   (`src/Simplex/Chat/Library/Internal.hs:1466-1482`), `p` = directory's *stored*
+   `GroupProfile`, `groupProfile` = profile from the *fetched* link short-link data.
+4. **The flag is behaviorally directory-only** — the mobile/desktop/iOS
+   `GroupLinkPlan.Known` variant does not carry it (`SimpleXAPI.kt:7158`; iOS
+   `AppAPITypes.swift`); only the directory consumes it (`Service.hs:824`, `:825`,
+   `:988`→`deReregistration:1043/1046`).
 
-2. **`DEGroupLinkCheck` re-approves iff `groupUpdated` is true.** `deGroupLinkCheck`
-   runs `APIConnectPlan` against the channel link and, on a `GLPKnown` plan, does
-   `when groupUpdated $ reapprove …` (`Service.hs:815-854`, trigger at `:824`),
-   which sets `GRSPendingApproval` and re-sends for admin approval.
+## 3. Root cause (deduced by elimination — code-confirmed)
 
-3. **`groupUpdated` is a whole-profile byte inequality.** It is the `Bool` returned
-   by `updateGroupFromLinkData`: `profileChanged = p /= groupProfile`
-   (`src/Simplex/Chat/Library/Internal.hs:1466-1482`), where `p` is the directory's
-   **stored** `GroupProfile` and `groupProfile` is the profile in the **fetched
-   link data**.
+Three independent traces close the case without needing a runtime diagnostic:
 
-4. **`groupUpdated` is behaviorally directory-only.** The mobile/desktop clients do
-   not even deserialize it: the client `GroupLinkPlan.Known` variant carries only
-   `groupInfo` — `class Known(val groupInfo: GroupInfo)`
-   (`apps/multiplatform/.../model/SimpleXAPI.kt:7158`; iOS
-   `apps/ios/Shared/Model/AppAPITypes.swift`, `enum GroupLinkPlan`). The only
-   consumers of the flag are in the directory service: re-approval (`Service.hs:824`),
-   listing refresh (`:825`), and owner re-registration (`:988` →
-   `deReregistration:1043,1046`). (All other `groupUpdated` matches in the tree are
-   an unrelated chat event, `RcvGroupEvent`/`CR.GroupUpdated`.)
+- **The fetched link profile is byte-identical across fetches.** It is served
+  verbatim from the owner's published, owner-authorized `LSET` blob via `LGET`
+  (`simplexmq` agent `getConnShortLink` → `decryptLinkData`); there is no
+  timestamp, per-fetch nonce, relay reconstruction, or server-computed member
+  count. Member count lives in `GroupShortLinkData.publicGroupData` (a sibling of
+  `groupProfile`) and drives `countChanged`, not `groupUpdated`. So the link side
+  cannot make `groupUpdated` flip on its own.
+- **Every `Eq`-relevant `GroupProfile` field except one is persisted by
+  `updateGroupProfile` and therefore converges** after the first store
+  (`Internal.hs:1471`). The single exception is **`publicGroupId`**
+  (`Types.hs:858`, part of `PublicGroupProfile`, `deriving Eq`): the UPDATE in
+  `updateGroupProfile` (`src/Simplex/Chat/Store/Groups.hs:2721-2732`) writes
+  `group_type, group_link, group_web_page, group_domain, domain_web_page,
+  allow_embedding, group_domain_proof, …` but **omits `public_group_id`**. It is
+  read back from the stored column (`Shared.hs:699`, `Groups.hs:2779`), and
+  `toPublicGroupProfile` returns `publicGroup = Nothing` unless `group_type` **and**
+  `group_link` **and** `public_group_id` are all present (`Shared.hs:713-716`).
+- **The domain claim/proof is not the cause.** `group_domain`/`group_domain_proof`
+  *are* persisted and round-trip symmetrically (`Shared.hs:721`/`:727`), so they
+  converge. In the group flow the proof is `Nothing` anyway (`SimplexDomainProof`
+  is never constructed in `src/`; group claims use `mkDomainClaim`, `proof = Nothing`,
+  `Names.hs:56`, `Commands.hs:5693`), and group verification is a separate scalar
+  column `group_domain_verified` (`Groups.hs:2740-2746`).
 
-## 3. What is NOT yet established
+**Deduction:** a *perpetual* re-approval requires a field that never reconciles.
+The link side is deterministic, and every field except `publicGroupId` converges
+after one store — so the only field that can hold `p /= groupProfile` forever is
+`publicGroupId`. It does so because the directory's stored `public_group_id` is
+**NULL / stale** and `updateGroupProfile` — the only function that syncs a group's
+profile from link data or `XGrpInfo` — cannot write that column.
 
-**Why the two profiles fail to converge every cycle is unproven.** An ordinary
-profile change self-corrects: when `profileChanged` is true,
-`updateGroupFromLinkData` writes the link profile to the DB (`Internal.hs:1471`),
-and the store round-trips the domain claim + proof faithfully
-(`group_domain_proof` column; symmetric `publicGroupAccessRow` /
-`toPublicGroupAccess`, `src/Simplex/Chat/Store/Shared.hs:721`/`:727`). So a
-one-time change re-approves **once** and then converges. A perpetual 30-min
-re-approval requires the directory's stored profile to be **permanently unequal**
-to the fetched link profile — and which field differs has **not been observed**.
+**Why the directory's `public_group_id` is NULL, and why it correlates with the
+name.** `public_group_id` is written in only three places, all *creation-time*:
+the two group INSERTs (`Groups.hs:405`, `:912`, from the profile's `publicGroup`)
+and `updateRelayGroupKeys` (`:2293`). If the directory joined the channel while it
+had no `publicGroupId` in its link profile (an older channel, or one that became a
+public/named channel later), its `public_group_id` was inserted NULL and can never
+be populated afterward. When the owner adds the SimpleX name, the owner republishes
+the link with a fully-populated `publicGroup` (`publicGroupId` + `publicGroupAccess`),
+so the fetched profile's `publicGroup` becomes `Just{…}` while the directory's
+stored copy stays `Nothing` — a permanent inequality, re-approved every 30 min.
 
-Two hypotheses were considered and both are insufficient as stated:
+**Confirmation step (cheap, not blocking):** on the affected directory,
+`SELECT public_group_id FROM group_profiles` joined to the channel's group should
+show NULL, while the link's `publicGroupId` is present.
 
-- **Relay drops the domain claim from the served link data**
-  (`src/Simplex/Chat/Library/Commands.hs:4326-4328` handles this case). But this
-  **converges after one cycle**: the directory stores the claim-less link profile,
-  and with no further owner change nothing restores the claim, so the next check
-  matches. It explains a single reapproval, not a repeat.
-- **A re-presented proof with a fresh nonce.** This does **not** apply to domain
-  claims. `PHTest`/`badgeProof` (fresh nonce per presentation) is the separate
-  *badge* feature, attached to `Profile.badge` (`Internal.hs:2085-2086`), not to
-  the domain claim. A `SimplexDomainProof`'s `presHeader` is **inside the signed
-  payload** (`Commands.hs:4869`, verified at `:4867`), so it cannot be re-presented
-  with a new nonce without re-signing by the owner — it is static. The group claim
-  is also frequently created with `proof = Nothing` (`mkDomainClaim`,
-  `src/Simplex/Chat/Names.hs:56`; used at `Commands.hs:5693`, `:1510`).
+## 4. The fix (core, minimal): let `updateGroupProfile` populate `public_group_id`
 
-So the correlation ("started right after adding a name") strongly implicates the
-domain claim as the differing field, but the **exact field and the reason it
-never converges are not yet demonstrated.** This plan therefore treats the fix as
-gated on a diagnostic.
+`updateGroupProfile` is missing a profile column that its sibling INSERT paths
+already persist. Add `public_group_id` to its UPDATE, **guarded by `COALESCE` so it
+only populates a currently-NULL value and never changes or erases an existing
+identity** (respecting `publicGroupId`'s immutability):
 
-## 4. Likely mechanism (hypothesis, to be confirmed)
-
-The differing field is the group profile's `publicGroup.publicGroupAccess.groupDomainClaim`
-(or its `proof`): the directory's stored copy and the fetched link copy carry
-different claim representations on every fetch, in a way that storing the link
-copy does not reconcile. Because the domain claim is verified **independently** —
-cryptographically + on-chain by `verifyEntityDomain` (`Commands.hs:4840`), with
-verification tracked in a *separate* field `group_domain_verified`
-(`Store/Groups.hs:2710-2713`) — it is not admin-moderated content and should never
-gate re-approval. The bug is that `groupUpdated` conflates "profile changed at
-all" (used to decide whether to *store* the fresh claim) with "profile changed in
-a way needing admin *re-moderation*" (used to decide re-approval).
-
-## 5. Required diagnostic (gate before the fix)
-
-Add a temporary log at the one comparison that flips everything,
-`Internal.hs:1482`, dumping the two profiles' domain claims when `profileChanged`
-fires, and run it against the affected channel across ≥2 link-check cycles:
-
-```haskell
--- temporary:
-when (p /= groupProfile) $ logInfo $ "linkcheck delta: stored=" <> tshow (claimOf p)
-                                   <> " link=" <> tshow (claimOf groupProfile)
+```sql
+-- src/Simplex/Chat/Store/Groups.hs, updateGroupProfile_ UPDATE:
+SET display_name = ?, full_name = ?, short_descr = ?, description = ?, image = ?,
+    group_type = ?, group_link = ?, public_group_id = COALESCE(public_group_id, ?),
+    group_web_page = ?, group_domain = ?, domain_web_page = ?, allow_embedding = ?,
+    group_domain_proof = ?, preferences = ?, member_admission = ?, updated_at = ?
 ```
 
-Decision:
-- **Delta is the domain claim, identical each cycle** → structural asymmetry;
-  apply §6 (proof redaction covers it if the delta is the proof; if the delta is
-  the whole claim, widen the redaction to the claim — decide from the log).
-- **Delta changes each cycle** → identify the varying field from the log; if it is
-  not the claim, this plan's fix does not apply and the diagnosis restarts here.
-
-The fix in §6 is only justified once the log shows the per-cycle delta is confined
-to the domain claim/proof.
-
-## 6. The fix (conditional on §5)
-
-In `updateGroupFromLinkData` (`Internal.hs`), keep storing on the full
-`profileChanged` (so the claim/proof and verification stay current), but report
-`groupUpdated` with the domain-claim **proof** redacted — reusing the codebase's
-existing proof-redaction idiom (`Types.hs:750` `clearProofs`; `Internal.hs:1265`
-`redactedDomain`), rather than new helpers:
+with the new `?` sourced exactly like the INSERT paths (`Groups.hs:384-385`):
 
 ```haskell
-        pure (g'', moderationChanged)      -- was: profileChanged
-  ...
-  where
-    profileChanged = p /= groupProfile     -- keep: still gates storing the fresh claim
-    -- A domain-claim change is verified independently (on-chain + owner signature)
-    -- and is not admin-moderated, so it must not trigger directory re-approval.
-    -- Redact the proof before comparing (same idiom as Types.clearProofs).
-    moderationChanged = redactProof p /= redactProof groupProfile
-    redactProof gp@GroupProfile {publicGroup} = gp {publicGroup = redactPg <$> publicGroup}
-    redactPg pg@PublicGroupProfile {publicGroupAccess} = pg {publicGroupAccess = redactAccess <$> publicGroupAccess}
-    redactAccess a@PublicGroupAccess {groupDomainClaim} =
-      a {groupDomainClaim = (\d -> d {proof = Nothing} :: SimplexDomainClaim) <$> groupDomainClaim}
+publicGroupId_ = case publicGroup of
+  Just PublicGroupProfile {publicGroupId} -> Just publicGroupId
+  Nothing -> Nothing
 ```
 
-Redacting **only the proof** (not the whole claim) is the surgical choice: it kills
-any proof-representation delta while still letting a genuine domain add/change
-register as a one-time change (which then converges). If §5 shows the delta is the
-whole claim (e.g. claim present vs absent every cycle), replace `redactAccess` with
-`groupDomainClaim = Nothing`; note this also suppresses the legitimate one-time
-reapproval on a name add.
+Effect: on the next link check, the directory's NULL `public_group_id` is populated
+from the authoritative link profile → its stored `publicGroup` reconstructs as
+`Just{…}` equal to the link's → `profileChanged` becomes false → re-approval stops.
 
-Storage keys off the full `profileChanged`, so the claim/proof and
-`setGroupDomainVerified` still update — by-name lookups and the verified badge stay
-correct.
+## 5. Why this is the most correct fix
 
-## 7. Why this is safe (given §5 confirms the delta)
+- **Fixes the actual root cause, and converges.** After one sync the profiles are
+  equal, so `groupUpdated` correctly reports "no change." Symptom and cause both go.
+- **It is a plain completeness fix.** The two INSERT paths and `updateRelayGroupKeys`
+  already persist `public_group_id`; `updateGroupProfile` omitting it is the bug.
+- **Safe under `COALESCE(public_group_id, ?)`** — it *only* fills a NULL. It never
+  changes a set identity, so it cannot corrupt a correct `publicGroupId`, and it
+  cannot be erased by a claim-less `XGrpInfo` (new value `Nothing` → keep old).
+  This preserves the "immutable identity" invariant while repairing missing data.
+- **General, not a directory workaround.** Any client whose `public_group_id` is
+  missing gets it repaired on the next profile sync; the fix is in shared core, as
+  intended, and needs no judgment about which fields are "moderatable."
+- **Blast radius is safe.** `updateGroupProfile` is widely called, but the only
+  behavioral change is *populating a NULL column when a profile carrying a
+  `publicGroupId` is stored* — a pure improvement for every caller.
 
-- **Directory-only blast radius** (fact, §2.4). All three consumers behave
-  correctly with the proof/claim excluded:
-  - `Service.hs:824` periodic re-approval → **fixed**.
-  - `Service.hs:988` → `deReregistration` (`:1043`/`:1046`) — an owner re-submitting a
-    name-only change gets "already listed" instead of forced re-approval.
-  - `Service.hs:825` `listingsUpdated` — minor trade-off: a name-only change no longer
-    *immediately* refreshes web-listing files (still refreshes on any real change or
-    member-count change). If prompt refresh matters, keep `:825` on the raw
-    `profileChanged` while `:824` uses `moderationChanged`.
-- **Moderation not weakened.** Re-approval still fires on any moderatable field
-  (name, description, image); only proof/claim deltas are excluded, and those are
-  independently verified.
+## 6. Alternative considered — and why not
 
-## 8. Residual behaviour (accepted)
+**Scope the re-approval comparison** (return `groupUpdated` from
+`updateGroupFromLinkData` computed over only the moderatable display fields,
+excluding `publicGroup`). This mirrors the contact path's `clearProofs` /
+`sameProfileContent` redaction (`Types.hs:747-750`, `:803`) and the existing
+`DirectoryTests` expectation that link-only changes must not re-approve
+(`tests/Bots/DirectoryTests.hs:296-326`). It would stop the re-approval — **but it
+only hides the symptom**: the stored `public_group_id` stays NULL, the profiles
+stay unequal, so `updateGroupFromLinkData` keeps calling `updateGroupProfile` every
+30 min to store a profile that never fully matches (idempotent churn), and any
+other consumer of the difference stays broken. §4 is preferred because it removes
+the inequality itself. (This scoping could still be added later as defense in depth
+for genuinely non-moderatable fields, but it is not needed for this bug.)
 
-If the claim/proof genuinely differs each cycle, the store branch re-writes the
-`group_profiles` row every 30 min. This is idempotent and does not thrash
-verification (`claimChanged` in `updateGroupProfile` compares the *domain*, not the
-proof — `Groups.hs:2708-2709`). A follow-up could skip the store on proof-only
-deltas; out of scope.
+## 7. Verification plan
 
-## 9. Verification plan
+1. Confirm on the affected directory that the channel's `public_group_id` is NULL
+   while the link carries a `publicGroupId` (validates §3; one SELECT).
+2. Apply §4.
+3. **Regression test** in `tests/Bots/DirectoryTests.hs` (sits alongside the
+   existing "link-only / whitespace-only must not re-approve" tests at `:296-326`):
+   register a channel whose stored `public_group_id` is NULL → add a SimpleX name /
+   populate the link `publicGroupId` → run ≥2 link checks → assert the registration
+   stays `GRSActive` (no `GRSPendingApproval`, no owner re-approval message). Also
+   assert the group's `public_group_id` is populated after the first check.
+4. Build the directory service (which statically links core); run the directory
+   test suite.
 
-1. Land the §5 diagnostic, capture the delta on the affected channel, confirm it is
-   the domain claim/proof, and choose proof-vs-whole-claim redaction from the log.
-2. Apply §6.
-3. **Regression test** in `tests/Bots/DirectoryTests.hs`: register a channel →
-   approve → add a SimpleX name → trigger ≥2 link checks → assert the registration
-   stays `GRSActive` (no `GRSPendingApproval`, no owner re-approval message).
-4. Build the directory service; run the directory test suite.
+## 8. Files touched
 
-## 10. Files touched
+- `src/Simplex/Chat/Store/Groups.hs` — `updateGroupProfile`: add
+  `public_group_id = COALESCE(public_group_id, ?)` to the UPDATE and thread the
+  `publicGroupId_` parameter (as the INSERT paths do). No other logic change.
+- `tests/Bots/DirectoryTests.hs` — add the name-added / NULL-`public_group_id`
+  no-reapproval regression test.
 
-- `src/Simplex/Chat/Library/Internal.hs` — `updateGroupFromLinkData`: return a
-  claim/proof-insensitive change flag (store logic unchanged). Temporary diagnostic
-  log removed before merge.
-- `tests/Bots/DirectoryTests.hs` — add the name-added-no-reapproval regression test.
-
-No schema, wire-format, or API changes. `GLPKnown.groupUpdated`'s type is unchanged;
-only its value semantics (directory-only consumer) are refined.
+No schema, wire-format, or API changes. `updateGroupProfile`'s signature is
+unchanged; it simply stops dropping a column it is already given.

--- a/plans/2026-07-06-fix-directory-name-reapproval.md
+++ b/plans/2026-07-06-fix-directory-name-reapproval.md
@@ -1,0 +1,184 @@
+# Fix: SimpleX directory re-approves a channel every 30 min after a blockchain name is added
+
+Status: proposed
+Branch: `nd/fix-directory-names`
+Base: `origin/master` (`b38015c7b`)
+
+## 1. Problem
+
+After an owner adds a SimpleX name (blockchain domain claim) to a public
+channel, the SimpleX Directory service repeatedly asks the owner to re-approve
+the channel **every 30 minutes, indefinitely**, with no changes on the owner's
+side. The channel keeps flipping to "hidden until approved."
+
+The 30-minute cadence is not a coincidence — it is the directory's own periodic
+link-check interval.
+
+## 2. Grounded diagnosis (facts, file:line)
+
+1. **The 30-min repeat is the directory's link-check timer.**
+   `linkCheckInterval` defaults to **1800 s** (`apps/simplex-directory-service/src/Directory/Options.hs:181`).
+   `linkCheckThread_` sleeps that long and enqueues a `DEGroupLinkCheck` event for
+   every non-removed registered group
+   (`apps/simplex-directory-service/src/Directory/Service.hs:199-211`).
+
+2. **`DEGroupLinkCheck` re-approves whenever `groupUpdated` is true.**
+   `deGroupLinkCheck` runs `APIConnectPlan` against the channel's link and, on a
+   `GLPKnown` plan, does `when groupUpdated $ reapprove …`
+   (`Service.hs:815-854`, trigger at `:824`), which sets `GRSPendingApproval` and
+   re-sends the channel for admin approval.
+
+3. **`groupUpdated` is a whole-profile byte inequality.**
+   It is the `Bool` returned by `updateGroupFromLinkData`, defined as
+   `profileChanged = p /= groupProfile`
+   (`src/Simplex/Chat/Library/Internal.hs:1466-1482`), where `p` is the
+   directory's **stored** `GroupProfile` and `groupProfile` is the profile inside
+   the **fetched link data**. This equality includes
+   `publicGroup.publicGroupAccess.groupDomainClaim` and its `proof`.
+
+4. **A normal profile change self-corrects after one cycle — so this is a
+   non-convergence bug specific to the domain claim.**
+   When `profileChanged` is true, `updateGroupFromLinkData` also writes the link
+   profile to the DB (`Internal.hs:1471`), and the store persists the domain claim
+   *and its proof* (`group_domain_proof` column,
+   `src/Simplex/Chat/Store/Groups.hs:2724`; write/read are symmetric —
+   `publicGroupAccessRow` / `toPublicGroupAccess`,
+   `src/Simplex/Chat/Store/Shared.hs:721` and `:727`). So an ordinary field change
+   (name/description/image) re-approves **once** and then converges. For the loop
+   to persist, the directory's stored profile must be **permanently unequal** to
+   the fetched link profile — and the only field that behaves this way after a
+   name is added is the domain claim/proof.
+
+5. **The domain claim/proof legitimately differs between "stored" and "link"
+   representations.** Two documented mechanisms, either of which reproduces the
+   symptom (we do not need to distinguish them — see §4):
+   - A relay can **drop the domain claim** from the served link data — the code
+     explicitly handles this case (`src/Simplex/Chat/Library/Commands.hs:4326-4328`,
+     "an un-upgraded relay dropped the claim").
+   - The proof carries a `ProofPresHeader` that supports a **fresh
+     per-presentation nonce** (`PHTest nonce`, `src/Simplex/Chat/Badges.hs:197-221`),
+     so a re-presented proof is not byte-identical to the stored one.
+
+6. **The domain claim is verified independently and is not admin-moderated
+   content.** Ownership is proven cryptographically and on-chain by
+   `verifyEntityDomain` (`Commands.hs:4845`: the on-chain link must match the
+   connection link, and the proof must be signed by the address owner's key), and
+   verification state is tracked in a **separate** field, `group_domain_verified`
+   (`Groups.hs:2710-2713`, `setGroupDomainVerified`). Nothing about the name
+   requires directory-admin re-approval.
+
+## 3. Root cause
+
+The directory's re-approval trigger (`groupUpdated`) is a byte-comparison of the
+**entire** group profile, including the independently-verified domain claim and
+its proof. Adding a name introduces a claim/proof whose link-side representation
+never byte-matches the directory's stored copy (relay-stripped claim and/or
+re-presented proof nonce), so `profileChanged` is true on **every** 30-minute
+link check → re-approval on repeat.
+
+The conceptual error: `groupUpdated` conflates two different questions —
+"did the profile change at all?" (used to decide whether to *store* the fresh
+claim/proof) and "did the profile change in a way that requires admin
+*re-moderation*?" (used to decide re-approval). These must be separated for the
+domain claim.
+
+## 4. The fix (minimal, idiomatic)
+
+In `src/Simplex/Chat/Library/Internal.hs`, `updateGroupFromLinkData`:
+keep storing on the full `profileChanged` (so the claim/proof and verification
+stay current), but **report `groupUpdated` with the domain claim excluded**.
+
+```haskell
+        -- store branch unchanged; only the returned flag changes:
+        pure (g'', moderationChanged)      -- was: profileChanged
+  ...
+  where
+    profileChanged = p /= groupProfile     -- keep: still gates storing fresh claim/proof
+    -- The domain claim is verified independently (on-chain + owner signature) and
+    -- is not admin-moderated; its link vs stored representation can differ (a relay
+    -- dropping the claim, or a re-presented proof nonce), which otherwise re-triggers
+    -- directory approval on every link check. Exclude it from the reported change.
+    moderationChanged = withoutClaim p /= withoutClaim groupProfile
+    withoutClaim gp@GroupProfile {publicGroup = pgm} = gp {publicGroup = clearClaim <$> pgm}
+    clearClaim pg@PublicGroupProfile {publicGroupAccess = a} =
+      pg {publicGroupAccess = (\acc -> acc {groupDomainClaim = Nothing}) <$> a}
+```
+
+This is a semantics fix, not a convergence hack: a domain-claim change should
+**never** trigger re-approval, independently of *why* the two representations
+differ. It is therefore robust to both mechanisms in §2.5 — we do not need to
+resolve which one occurs in production.
+
+## 5. Why this is correct, sufficient, and safe
+
+**Blast radius is contained to the directory.** `GLPKnown.groupUpdated`
+(`src/Simplex/Chat/Controller.hs:1131`) is consumed **only** by the directory
+service. (The many other `groupUpdated` matches in the tree are an unrelated
+chat event — `RcvGroupEvent.GroupUpdated` / `CR.GroupUpdated` — not this plan
+flag.) The three directory consumers all behave correctly with the claim
+excluded:
+
+- `Service.hs:824` — periodic re-approval → **fixed** (the 30-min loop stops).
+- `Service.hs:988` → `deReregistration` (`:1018`, uses the flag at `:1043` and
+  `:1046`) — an owner re-submitting a **name-only** change now correctly gets
+  "already listed" instead of being forced back into approval.
+- `Service.hs:825` — `listingsUpdated` on `groupUpdated || summary changed`. The
+  only trade-off: a name-only change no longer *immediately* refreshes the web
+  listing files (it still refreshes on any real profile change or member-count
+  change). See §6 for the variant that preserves this.
+
+**Storage and verification stay correct.** Because the store branch still keys
+off the full `profileChanged`, the directory continues to persist a genuinely
+new claim/proof, and `verifyChanged`/`setGroupDomainVerified` still run — so
+by-name lookups and the verified badge remain accurate.
+
+**Moderation is not weakened.** Re-approval exists to re-check *moderatable*
+fields (display name, description, image) that an owner might change after
+approval. The SimpleX name is not such a field: it is cryptographically verified
+and, if name-content moderation is ever desired, that is a separate feature
+operating on the resolved name value — not on byte-equality of a proof.
+
+## 6. Alternatives considered
+
+- **Fix in the directory (`deGroupLinkCheck`) instead of core.** Rejected: the
+  directory only receives the `Bool`, not the profile diff, so it cannot tell a
+  claim-only change from a real one without the core change anyway. The core is
+  the correct single locus.
+- **Make the profiles converge (stop the relay stripping / freeze the proof
+  nonce).** Larger, mechanism-specific, and touches link-data serving and proof
+  presentation. The semantics fix in §4 is smaller and correct regardless.
+- **Preserve prompt listing refresh on name changes.** If desired, keep the
+  `listingsUpdated` check (`Service.hs:825`) driven by the raw `profileChanged`
+  while re-approval (`:824`) uses the new `moderationChanged`. This needs the
+  plan to carry both signals (or the directory to recompute); recommended only
+  if the web listing renders the verified name and staleness is a concern.
+
+## 7. Residual behaviour (accepted)
+
+If the claim/proof is genuinely volatile (per-presentation nonce), the store
+branch will re-write the group_profiles row on each 30-min check (same domain →
+`claimChanged` is false, so verification is **not** thrashed;
+`Groups.hs:2708-2713` compares domain, not proof). This is a harmless idempotent
+write and is vastly preferable to the owner-facing re-approval spam. A follow-up
+could gate the store to skip proof-only deltas; out of scope here.
+
+## 8. Verification plan
+
+1. **Regression test** in `tests/Bots/DirectoryTests.hs` (the member-review
+   branch already added directory concurrency coverage there): register a
+   channel → approve → add a SimpleX name (domain claim) → trigger a link check →
+   assert the registration status **stays `GRSActive`** (no `GRSPendingApproval`,
+   no re-approval message to the owner).
+2. **Optional diagnostic** before/after: a one-line log at `Internal.hs:1482`
+   dumping the two `groupDomainClaim` values confirms which §2.5 mechanism occurs
+   in a live setup — informative, not required for the fix.
+3. Build the directory service and run the directory test suite.
+
+## 9. Files touched
+
+- `src/Simplex/Chat/Library/Internal.hs` — `updateGroupFromLinkData`: return a
+  claim-insensitive change flag (store logic unchanged).
+- `tests/Bots/DirectoryTests.hs` — add the name-added-no-reapproval regression test.
+
+No schema, wire-format, or API changes. `GLPKnown.groupUpdated`'s type is
+unchanged; only its value semantics (directory-only consumer) are refined.

--- a/plans/2026-07-06-fix-directory-name-reapproval.md
+++ b/plans/2026-07-06-fix-directory-name-reapproval.md
@@ -1,184 +1,185 @@
 # Fix: SimpleX directory re-approves a channel every 30 min after a blockchain name is added
 
-Status: proposed
+Status: proposed — **fix gated on a diagnostic step (see §5); root-cause delta not yet observed**
 Branch: `nd/fix-directory-names`
 Base: `origin/master` (`b38015c7b`)
 
 ## 1. Problem
 
 After an owner adds a SimpleX name (blockchain domain claim) to a public
-channel, the SimpleX Directory service repeatedly asks the owner to re-approve
-the channel **every 30 minutes, indefinitely**, with no changes on the owner's
-side. The channel keeps flipping to "hidden until approved."
+channel, the SimpleX Directory service asks the owner to re-approve the channel
+**every 30 minutes, indefinitely**, with no changes on the owner's side. The
+channel keeps flipping to "hidden until approved."
 
-The 30-minute cadence is not a coincidence — it is the directory's own periodic
-link-check interval.
+## 2. What is confirmed (facts, file:line)
 
-## 2. Grounded diagnosis (facts, file:line)
+1. **The 30-min cadence is the directory's link-check timer.** `linkCheckInterval`
+   defaults to **1800 s** (`apps/simplex-directory-service/src/Directory/Options.hs:181`);
+   `linkCheckThread_` sleeps that long and enqueues a `DEGroupLinkCheck` for every
+   non-removed registered group (`.../Directory/Service.hs:199-211`).
 
-1. **The 30-min repeat is the directory's link-check timer.**
-   `linkCheckInterval` defaults to **1800 s** (`apps/simplex-directory-service/src/Directory/Options.hs:181`).
-   `linkCheckThread_` sleeps that long and enqueues a `DEGroupLinkCheck` event for
-   every non-removed registered group
-   (`apps/simplex-directory-service/src/Directory/Service.hs:199-211`).
+2. **`DEGroupLinkCheck` re-approves iff `groupUpdated` is true.** `deGroupLinkCheck`
+   runs `APIConnectPlan` against the channel link and, on a `GLPKnown` plan, does
+   `when groupUpdated $ reapprove …` (`Service.hs:815-854`, trigger at `:824`),
+   which sets `GRSPendingApproval` and re-sends for admin approval.
 
-2. **`DEGroupLinkCheck` re-approves whenever `groupUpdated` is true.**
-   `deGroupLinkCheck` runs `APIConnectPlan` against the channel's link and, on a
-   `GLPKnown` plan, does `when groupUpdated $ reapprove …`
-   (`Service.hs:815-854`, trigger at `:824`), which sets `GRSPendingApproval` and
-   re-sends the channel for admin approval.
+3. **`groupUpdated` is a whole-profile byte inequality.** It is the `Bool` returned
+   by `updateGroupFromLinkData`: `profileChanged = p /= groupProfile`
+   (`src/Simplex/Chat/Library/Internal.hs:1466-1482`), where `p` is the directory's
+   **stored** `GroupProfile` and `groupProfile` is the profile in the **fetched
+   link data**.
 
-3. **`groupUpdated` is a whole-profile byte inequality.**
-   It is the `Bool` returned by `updateGroupFromLinkData`, defined as
-   `profileChanged = p /= groupProfile`
-   (`src/Simplex/Chat/Library/Internal.hs:1466-1482`), where `p` is the
-   directory's **stored** `GroupProfile` and `groupProfile` is the profile inside
-   the **fetched link data**. This equality includes
-   `publicGroup.publicGroupAccess.groupDomainClaim` and its `proof`.
+4. **`groupUpdated` is behaviorally directory-only.** The mobile/desktop clients do
+   not even deserialize it: the client `GroupLinkPlan.Known` variant carries only
+   `groupInfo` — `class Known(val groupInfo: GroupInfo)`
+   (`apps/multiplatform/.../model/SimpleXAPI.kt:7158`; iOS
+   `apps/ios/Shared/Model/AppAPITypes.swift`, `enum GroupLinkPlan`). The only
+   consumers of the flag are in the directory service: re-approval (`Service.hs:824`),
+   listing refresh (`:825`), and owner re-registration (`:988` →
+   `deReregistration:1043,1046`). (All other `groupUpdated` matches in the tree are
+   an unrelated chat event, `RcvGroupEvent`/`CR.GroupUpdated`.)
 
-4. **A normal profile change self-corrects after one cycle — so this is a
-   non-convergence bug specific to the domain claim.**
-   When `profileChanged` is true, `updateGroupFromLinkData` also writes the link
-   profile to the DB (`Internal.hs:1471`), and the store persists the domain claim
-   *and its proof* (`group_domain_proof` column,
-   `src/Simplex/Chat/Store/Groups.hs:2724`; write/read are symmetric —
-   `publicGroupAccessRow` / `toPublicGroupAccess`,
-   `src/Simplex/Chat/Store/Shared.hs:721` and `:727`). So an ordinary field change
-   (name/description/image) re-approves **once** and then converges. For the loop
-   to persist, the directory's stored profile must be **permanently unequal** to
-   the fetched link profile — and the only field that behaves this way after a
-   name is added is the domain claim/proof.
+## 3. What is NOT yet established
 
-5. **The domain claim/proof legitimately differs between "stored" and "link"
-   representations.** Two documented mechanisms, either of which reproduces the
-   symptom (we do not need to distinguish them — see §4):
-   - A relay can **drop the domain claim** from the served link data — the code
-     explicitly handles this case (`src/Simplex/Chat/Library/Commands.hs:4326-4328`,
-     "an un-upgraded relay dropped the claim").
-   - The proof carries a `ProofPresHeader` that supports a **fresh
-     per-presentation nonce** (`PHTest nonce`, `src/Simplex/Chat/Badges.hs:197-221`),
-     so a re-presented proof is not byte-identical to the stored one.
+**Why the two profiles fail to converge every cycle is unproven.** An ordinary
+profile change self-corrects: when `profileChanged` is true,
+`updateGroupFromLinkData` writes the link profile to the DB (`Internal.hs:1471`),
+and the store round-trips the domain claim + proof faithfully
+(`group_domain_proof` column; symmetric `publicGroupAccessRow` /
+`toPublicGroupAccess`, `src/Simplex/Chat/Store/Shared.hs:721`/`:727`). So a
+one-time change re-approves **once** and then converges. A perpetual 30-min
+re-approval requires the directory's stored profile to be **permanently unequal**
+to the fetched link profile — and which field differs has **not been observed**.
 
-6. **The domain claim is verified independently and is not admin-moderated
-   content.** Ownership is proven cryptographically and on-chain by
-   `verifyEntityDomain` (`Commands.hs:4845`: the on-chain link must match the
-   connection link, and the proof must be signed by the address owner's key), and
-   verification state is tracked in a **separate** field, `group_domain_verified`
-   (`Groups.hs:2710-2713`, `setGroupDomainVerified`). Nothing about the name
-   requires directory-admin re-approval.
+Two hypotheses were considered and both are insufficient as stated:
 
-## 3. Root cause
+- **Relay drops the domain claim from the served link data**
+  (`src/Simplex/Chat/Library/Commands.hs:4326-4328` handles this case). But this
+  **converges after one cycle**: the directory stores the claim-less link profile,
+  and with no further owner change nothing restores the claim, so the next check
+  matches. It explains a single reapproval, not a repeat.
+- **A re-presented proof with a fresh nonce.** This does **not** apply to domain
+  claims. `PHTest`/`badgeProof` (fresh nonce per presentation) is the separate
+  *badge* feature, attached to `Profile.badge` (`Internal.hs:2085-2086`), not to
+  the domain claim. A `SimplexDomainProof`'s `presHeader` is **inside the signed
+  payload** (`Commands.hs:4869`, verified at `:4867`), so it cannot be re-presented
+  with a new nonce without re-signing by the owner — it is static. The group claim
+  is also frequently created with `proof = Nothing` (`mkDomainClaim`,
+  `src/Simplex/Chat/Names.hs:56`; used at `Commands.hs:5693`, `:1510`).
 
-The directory's re-approval trigger (`groupUpdated`) is a byte-comparison of the
-**entire** group profile, including the independently-verified domain claim and
-its proof. Adding a name introduces a claim/proof whose link-side representation
-never byte-matches the directory's stored copy (relay-stripped claim and/or
-re-presented proof nonce), so `profileChanged` is true on **every** 30-minute
-link check → re-approval on repeat.
+So the correlation ("started right after adding a name") strongly implicates the
+domain claim as the differing field, but the **exact field and the reason it
+never converges are not yet demonstrated.** This plan therefore treats the fix as
+gated on a diagnostic.
 
-The conceptual error: `groupUpdated` conflates two different questions —
-"did the profile change at all?" (used to decide whether to *store* the fresh
-claim/proof) and "did the profile change in a way that requires admin
-*re-moderation*?" (used to decide re-approval). These must be separated for the
-domain claim.
+## 4. Likely mechanism (hypothesis, to be confirmed)
 
-## 4. The fix (minimal, idiomatic)
+The differing field is the group profile's `publicGroup.publicGroupAccess.groupDomainClaim`
+(or its `proof`): the directory's stored copy and the fetched link copy carry
+different claim representations on every fetch, in a way that storing the link
+copy does not reconcile. Because the domain claim is verified **independently** —
+cryptographically + on-chain by `verifyEntityDomain` (`Commands.hs:4840`), with
+verification tracked in a *separate* field `group_domain_verified`
+(`Store/Groups.hs:2710-2713`) — it is not admin-moderated content and should never
+gate re-approval. The bug is that `groupUpdated` conflates "profile changed at
+all" (used to decide whether to *store* the fresh claim) with "profile changed in
+a way needing admin *re-moderation*" (used to decide re-approval).
 
-In `src/Simplex/Chat/Library/Internal.hs`, `updateGroupFromLinkData`:
-keep storing on the full `profileChanged` (so the claim/proof and verification
-stay current), but **report `groupUpdated` with the domain claim excluded**.
+## 5. Required diagnostic (gate before the fix)
+
+Add a temporary log at the one comparison that flips everything,
+`Internal.hs:1482`, dumping the two profiles' domain claims when `profileChanged`
+fires, and run it against the affected channel across ≥2 link-check cycles:
 
 ```haskell
-        -- store branch unchanged; only the returned flag changes:
+-- temporary:
+when (p /= groupProfile) $ logInfo $ "linkcheck delta: stored=" <> tshow (claimOf p)
+                                   <> " link=" <> tshow (claimOf groupProfile)
+```
+
+Decision:
+- **Delta is the domain claim, identical each cycle** → structural asymmetry;
+  apply §6 (proof redaction covers it if the delta is the proof; if the delta is
+  the whole claim, widen the redaction to the claim — decide from the log).
+- **Delta changes each cycle** → identify the varying field from the log; if it is
+  not the claim, this plan's fix does not apply and the diagnosis restarts here.
+
+The fix in §6 is only justified once the log shows the per-cycle delta is confined
+to the domain claim/proof.
+
+## 6. The fix (conditional on §5)
+
+In `updateGroupFromLinkData` (`Internal.hs`), keep storing on the full
+`profileChanged` (so the claim/proof and verification stay current), but report
+`groupUpdated` with the domain-claim **proof** redacted — reusing the codebase's
+existing proof-redaction idiom (`Types.hs:750` `clearProofs`; `Internal.hs:1265`
+`redactedDomain`), rather than new helpers:
+
+```haskell
         pure (g'', moderationChanged)      -- was: profileChanged
   ...
   where
-    profileChanged = p /= groupProfile     -- keep: still gates storing fresh claim/proof
-    -- The domain claim is verified independently (on-chain + owner signature) and
-    -- is not admin-moderated; its link vs stored representation can differ (a relay
-    -- dropping the claim, or a re-presented proof nonce), which otherwise re-triggers
-    -- directory approval on every link check. Exclude it from the reported change.
-    moderationChanged = withoutClaim p /= withoutClaim groupProfile
-    withoutClaim gp@GroupProfile {publicGroup = pgm} = gp {publicGroup = clearClaim <$> pgm}
-    clearClaim pg@PublicGroupProfile {publicGroupAccess = a} =
-      pg {publicGroupAccess = (\acc -> acc {groupDomainClaim = Nothing}) <$> a}
+    profileChanged = p /= groupProfile     -- keep: still gates storing the fresh claim
+    -- A domain-claim change is verified independently (on-chain + owner signature)
+    -- and is not admin-moderated, so it must not trigger directory re-approval.
+    -- Redact the proof before comparing (same idiom as Types.clearProofs).
+    moderationChanged = redactProof p /= redactProof groupProfile
+    redactProof gp@GroupProfile {publicGroup} = gp {publicGroup = redactPg <$> publicGroup}
+    redactPg pg@PublicGroupProfile {publicGroupAccess} = pg {publicGroupAccess = redactAccess <$> publicGroupAccess}
+    redactAccess a@PublicGroupAccess {groupDomainClaim} =
+      a {groupDomainClaim = (\d -> d {proof = Nothing} :: SimplexDomainClaim) <$> groupDomainClaim}
 ```
 
-This is a semantics fix, not a convergence hack: a domain-claim change should
-**never** trigger re-approval, independently of *why* the two representations
-differ. It is therefore robust to both mechanisms in §2.5 — we do not need to
-resolve which one occurs in production.
+Redacting **only the proof** (not the whole claim) is the surgical choice: it kills
+any proof-representation delta while still letting a genuine domain add/change
+register as a one-time change (which then converges). If §5 shows the delta is the
+whole claim (e.g. claim present vs absent every cycle), replace `redactAccess` with
+`groupDomainClaim = Nothing`; note this also suppresses the legitimate one-time
+reapproval on a name add.
 
-## 5. Why this is correct, sufficient, and safe
+Storage keys off the full `profileChanged`, so the claim/proof and
+`setGroupDomainVerified` still update — by-name lookups and the verified badge stay
+correct.
 
-**Blast radius is contained to the directory.** `GLPKnown.groupUpdated`
-(`src/Simplex/Chat/Controller.hs:1131`) is consumed **only** by the directory
-service. (The many other `groupUpdated` matches in the tree are an unrelated
-chat event — `RcvGroupEvent.GroupUpdated` / `CR.GroupUpdated` — not this plan
-flag.) The three directory consumers all behave correctly with the claim
-excluded:
+## 7. Why this is safe (given §5 confirms the delta)
 
-- `Service.hs:824` — periodic re-approval → **fixed** (the 30-min loop stops).
-- `Service.hs:988` → `deReregistration` (`:1018`, uses the flag at `:1043` and
-  `:1046`) — an owner re-submitting a **name-only** change now correctly gets
-  "already listed" instead of being forced back into approval.
-- `Service.hs:825` — `listingsUpdated` on `groupUpdated || summary changed`. The
-  only trade-off: a name-only change no longer *immediately* refreshes the web
-  listing files (it still refreshes on any real profile change or member-count
-  change). See §6 for the variant that preserves this.
+- **Directory-only blast radius** (fact, §2.4). All three consumers behave
+  correctly with the proof/claim excluded:
+  - `Service.hs:824` periodic re-approval → **fixed**.
+  - `Service.hs:988` → `deReregistration` (`:1043`/`:1046`) — an owner re-submitting a
+    name-only change gets "already listed" instead of forced re-approval.
+  - `Service.hs:825` `listingsUpdated` — minor trade-off: a name-only change no longer
+    *immediately* refreshes web-listing files (still refreshes on any real change or
+    member-count change). If prompt refresh matters, keep `:825` on the raw
+    `profileChanged` while `:824` uses `moderationChanged`.
+- **Moderation not weakened.** Re-approval still fires on any moderatable field
+  (name, description, image); only proof/claim deltas are excluded, and those are
+  independently verified.
 
-**Storage and verification stay correct.** Because the store branch still keys
-off the full `profileChanged`, the directory continues to persist a genuinely
-new claim/proof, and `verifyChanged`/`setGroupDomainVerified` still run — so
-by-name lookups and the verified badge remain accurate.
+## 8. Residual behaviour (accepted)
 
-**Moderation is not weakened.** Re-approval exists to re-check *moderatable*
-fields (display name, description, image) that an owner might change after
-approval. The SimpleX name is not such a field: it is cryptographically verified
-and, if name-content moderation is ever desired, that is a separate feature
-operating on the resolved name value — not on byte-equality of a proof.
+If the claim/proof genuinely differs each cycle, the store branch re-writes the
+`group_profiles` row every 30 min. This is idempotent and does not thrash
+verification (`claimChanged` in `updateGroupProfile` compares the *domain*, not the
+proof — `Groups.hs:2708-2709`). A follow-up could skip the store on proof-only
+deltas; out of scope.
 
-## 6. Alternatives considered
+## 9. Verification plan
 
-- **Fix in the directory (`deGroupLinkCheck`) instead of core.** Rejected: the
-  directory only receives the `Bool`, not the profile diff, so it cannot tell a
-  claim-only change from a real one without the core change anyway. The core is
-  the correct single locus.
-- **Make the profiles converge (stop the relay stripping / freeze the proof
-  nonce).** Larger, mechanism-specific, and touches link-data serving and proof
-  presentation. The semantics fix in §4 is smaller and correct regardless.
-- **Preserve prompt listing refresh on name changes.** If desired, keep the
-  `listingsUpdated` check (`Service.hs:825`) driven by the raw `profileChanged`
-  while re-approval (`:824`) uses the new `moderationChanged`. This needs the
-  plan to carry both signals (or the directory to recompute); recommended only
-  if the web listing renders the verified name and staleness is a concern.
+1. Land the §5 diagnostic, capture the delta on the affected channel, confirm it is
+   the domain claim/proof, and choose proof-vs-whole-claim redaction from the log.
+2. Apply §6.
+3. **Regression test** in `tests/Bots/DirectoryTests.hs`: register a channel →
+   approve → add a SimpleX name → trigger ≥2 link checks → assert the registration
+   stays `GRSActive` (no `GRSPendingApproval`, no owner re-approval message).
+4. Build the directory service; run the directory test suite.
 
-## 7. Residual behaviour (accepted)
-
-If the claim/proof is genuinely volatile (per-presentation nonce), the store
-branch will re-write the group_profiles row on each 30-min check (same domain →
-`claimChanged` is false, so verification is **not** thrashed;
-`Groups.hs:2708-2713` compares domain, not proof). This is a harmless idempotent
-write and is vastly preferable to the owner-facing re-approval spam. A follow-up
-could gate the store to skip proof-only deltas; out of scope here.
-
-## 8. Verification plan
-
-1. **Regression test** in `tests/Bots/DirectoryTests.hs` (the member-review
-   branch already added directory concurrency coverage there): register a
-   channel → approve → add a SimpleX name (domain claim) → trigger a link check →
-   assert the registration status **stays `GRSActive`** (no `GRSPendingApproval`,
-   no re-approval message to the owner).
-2. **Optional diagnostic** before/after: a one-line log at `Internal.hs:1482`
-   dumping the two `groupDomainClaim` values confirms which §2.5 mechanism occurs
-   in a live setup — informative, not required for the fix.
-3. Build the directory service and run the directory test suite.
-
-## 9. Files touched
+## 10. Files touched
 
 - `src/Simplex/Chat/Library/Internal.hs` — `updateGroupFromLinkData`: return a
-  claim-insensitive change flag (store logic unchanged).
+  claim/proof-insensitive change flag (store logic unchanged). Temporary diagnostic
+  log removed before merge.
 - `tests/Bots/DirectoryTests.hs` — add the name-added-no-reapproval regression test.
 
-No schema, wire-format, or API changes. `GLPKnown.groupUpdated`'s type is
-unchanged; only its value semantics (directory-only consumer) are refined.
+No schema, wire-format, or API changes. `GLPKnown.groupUpdated`'s type is unchanged;
+only its value semantics (directory-only consumer) are refined.

--- a/plans/2026-07-06-fix-directory-name-reapproval.md
+++ b/plans/2026-07-06-fix-directory-name-reapproval.md
@@ -171,6 +171,29 @@ not a directory policy, so it belongs where the comparison lives:
   pre-update snapshot (enqueue-vs-process window) and leaves `groupUpdated`
   misleading for any future consumer. Core is preferred per §5.
 
+## 7b. Regressions checked (none found)
+
+- **Compiles.** `Internal.hs` has `{-# LANGUAGE OverloadedStrings #-}`, so
+  `B64UrlByteString ""` type-checks. (`B64UrlByteString mempty` — inner
+  `ByteString` `mempty` — is an equivalent pragma-independent form.)
+- **Existing "link/whitespace-only must not re-approve" test is untouched**
+  (`DirectoryTests.hs:296-326`). That test changes a URL inside the *welcome
+  message* text and exercises the owner-update path (`deGroupUpdated`) — not
+  `publicGroup.groupLink`, not `publicGroupId`, and not the link-check path. The
+  fix normalizes only `publicGroupId`, so every non-`publicGroupId` field
+  (including `groupLink`, description, image) compares exactly as before.
+- **No missed re-approval.** Only `publicGroupId` is excluded; any moderatable
+  field still differs under the comparison and still re-approves.
+- **Non-directory clients unaffected.** They don't read the returned flag (the
+  mobile/desktop `GroupLinkPlan.Known` variant omits it, §2.4); the only other
+  effect is skipping an `updateGroupProfile` call when *only* `publicGroupId`
+  differs — a no-op, since that column is never written there anyway.
+- **Other `updateGroupFromLinkData` callers safe.** `Commands.hs:4331` (CTName
+  path) ignores the returned `Bool` and uses `g'`; its domain check reads the
+  claim *domain*, which still converges (a real claim change keeps
+  `profileChanged` true and stores). `Commands.hs:4358` is the directory path this
+  fix targets.
+
 ## 8. Verification plan
 
 1. **Regression test** in `tests/Bots/DirectoryTests.hs` (beside the existing

--- a/plans/2026-07-06-fix-directory-name-reapproval.md
+++ b/plans/2026-07-06-fix-directory-name-reapproval.md
@@ -1,6 +1,6 @@
 # Fix: SimpleX directory re-approves a channel every 30 min after a blockchain name is added
 
-Status: proposed — **root cause confirmed by code (deduction, §3); fix in core (§4)**
+Status: implemented & verified — **root cause confirmed by code (deduction, §3); fix in core (§4); regression test passes and fails without the fix (§8)**
 Branch: `nd/fix-directory-names`
 Base: `origin/master` (`b38015c7b`)
 
@@ -107,7 +107,7 @@ sites — the guard, the `if … then updateGroupProfile`, and the returned flag
     -- Internal.hs:2986, which normalizes groupPreferences the same way).
     profileChanged = clearId p /= clearId groupProfile
     clearId gp@GroupProfile {publicGroup} =
-      gp {publicGroup = (\pg -> pg {publicGroupId = B64UrlByteString ""}) <$> publicGroup}
+      gp {publicGroup = (\pg -> (pg :: PublicGroupProfile) {publicGroupId = B64UrlByteString ""}) <$> publicGroup}
 ```
 
 The `| profileChanged || countChanged || verifyChanged` guard, the
@@ -207,16 +207,24 @@ not a directory policy, so it belongs where the comparison lives:
   `profileChanged` true and stores). `Commands.hs:4358` is the directory path this
   fix targets.
 
-## 8. Verification plan
+## 8. Verification (done)
 
-1. **Regression test** in `tests/Bots/DirectoryTests.hs` (beside the existing
-   "link/whitespace-only must not re-approve" tests, `:296-326`): register a channel
-   with one `public_group_id`, then make the fetched link carry a *different*
-   `publicGroupId` (all other fields equal), run ≥2 link checks, and assert the reg
-   stays `GRSActive` (no `GRSPendingApproval`, no owner re-approval message). Add a
-   positive control: a display-name change *does* re-approve.
-2. Apply §4.
-3. Build the directory service (statically links core); run the directory suite.
+Regression test `testLinkCheckStalePublicGroupId` in `tests/Bots/DirectoryTests.hs`
+(beside the existing "link/whitespace-only must not re-approve" tests): register +
+approve a channel, then corrupt the directory's *stored* `public_group_id` via
+`/x /sql chat UPDATE group_profiles SET public_group_id = randomblob(32) …` (so it
+differs from the link's; the value stays non-NULL, so `publicGroup` remains `Just`
+and the link check still runs), let a link check run (`linkCheckInterval = 1`), and
+assert the channel stays listed with no re-approval.
+
+Results:
+- `cabal build simplex-directory-service` — links (the fix compiles into the bot).
+- `cabal build simplex-chat-test` — the test compiles.
+- Test **passes** with the fix (1 example, 0 failures).
+- **Negative control** (fix reverted, test kept): the test **fails** with
+  `but got: Just "…The channel ID 1 (news) profile changed."` — the exact production
+  re-approval message. So the test genuinely guards the bug, and the root cause is
+  demonstrated end-to-end (not just deduced).
 
 ## 9. Files touched
 

--- a/plans/2026-07-06-fix-directory-name-reapproval.md
+++ b/plans/2026-07-06-fix-directory-name-reapproval.md
@@ -130,9 +130,24 @@ not a directory policy, so it belongs where the comparison lives:
 - **Fixes the confirmed cause and converges** the re-approval decision: an
   identity-only difference no longer reads as a change, so `groupUpdated` is false
   and re-approval stops.
+- **Correctly scoped, not a workaround.** `publicGroupId` is *not* a field
+  `updateGroupProfile` manages — it is owned by the group INSERTs and
+  `updateRelayGroupKeys` (`Groups.hs:2293`); genuine identity/key changes flow
+  through that path, never through profile sync. So `updateGroupFromLinkData`
+  reacting to it was the defect: it compared a field it neither syncs nor should.
+  Normalizing it out aligns the comparison with exactly the columns
+  `updateGroupProfile` actually writes (and `publicGroupId` is the *only* `Eq`-field
+  it omits — so this is precisely "compare the managed fields").
 - **No data mutation.** It does *not* write `public_group_id`, so it cannot violate
-  any "immutable identity" assumption elsewhere; the stale stored value simply stops
-  driving moderation.
+  any "immutable identity" assumption elsewhere.
+- **The residual stored staleness is inert.** The directory reads its stored
+  `publicGroupId` in *only* this comparison: `generateListing`
+  (`Directory/Listing.hs:146`) names files by `listingFileName`/`promotedFileName`,
+  not `publicGroupId`; the directory does not use `Simplex.Chat.Web` /
+  `webPreviewWorker` (the per-`publicGroupId` web-file naming is a channel-owner
+  feature); and the `publicGroupId`↔entity-id validations (`Commands.hs:2190-2193`,
+  `:4315`) use the *fetched link* value, not the stored one. So leaving the stored
+  value stale changes nothing else the directory does.
 - **No store churn.** Because the redefined `profileChanged` also gates the store, an
   identity-only delta no longer triggers a pointless `updateGroupProfile` every 30 min.
 - **Moderation intact.** Any moderatable change (display name, full name, short
@@ -145,9 +160,11 @@ not a directory policy, so it belongs where the comparison lives:
 ## 7. Alternatives considered — and why not
 
 - **Persist the column** (`public_group_id = COALESCE(?, public_group_id)`, adopt the
-  link's value). Also converges, but it **mutates an "immutable" identity** on every
-  profile sync and risks assumptions elsewhere; identity repair is a bigger, riskier
-  change than simply not moderating on identity.
+  link's value). Also converges, and it *additionally* repairs the stored staleness —
+  but that staleness is inert for the directory (§6), so this fixes a separate,
+  non-reported concern. It **mutates an "immutable" identity** on every profile sync
+  (a field `updateGroupProfile` deliberately does not manage) and risks assumptions
+  in its many other callers — a bigger, riskier change for no benefit to this bug.
 - **Directory-only** (compare `gInfo` vs `g'` at `Service.hs:824` instead of
   `groupUpdated`). Works — both are stored-side, so the stale `publicGroupId` is
   equal on both and never fires — but it relies on `gInfo` being a faithful

--- a/plans/2026-07-06-fix-directory-name-reapproval.md
+++ b/plans/2026-07-06-fix-directory-name-reapproval.md
@@ -78,32 +78,39 @@ pre-existing `publicGroupId` staleness.
 
 `publicGroupId` is immutable cryptographic identity (`sha256(genesis root key)`,
 `Types.hs:858`), not moderatable content. `updateGroupFromLinkData` should not treat
-an identity difference as a profile change. Compare with `publicGroupId` normalized
-out, and use that for **both** the store guard **and** the returned flag (so there is
-neither re-approval nor per-cycle store churn):
+an identity difference as a profile change.
+
+`profileChanged` is a local `where`-binding already used in all three relevant
+sites — the guard, the `if … then updateGroupProfile`, and the returned flag — so
+**redefining only its definition** fixes all three at once with **no body edits**
+(so there is neither re-approval nor per-cycle store churn). The entire change:
 
 ```haskell
--- src/Simplex/Chat/Library/Internal.hs, updateGroupFromLinkData:
-  | contentChanged || countChanged || verifyChanged = do
-      cxt <- chatStoreCxt
-      withStore $ \db -> do
-        g   <- if contentChanged then updateGroupProfile db user gInfo groupProfile else pure gInfo
-        g'  <- …count…
-        g'' <- if verifyChanged then …setGroupDomainVerified… else pure g'
-        pure (g'', contentChanged)
-  | otherwise = pure (gInfo, False)
-  where
+-- src/Simplex/Chat/Library/Internal.hs, updateGroupFromLinkData `where` block:
+    -- was: profileChanged = p /= groupProfile
     -- publicGroupId is immutable identity, not content; updateGroupProfile never
-    -- re-syncs it, so a stale stored value would make a plain (/=) re-trigger
-    -- approval forever. Compare content with it normalized out.
-    contentChanged = clearId p /= clearId groupProfile
+    -- re-syncs it, so a stale stored value makes a plain (/=) re-trigger approval
+    -- forever. Compare content with it normalized out (mirrors sameGroupProfileInfo,
+    -- Internal.hs:2986, which normalizes groupPreferences the same way).
+    profileChanged = clearId p /= clearId groupProfile
     clearId gp@GroupProfile {publicGroup} =
-      gp {publicGroup = (\pg -> pg {publicGroupId = mempty}) <$> publicGroup}
-    …
+      gp {publicGroup = (\pg -> pg {publicGroupId = B64UrlByteString ""}) <$> publicGroup}
 ```
 
-(`profileChanged = p /= groupProfile` is removed; `countChanged`/`verifyChanged`
-unchanged.)
+The `| profileChanged || countChanged || verifyChanged` guard, the
+`if profileChanged then updateGroupProfile …`, and the `pure (g'', profileChanged)`
+return are all **unchanged** — they keep referencing `profileChanged`, whose meaning
+is now "content changed, ignoring identity". `countChanged`/`verifyChanged`
+unchanged. Net diff: one redefined `where` line + one helper line, zero body edits.
+
+Notes:
+- `B64UrlByteString` has no `Monoid` instance (`Types.hs:161-163`), so use
+  `B64UrlByteString ""`, **not** `mempty`. The value is only used inside the local
+  `/=` and discarded — nothing is written.
+- **Do not** reuse/extend `sameGroupProfileInfo` for this: it also drops
+  `groupPreferences`, which would change a shared helper (its other caller is
+  `Commands.hs:3939`) and silently stop the directory re-approving on preference
+  changes — scope creep beyond this bug. Normalize `publicGroupId` only.
 
 ## 5. Why core, not the directory
 
@@ -126,8 +133,8 @@ not a directory policy, so it belongs where the comparison lives:
 - **No data mutation.** It does *not* write `public_group_id`, so it cannot violate
   any "immutable identity" assumption elsewhere; the stale stored value simply stops
   driving moderation.
-- **No store churn.** Because `contentChanged` also gates the store, an identity-only
-  delta no longer triggers a pointless `updateGroupProfile` every 30 min.
+- **No store churn.** Because the redefined `profileChanged` also gates the store, an
+  identity-only delta no longer triggers a pointless `updateGroupProfile` every 30 min.
 - **Moderation intact.** Any moderatable change (display name, full name, short
   descr, description, image, prefs, admission, or the domain claim) still differs
   under `clearId` and still re-approves. Only immutable identity is excluded —
@@ -160,8 +167,9 @@ not a directory policy, so it belongs where the comparison lives:
 
 ## 9. Files touched
 
-- `src/Simplex/Chat/Library/Internal.hs` — `updateGroupFromLinkData`: replace
-  `profileChanged` (store guard + returned flag) with a `publicGroupId`-insensitive
-  `contentChanged`. No store, schema, wire, or API change.
+- `src/Simplex/Chat/Library/Internal.hs` — `updateGroupFromLinkData`: redefine the
+  local `profileChanged` `where`-binding to normalize `publicGroupId` out before
+  comparing (one redefined line + one `clearId` helper line; no body edits). No
+  store, schema, wire, or API change.
 - `tests/Bots/DirectoryTests.hs` — add the identity-difference no-reapproval
   regression test (+ display-name positive control).

--- a/plans/2026-07-06-fix-directory-name-reapproval.md
+++ b/plans/2026-07-06-fix-directory-name-reapproval.md
@@ -1,168 +1,167 @@
 # Fix: SimpleX directory re-approves a channel every 30 min after a blockchain name is added
 
-Status: proposed — **root cause deduced from code (see §3); fix in core**
+Status: proposed — **root cause confirmed by code (deduction, §3); fix in core (§4)**
 Branch: `nd/fix-directory-names`
 Base: `origin/master` (`b38015c7b`)
 
-> This supersedes two earlier drafts of this plan that blamed the domain claim/proof.
-> Deep investigation showed that was a **red herring** — the claim/proof round-trips
-> and converges. The real non-convergent field is **`publicGroupId`**. See §3.
+> Supersedes earlier drafts that blamed the domain claim/proof, and a draft that
+> proposed `COALESCE(public_group_id, ?)`. Both were wrong. Deep investigation
+> (three traces + elimination) pins the cause to **`publicGroupId`** and the fix to
+> a content-comparison in `updateGroupFromLinkData`. See §3–§4.
 
 ## 1. Problem
 
 After an owner adds a SimpleX name (blockchain domain claim) to a public channel,
 the SimpleX Directory service asks the owner to re-approve the channel **every
-30 minutes, indefinitely**, with no changes on the owner's side. The channel keeps
-flipping to "hidden until approved."
+30 minutes, indefinitely**, with no changes on the owner's side.
 
 ## 2. Confirmed trigger (facts, file:line)
 
 1. **30-min cadence = the directory's link-check timer.** `linkCheckInterval`
-   defaults to **1800 s** (`apps/simplex-directory-service/src/Directory/Options.hs:181`);
-   `linkCheckThread_` sleeps that interval and enqueues a `DEGroupLinkCheck` for
-   every non-removed registered group (`.../Directory/Service.hs:199-211`).
-2. **`deGroupLinkCheck` re-approves iff `groupUpdated` is true** —
-   `when groupUpdated $ reapprove …` (`Service.hs:824`), flipping `GRSActive →
-   GRSPendingApproval` and re-sending for admin approval (`:843-854`).
-3. **`groupUpdated` is a whole-profile byte inequality** — the `Bool` returned by
+   defaults to 1800 s (`apps/simplex-directory-service/src/Directory/Options.hs:181`);
+   `linkCheckThread_` enqueues `DEGroupLinkCheck` per registered group every interval
+   (`.../Directory/Service.hs:199-211`).
+2. **`deGroupLinkCheck` re-approves iff `groupUpdated`** — `when groupUpdated $
+   reapprove …` (`Service.hs:824`), which flips the reg to `GRSPendingApproval` and
+   re-sends for approval (`:843-854`). It only runs when the stored `publicGroup` is
+   `Just` (`forM_ pg_ …`, `:817`).
+3. **`groupUpdated` = full structural inequality.** It is the `Bool` from
    `updateGroupFromLinkData`: `profileChanged = p /= groupProfile`
    (`src/Simplex/Chat/Library/Internal.hs:1466-1482`), `p` = directory's *stored*
-   `GroupProfile`, `groupProfile` = profile from the *fetched* link short-link data.
-4. **The flag is behaviorally directory-only** — the mobile/desktop/iOS
+   `GroupProfile`, `groupProfile` = the *fetched link* profile.
+4. **The flag is behaviorally directory-only.** The mobile/desktop/iOS
    `GroupLinkPlan.Known` variant does not carry it (`SimpleXAPI.kt:7158`; iOS
-   `AppAPITypes.swift`); only the directory consumes it (`Service.hs:824`, `:825`,
+   `AppAPITypes.swift`); consumers are all in the directory (`Service.hs:824`, `:825`,
    `:988`→`deReregistration:1043/1046`).
 
-## 3. Root cause (deduced by elimination — code-confirmed)
+## 3. Root cause — `publicGroupId`, confirmed by elimination (no diagnostic needed)
 
-Three independent traces close the case without needing a runtime diagnostic:
+Three facts close the case deductively:
 
-- **The fetched link profile is byte-identical across fetches.** It is served
-  verbatim from the owner's published, owner-authorized `LSET` blob via `LGET`
-  (`simplexmq` agent `getConnShortLink` → `decryptLinkData`); there is no
-  timestamp, per-fetch nonce, relay reconstruction, or server-computed member
-  count. Member count lives in `GroupShortLinkData.publicGroupData` (a sibling of
-  `groupProfile`) and drives `countChanged`, not `groupUpdated`. So the link side
-  cannot make `groupUpdated` flip on its own.
-- **Every `Eq`-relevant `GroupProfile` field except one is persisted by
-  `updateGroupProfile` and therefore converges** after the first store
-  (`Internal.hs:1471`). The single exception is **`publicGroupId`**
-  (`Types.hs:858`, part of `PublicGroupProfile`, `deriving Eq`): the UPDATE in
-  `updateGroupProfile` (`src/Simplex/Chat/Store/Groups.hs:2721-2732`) writes
-  `group_type, group_link, group_web_page, group_domain, domain_web_page,
-  allow_embedding, group_domain_proof, …` but **omits `public_group_id`**. It is
-  read back from the stored column (`Shared.hs:699`, `Groups.hs:2779`), and
-  `toPublicGroupProfile` returns `publicGroup = Nothing` unless `group_type` **and**
-  `group_link` **and** `public_group_id` are all present (`Shared.hs:713-716`).
-- **The domain claim/proof is not the cause.** `group_domain`/`group_domain_proof`
-  *are* persisted and round-trip symmetrically (`Shared.hs:721`/`:727`), so they
-  converge. In the group flow the proof is `Nothing` anyway (`SimplexDomainProof`
-  is never constructed in `src/`; group claims use `mkDomainClaim`, `proof = Nothing`,
-  `Names.hs:56`, `Commands.hs:5693`), and group verification is a separate scalar
-  column `group_domain_verified` (`Groups.hs:2740-2746`).
+- **`p` reflects every persisted column.** The directory's CTLink plan resolves via
+  `getGroupToConnect` → `getGroupViaShortLinkToConnect` (`Groups.hs:1084`) →
+  **`getGroupInfo`** (`:2841`) — the standard projection reading all `group_profiles`
+  columns.
+- **`updateGroupProfile` persists every `Eq`-relevant `GroupProfile` field except
+  one.** Its UPDATE (`Groups.hs:2721-2732`) writes `display_name, full_name,
+  short_descr, description, image, group_type, group_link, group_web_page,
+  group_domain, domain_web_page, allow_embedding, group_domain_proof, preferences,
+  member_admission` — but **omits `public_group_id`**. That column is written only at
+  group creation (INSERTs, `:405`/`:912`) and by `updateRelayGroupKeys` (`:2293`).
+- **The fetched link profile is byte-identical across fetches** — served verbatim
+  from the owner's `LSET` blob via `LGET` (no timestamp/nonce/reconstruction).
 
-**Deduction:** a *perpetual* re-approval requires a field that never reconciles.
-The link side is deterministic, and every field except `publicGroupId` converges
-after one store — so the only field that can hold `p /= groupProfile` forever is
-`publicGroupId`. It does so because the directory's stored `public_group_id` is
-**NULL / stale** and `updateGroupProfile` — the only function that syncs a group's
-profile from link data or `XGrpInfo` — cannot write that column.
+**Deduction.** When `profileChanged` is true, `updateGroupFromLinkData` stores the
+link profile (`Internal.hs:1471`); on the next check `getGroupInfo` re-reads a `p`
+equal to the link profile on **every field except `public_group_id`**, which the
+store cannot change. The link side is deterministic. Therefore a *perpetual*
+inequality is possible **iff** the stored `public_group_id` differs from the link's
+— it is the only field that cannot converge. This is deductively certain.
 
-**Why the directory's `public_group_id` is NULL, and why it correlates with the
-name.** `public_group_id` is written in only three places, all *creation-time*:
-the two group INSERTs (`Groups.hs:405`, `:912`, from the profile's `publicGroup`)
-and `updateRelayGroupKeys` (`:2293`). If the directory joined the channel while it
-had no `publicGroupId` in its link profile (an older channel, or one that became a
-public/named channel later), its `public_group_id` was inserted NULL and can never
-be populated afterward. When the owner adds the SimpleX name, the owner republishes
-the link with a fully-populated `publicGroup` (`publicGroupId` + `publicGroupAccess`),
-so the fetched profile's `publicGroup` becomes `Just{…}` while the directory's
-stored copy stays `Nothing` — a permanent inequality, re-approved every 30 min.
+**Why it is non-NULL-but-stale (not NULL).** The re-approval only runs when the
+stored `publicGroup` is `Just`, which requires `public_group_id` non-NULL. So the
+directory's value is present but **stale**: set once at join time (or via
+`updateRelayGroupKeys`) and never re-synced, because `updateGroupProfile` — the
+function that syncs the profile from link data / `XGrpInfo` on every update — never
+writes that column. When adding the name causes the owner to (re)publish a
+`publicGroupId` that differs from the directory's stale stored value, the mismatch
+is permanent → `groupUpdated` true every cycle → re-approval on repeat.
 
-**Confirmation step (cheap, not blocking):** on the affected directory,
-`SELECT public_group_id FROM group_profiles` joined to the channel's group should
-show NULL, while the link's `publicGroupId` is present.
+**Ruled out (earlier drafts):** the domain claim/proof **is** persisted
+(`group_domain`/`group_domain_proof`, symmetric `publicGroupAccessRow`/
+`toPublicGroupAccess`) and therefore converges; in the group flow the proof is
+`Nothing` anyway (`mkDomainClaim`, `Names.hs:56`). The claim is a red herring — it
+is merely the *occasion* (the owner republishing the link) that surfaces the
+pre-existing `publicGroupId` staleness.
 
-## 4. The fix (core, minimal): let `updateGroupProfile` populate `public_group_id`
+## 4. The fix (core, minimal): compare *content*, ignoring immutable identity
 
-`updateGroupProfile` is missing a profile column that its sibling INSERT paths
-already persist. Add `public_group_id` to its UPDATE, **guarded by `COALESCE` so it
-only populates a currently-NULL value and never changes or erases an existing
-identity** (respecting `publicGroupId`'s immutability):
-
-```sql
--- src/Simplex/Chat/Store/Groups.hs, updateGroupProfile_ UPDATE:
-SET display_name = ?, full_name = ?, short_descr = ?, description = ?, image = ?,
-    group_type = ?, group_link = ?, public_group_id = COALESCE(public_group_id, ?),
-    group_web_page = ?, group_domain = ?, domain_web_page = ?, allow_embedding = ?,
-    group_domain_proof = ?, preferences = ?, member_admission = ?, updated_at = ?
-```
-
-with the new `?` sourced exactly like the INSERT paths (`Groups.hs:384-385`):
+`publicGroupId` is immutable cryptographic identity (`sha256(genesis root key)`,
+`Types.hs:858`), not moderatable content. `updateGroupFromLinkData` should not treat
+an identity difference as a profile change. Compare with `publicGroupId` normalized
+out, and use that for **both** the store guard **and** the returned flag (so there is
+neither re-approval nor per-cycle store churn):
 
 ```haskell
-publicGroupId_ = case publicGroup of
-  Just PublicGroupProfile {publicGroupId} -> Just publicGroupId
-  Nothing -> Nothing
+-- src/Simplex/Chat/Library/Internal.hs, updateGroupFromLinkData:
+  | contentChanged || countChanged || verifyChanged = do
+      cxt <- chatStoreCxt
+      withStore $ \db -> do
+        g   <- if contentChanged then updateGroupProfile db user gInfo groupProfile else pure gInfo
+        g'  <- …count…
+        g'' <- if verifyChanged then …setGroupDomainVerified… else pure g'
+        pure (g'', contentChanged)
+  | otherwise = pure (gInfo, False)
+  where
+    -- publicGroupId is immutable identity, not content; updateGroupProfile never
+    -- re-syncs it, so a stale stored value would make a plain (/=) re-trigger
+    -- approval forever. Compare content with it normalized out.
+    contentChanged = clearId p /= clearId groupProfile
+    clearId gp@GroupProfile {publicGroup} =
+      gp {publicGroup = (\pg -> pg {publicGroupId = mempty}) <$> publicGroup}
+    …
 ```
 
-Effect: on the next link check, the directory's NULL `public_group_id` is populated
-from the authoritative link profile → its stored `publicGroup` reconstructs as
-`Just{…}` equal to the link's → `profileChanged` becomes false → re-approval stops.
+(`profileChanged = p /= groupProfile` is removed; `countChanged`/`verifyChanged`
+unchanged.)
 
-## 5. Why this is the most correct fix
+## 5. Why core, not the directory
 
-- **Fixes the actual root cause, and converges.** After one sync the profiles are
-  equal, so `groupUpdated` correctly reports "no change." Symptom and cause both go.
-- **It is a plain completeness fix.** The two INSERT paths and `updateRelayGroupKeys`
-  already persist `public_group_id`; `updateGroupProfile` omitting it is the bug.
-- **Safe under `COALESCE(public_group_id, ?)`** — it *only* fills a NULL. It never
-  changes a set identity, so it cannot corrupt a correct `publicGroupId`, and it
-  cannot be erased by a claim-less `XGrpInfo` (new value `Nothing` → keep old).
-  This preserves the "immutable identity" invariant while repairing missing data.
-- **General, not a directory workaround.** Any client whose `public_group_id` is
-  missing gets it repaired on the next profile sync; the fix is in shared core, as
-  intended, and needs no judgment about which fields are "moderatable."
-- **Blast radius is safe.** `updateGroupProfile` is widely called, but the only
-  behavioral change is *populating a NULL column when a profile carrying a
-  `publicGroupId` is stored* — a pure improvement for every caller.
+The defect is that a shared primitive — "did the group profile change?" — answers
+"yes" when only immutable identity differs. That is the primitive's correctness,
+not a directory policy, so it belongs where the comparison lives:
 
-## 6. Alternative considered — and why not
+- **Robust.** Compares the exact two profiles at the update site — no reliance on a
+  directory-side pre/post snapshot with an enqueue-vs-process timing window.
+- **Correct for any consumer.** The flag is directory-only today, but fixing it here
+  keeps it right for any future consumer at no extra cost.
+- **Isolation is illusory anyway.** The directory statically links core, so it is
+  rebuilt either way, and the behavioral change is directory-scoped either way.
 
-**Scope the re-approval comparison** (return `groupUpdated` from
-`updateGroupFromLinkData` computed over only the moderatable display fields,
-excluding `publicGroup`). This mirrors the contact path's `clearProofs` /
-`sameProfileContent` redaction (`Types.hs:747-750`, `:803`) and the existing
-`DirectoryTests` expectation that link-only changes must not re-approve
-(`tests/Bots/DirectoryTests.hs:296-326`). It would stop the re-approval — **but it
-only hides the symptom**: the stored `public_group_id` stays NULL, the profiles
-stay unequal, so `updateGroupFromLinkData` keeps calling `updateGroupProfile` every
-30 min to store a profile that never fully matches (idempotent churn), and any
-other consumer of the difference stays broken. §4 is preferred because it removes
-the inequality itself. (This scoping could still be added later as defense in depth
-for genuinely non-moderatable fields, but it is not needed for this bug.)
+## 6. Why this is correct, safe, and minimal
 
-## 7. Verification plan
+- **Fixes the confirmed cause and converges** the re-approval decision: an
+  identity-only difference no longer reads as a change, so `groupUpdated` is false
+  and re-approval stops.
+- **No data mutation.** It does *not* write `public_group_id`, so it cannot violate
+  any "immutable identity" assumption elsewhere; the stale stored value simply stops
+  driving moderation.
+- **No store churn.** Because `contentChanged` also gates the store, an identity-only
+  delta no longer triggers a pointless `updateGroupProfile` every 30 min.
+- **Moderation intact.** Any moderatable change (display name, full name, short
+  descr, description, image, prefs, admission, or the domain claim) still differs
+  under `clearId` and still re-approves. Only immutable identity is excluded —
+  consistent with the contact path's content-comparison (`Types.hs:747-750`
+  `clearProofs`) and the existing `DirectoryTests` expectation that link/identity
+  changes must not re-approve (`tests/Bots/DirectoryTests.hs:296-326`).
 
-1. Confirm on the affected directory that the channel's `public_group_id` is NULL
-   while the link carries a `publicGroupId` (validates §3; one SELECT).
+## 7. Alternatives considered — and why not
+
+- **Persist the column** (`public_group_id = COALESCE(?, public_group_id)`, adopt the
+  link's value). Also converges, but it **mutates an "immutable" identity** on every
+  profile sync and risks assumptions elsewhere; identity repair is a bigger, riskier
+  change than simply not moderating on identity.
+- **Directory-only** (compare `gInfo` vs `g'` at `Service.hs:824` instead of
+  `groupUpdated`). Works — both are stored-side, so the stale `publicGroupId` is
+  equal on both and never fires — but it relies on `gInfo` being a faithful
+  pre-update snapshot (enqueue-vs-process window) and leaves `groupUpdated`
+  misleading for any future consumer. Core is preferred per §5.
+
+## 8. Verification plan
+
+1. **Regression test** in `tests/Bots/DirectoryTests.hs` (beside the existing
+   "link/whitespace-only must not re-approve" tests, `:296-326`): register a channel
+   with one `public_group_id`, then make the fetched link carry a *different*
+   `publicGroupId` (all other fields equal), run ≥2 link checks, and assert the reg
+   stays `GRSActive` (no `GRSPendingApproval`, no owner re-approval message). Add a
+   positive control: a display-name change *does* re-approve.
 2. Apply §4.
-3. **Regression test** in `tests/Bots/DirectoryTests.hs` (sits alongside the
-   existing "link-only / whitespace-only must not re-approve" tests at `:296-326`):
-   register a channel whose stored `public_group_id` is NULL → add a SimpleX name /
-   populate the link `publicGroupId` → run ≥2 link checks → assert the registration
-   stays `GRSActive` (no `GRSPendingApproval`, no owner re-approval message). Also
-   assert the group's `public_group_id` is populated after the first check.
-4. Build the directory service (which statically links core); run the directory
-   test suite.
+3. Build the directory service (statically links core); run the directory suite.
 
-## 8. Files touched
+## 9. Files touched
 
-- `src/Simplex/Chat/Store/Groups.hs` — `updateGroupProfile`: add
-  `public_group_id = COALESCE(public_group_id, ?)` to the UPDATE and thread the
-  `publicGroupId_` parameter (as the INSERT paths do). No other logic change.
-- `tests/Bots/DirectoryTests.hs` — add the name-added / NULL-`public_group_id`
-  no-reapproval regression test.
-
-No schema, wire-format, or API changes. `updateGroupProfile`'s signature is
-unchanged; it simply stops dropping a column it is already given.
+- `src/Simplex/Chat/Library/Internal.hs` — `updateGroupFromLinkData`: replace
+  `profileChanged` (store guard + returned flag) with a `publicGroupId`-insensitive
+  `contentChanged`. No store, schema, wire, or API change.
+- `tests/Bots/DirectoryTests.hs` — add the identity-difference no-reapproval
+  regression test (+ display-name positive control).

--- a/src/Simplex/Chat/Library/Internal.hs
+++ b/src/Simplex/Chat/Library/Internal.hs
@@ -1479,7 +1479,13 @@ updateGroupFromLinkData user gInfo@GroupInfo {groupProfile = p, groupDomainVerif
         pure (g'', profileChanged)
   | otherwise = pure (gInfo, False)
   where
-    profileChanged = p /= groupProfile
+    -- publicGroupId is immutable identity, not content, and is not a column
+    -- updateGroupProfile syncs (it is set at group creation / by updateRelayGroupKeys).
+    -- A stale stored value would otherwise make this (/=) re-trigger directory
+    -- approval on every link check. Normalize it out (mirrors sameGroupProfileInfo).
+    profileChanged = clearId p /= clearId groupProfile
+    clearId gp@GroupProfile {publicGroup} =
+      gp {publicGroup = (\pg -> (pg :: PublicGroupProfile) {publicGroupId = B64UrlByteString ""}) <$> publicGroup}
     countChanged = case publicGroupData of
       Just PublicGroupData {publicMemberCount} -> Just publicMemberCount /= localCount
       _ -> False

--- a/tests/Bots/DirectoryTests.hs
+++ b/tests/Bots/DirectoryTests.hs
@@ -99,6 +99,7 @@ directoryServiceTests = do
     it "should delete channel registration and leave" testDeleteChannelRegistration
     it "should handle re-registration when already listed" testReregistrationAlreadyListed
     it "should update subscriber count periodically" testLinkCheckUpdatesCount
+    it "should not re-approve when only stored publicGroupId is stale" testLinkCheckStalePublicGroupId
 
 directoryProfile :: Profile
 directoryProfile = Profile {displayName = "SimpleX Directory", fullName = "", shortDescr = Nothing, image = Nothing, contactLink = Nothing, peerType = Just CPTBot, preferences = Nothing, badge = Nothing, contactDomain = Nothing}
@@ -2306,6 +2307,75 @@ testLinkCheckUpdatesCount ps = do
             bob <##. "Link to join channel: "
             bob <## "You need SimpleX Chat app v6.5 to join."
             bob <## "3 subscribers"
+
+-- Regression: a stale stored publicGroupId (which updateGroupProfile never re-syncs)
+-- differs from the link's on every link check. Before the fix this re-approved the
+-- channel every linkCheckInterval; after it, a publicGroupId-only difference is
+-- ignored and the channel stays listed. (See plans/2026-07-06-fix-directory-name-reapproval.md)
+testLinkCheckStalePublicGroupId :: HasCallStack => TestParams -> IO ()
+testLinkCheckStalePublicGroupId ps = do
+  dsLink <-
+    withNewTestChatCfg ps testCfg serviceDbPrefix directoryProfile $ \ds ->
+      withNewTestChatCfg ps testCfg "super_user" aliceProfile $ \superUser -> do
+        connectUsers ds superUser
+        ds ##> "/ad"
+        getContactLink ds True
+  let opts = (mkDirectoryOpts ps [KnownContact 2 "alice"] Nothing Nothing) {linkCheckInterval = 1}
+  runDirectory testCfg opts $
+    withTestChatCfg ps testCfg "super_user" $ \superUser -> do
+      superUser <## "subscribed 1 connections on server localhost"
+      withNewTestChatCfg ps testCfg "bob" bobProfile $ \bob ->
+        withRelay ps $ \relay -> do
+          bob `connectVia` dsLink
+          _ <- prepareChannel1Relay "news" bob relay
+          -- register and approve
+          bob ##> "/share chat #news @'SimpleX Directory'"
+          bob <# "@'SimpleX Directory' link to join channel #news (signed):"
+          _ <- getTermLine bob -- short link
+          _ <- getTermLine bob -- ownerSig JSON
+          bob <# "'SimpleX Directory'> Joining the channel news…"
+          concurrentlyN_
+            [ do
+                relay <## "'SimpleX Directory': accepting request to join group #news..."
+                relay <## "#news: 'SimpleX Directory' joined the group",
+              bob <## "#news: relay introduced 'SimpleX Directory_1' in the channel"
+            ]
+          bob <# "'SimpleX Directory'> Joined the channel news. Registration is pending approval — it may take up to 48 hours."
+          bob <# "'SimpleX Directory'> We recommend allowing direct messages, media, voice, and SimpleX links only for group moderators and admins. Use group preferences to set them."
+          bob <## "Captcha verification is enabled. Use /'filter 1' to change it."
+          superUser <# "'SimpleX Directory'> bob submitted the channel ID 1:"
+          superUser <## "news"
+          superUser <##. "Link to join channel: "
+          superUser <## "You need SimpleX Chat app v6.5 to join."
+          superUser <## "1 subscribers"
+          superUser <## ""
+          superUser <## "To approve send:"
+          superUser <# "'SimpleX Directory'> /approve 1:news 1"
+          let approve = "/approve 1:news 1"
+          superUser #> ("@'SimpleX Directory' " <> approve)
+          superUser <# ("'SimpleX Directory'> > " <> approve)
+          superUser <## "      Channel approved!"
+          bob <# "'SimpleX Directory'> The channel ID 1 (news) is approved and listed in directory - please moderate it!"
+          bob <## "Please note: if you change the channel profile it will be hidden from directory until it is re-approved."
+          -- Corrupt the directory's STORED public_group_id so it differs from the link's
+          -- (simulates the stale identity that updateGroupProfile never re-syncs). Value
+          -- stays non-NULL, so publicGroup remains Just and the link check still runs.
+          let sql = "/x /sql chat UPDATE group_profiles SET public_group_id = randomblob(32) WHERE public_group_id IS NOT NULL"
+          superUser #> ("@'SimpleX Directory' " <> sql)
+          superUser <# ("'SimpleX Directory'> > " <> sql)
+          superUser <## ""
+          -- allow >= 1 link check (interval = 1s) to run
+          threadDelay 1500000
+          -- channel is still listed and active (no re-approval); had it re-approved,
+          -- bob's search would first receive the "profile has changed" message and this
+          -- sequence would fail.
+          bob #> "@'SimpleX Directory' news"
+          bob <# "'SimpleX Directory'> > news"
+          bob <## "      Found 1 group(s)."
+          bob <# "'SimpleX Directory'> news"
+          bob <##. "Link to join channel: "
+          bob <## "You need SimpleX Chat app v6.5 to join."
+          bob <## "2 subscribers"
 
 testGetCaptchaStr :: HasCallStack => TestParams -> IO ()
 testGetCaptchaStr _ps = do


### PR DESCRIPTION
## Problem

After an owner adds a SimpleX name (blockchain domain claim) to a public channel, the SimpleX Directory service re-approves the channel **every ~30 minutes, indefinitely**, with no changes on the owner's side (it keeps flipping to "hidden until approved").

## Root cause

The directory's periodic link check re-approves whenever `updateGroupFromLinkData` reports the profile changed. That flag was a full structural comparison `p /= groupProfile` (`Simplex.Chat.Library.Internal`), which includes `publicGroupId` — an **immutable identity field that `updateGroupProfile` never re-syncs** (it's written only at group creation and by `updateRelayGroupKeys`).

So if the directory's stored `public_group_id` drifts from the link's, the comparison is true on **every** link check and can never converge, re-approving forever. Adding a name is merely the occasion that surfaces the pre-existing mismatch. By elimination, `publicGroupId` is the only `Eq`-relevant field `updateGroupProfile` doesn't persist, so it's the only field that can produce a permanent mismatch.

## Fix

Normalize `publicGroupId` out of the change comparison in `updateGroupFromLinkData` (used for both the store guard and the returned flag), so only fields `updateGroupProfile` actually manages drive the change signal. Mirrors the existing `sameGroupProfileInfo` / `clearProofs` content-comparison idiom.

One-field change; no schema, wire-format, or API change. The flag is consumed only by the directory service.

## Testing

Adds `testLinkCheckStalePublicGroupId` (`tests/Bots/DirectoryTests.hs`): register + approve a channel, corrupt the directory's stored `public_group_id` so it differs from the link's, run a link check, and assert the channel stays listed.

- Passes with the fix.
- **Fails without** the fix — the link check emits `The channel ID 1 (news) profile changed` (the exact re-approval symptom) — confirming the test guards the bug.

`simplex-directory-service` and `simplex-chat-test` both build.

Design notes and the full root-cause analysis are in `plans/2026-07-06-fix-directory-name-reapproval.md`.
