### PR TITLE
android, desktop: don't allow swipe-to-reply to a marked-deleted message

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
@@ -1960,7 +1960,7 @@ fun BoxScope.ChatItemsList(
           }
           false
         }
-        val swipeableModifier = if (appPlatform.isDesktop || !chatInfo.sendMsgEnabled) Modifier else SwipeToDismissModifier(
+        val swipeableModifier = if (appPlatform.isDesktop || !chatInfo.sendMsgEnabled || cItem.meta.itemDeleted != null) Modifier else SwipeToDismissModifier(
           state = dismissState,
           directions = setOf(DismissDirection.EndToStart),
           swipeDistance = with(LocalDensity.current) { 30.dp.toPx() },


### PR DESCRIPTION
Swiping a marked-deleted message opened the reply/quote composer even though the context menu (correctly) hides Reply for it, and sending the reply then failed with an error. The swipe handler's condition in `ChatView.kt` was missing the `itemDeleted == null` check that the menu and the swipe-reply indicator already enforce via `canReply`. Added that single check so swipe-to-reply is blocked for marked-deleted messages, matching the menu behavior.