### PR TITLE
ios: keep desktop remote session alive in background

### DIFF
--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -109,6 +109,6 @@ cd path/to/assets && ./resize.sh
 ## Background Capabilities
 
 Configured in Info.plist:
-- Background modes: audio, fetch, remote-notification, voip
+- Background modes: audio, fetch, processing, remote-notification, voip
 - URL scheme: `simplex://` for deep linking
-- BGTaskScheduler: `chat.simplex.app.receive`
+- BGTaskScheduler: `chat.simplex.app.receive`, `chat.simplex.app.remote-control.keepalive.*`

--- a/apps/ios/Shared/Model/RemoteCtrlBGKeepAlive.swift
+++ b/apps/ios/Shared/Model/RemoteCtrlBGKeepAlive.swift
@@ -1,0 +1,231 @@
+//
+//  RemoteCtrlBGKeepAlive.swift
+//  SimpleX (iOS)
+//
+//  Copyright (c) 2026 SimpleX Chat. All rights reserved.
+//
+
+import Foundation
+import UIKit
+@preconcurrency import BackgroundTasks
+import SimpleXChat
+
+private let remoteCtrlKeepAliveTaskPrefix = "chat.simplex.app.remote-control.keepalive"
+private let remoteCtrlKeepAliveTaskWildcardId = "\(remoteCtrlKeepAliveTaskPrefix).*"
+private let remoteCtrlKeepAliveTaskId = "\(remoteCtrlKeepAliveTaskPrefix).session"
+
+@MainActor
+final class RemoteCtrlBGKeepAlive {
+    static let shared = RemoteCtrlBGKeepAlive()
+
+    private let continuedProcessingTitle = "Desktop background session"
+    private let continuedProcessingMaxSeconds: Int64 = 15 * 60
+
+    private var running = false
+    private var stopping = false
+    private var registeredContinuedProcessing = false
+    private var startedAt: Date?
+    private var progressTimer: Timer?
+    private var endTask: ((Bool) -> Void)?
+
+    private init() {}
+
+    func start() {
+        guard !running, !stopping else { return }
+        guard ChatModel.shared.activeRemoteCtrl else { return }
+
+        running = true
+        startedAt = .now
+
+        if #available(iOS 26.0, *) {
+            startContinuedProcessing()
+        } else {
+            startShortBackgroundTask()
+        }
+    }
+
+    func stopKeepingSession() {
+        guard running else { return }
+        finishKeepingSession(success: true)
+    }
+
+    func explicitDisconnect() async throws {
+        guard !stopping else { return }
+        stopping = true
+        defer { stopping = false }
+        do {
+            try await stopRemoteCtrl()
+            finishKeepingSession(success: true)
+            clearRemoteCtrlSessionAfterStop()
+        } catch {
+            finishKeepingSession(success: false)
+            throw error
+        }
+    }
+
+    func expire(force: Bool = false) async {
+        guard force || running || endTask != nil else { return }
+        guard !stopping else {
+            finishKeepingSession(success: false)
+            return
+        }
+        stopping = true
+        defer { stopping = false }
+        try? await stopRemoteCtrl()
+        clearRemoteCtrlSessionAfterStop()
+        finishKeepingSession(success: false)
+    }
+
+    private func startShortBackgroundTask() {
+        var taskId: UIBackgroundTaskIdentifier = .invalid
+        taskId = UIApplication.shared.beginBackgroundTask(withName: "RemoteCtrlBGKeepAlive") {
+            Task { @MainActor in
+                await RemoteCtrlBGKeepAlive.shared.expire()
+            }
+        }
+        guard taskId != .invalid else {
+            Task { @MainActor in
+                await RemoteCtrlBGKeepAlive.shared.expire(force: true)
+            }
+            return
+        }
+        endTask = { _ in
+            if taskId != .invalid {
+                UIApplication.shared.endBackgroundTask(taskId)
+                taskId = .invalid
+            }
+        }
+    }
+
+    @available(iOS 26.0, *)
+    private func startContinuedProcessing() {
+        guard registerContinuedProcessing() else {
+            startShortBackgroundTask()
+            return
+        }
+
+        let taskId = continuedProcessingTaskId()
+        let request = BGContinuedProcessingTaskRequest(
+            identifier: taskId,
+            title: continuedProcessingTitle,
+            subtitle: continuedProcessingSubtitle()
+        )
+        request.strategy = .fail
+
+        do {
+            try BGTaskScheduler.shared.submit(request)
+            endTask = { _ in
+                BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: taskId)
+            }
+        } catch {
+            startShortBackgroundTask()
+        }
+    }
+
+    @available(iOS 26.0, *)
+    private func registerContinuedProcessing() -> Bool {
+        if registeredContinuedProcessing { return true }
+        registeredContinuedProcessing = BGTaskScheduler.shared.register(forTaskWithIdentifier: remoteCtrlKeepAliveTaskWildcardId, using: nil) { task in
+            guard let task = task as? BGContinuedProcessingTask else {
+                task.setTaskCompleted(success: false)
+                return
+            }
+            Task { @MainActor in
+                RemoteCtrlBGKeepAlive.shared.handleContinuedProcessing(task)
+            }
+        }
+        return registeredContinuedProcessing
+    }
+
+    @available(iOS 26.0, *)
+    private func handleContinuedProcessing(_ task: BGContinuedProcessingTask) {
+        guard running, ChatModel.shared.activeRemoteCtrl else {
+            task.setTaskCompleted(success: false)
+            return
+        }
+
+        task.expirationHandler = {
+            Task { @MainActor in
+                await RemoteCtrlBGKeepAlive.shared.expire()
+            }
+        }
+        startProgressUpdates(task)
+        endTask = { [weak task] success in
+            self.stopProgressUpdates()
+            task?.setTaskCompleted(success: success)
+        }
+    }
+
+    @available(iOS 26.0, *)
+    private func startProgressUpdates(_ task: BGContinuedProcessingTask) {
+        stopProgressUpdates()
+        task.progress.totalUnitCount = continuedProcessingMaxSeconds
+        updateContinuedProcessing(task)
+        progressTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak task] _ in
+            Task { @MainActor in
+                guard let task = task else { return }
+                RemoteCtrlBGKeepAlive.shared.updateContinuedProcessing(task)
+            }
+        }
+    }
+
+    @available(iOS 26.0, *)
+    private func updateContinuedProcessing(_ task: BGContinuedProcessingTask) {
+        task.updateTitle(continuedProcessingTitle, subtitle: continuedProcessingSubtitle())
+        let elapsed = elapsedSeconds()
+        task.progress.completedUnitCount = min(elapsed, continuedProcessingMaxSeconds)
+        if elapsed >= continuedProcessingMaxSeconds {
+            Task { @MainActor in
+                await RemoteCtrlBGKeepAlive.shared.expire(force: true)
+            }
+        }
+    }
+
+    private func stopProgressUpdates() {
+        progressTimer?.invalidate()
+        progressTimer = nil
+    }
+
+    private func finishKeepingSession(success: Bool) {
+        running = false
+        stopProgressUpdates()
+        let end = endTask
+        endTask = nil
+        startedAt = nil
+        end?(success)
+    }
+
+    private func clearRemoteCtrlSessionAfterStop() {
+        if case .connected = ChatModel.shared.remoteCtrlSession?.sessionState {
+            switchToLocalSession()
+        } else {
+            ChatModel.shared.remoteCtrlSession = nil
+        }
+    }
+
+    private func continuedProcessingSubtitle() -> String {
+        "Ends in \(formatDuration(max(0, continuedProcessingMaxSeconds - elapsedSeconds())))"
+    }
+
+    private func elapsedSeconds() -> Int64 {
+        guard let startedAt = startedAt else { return 0 }
+        return max(0, Int64(Date.now.timeIntervalSince(startedAt)))
+    }
+
+    private func continuedProcessingTaskId() -> String {
+        remoteCtrlKeepAliveTaskId
+    }
+
+    private func formatDuration(_ seconds: Int64) -> String {
+        let hours = seconds / 3600
+        let minutes = (seconds % 3600) / 60
+        let secs = seconds % 60
+        if hours > 0 {
+            return "\(hours)h \(minutes)m"
+        } else if minutes > 0 {
+            return "\(minutes)m \(secs)s"
+        } else {
+            return "\(secs)s"
+        }
+    }
+}

--- a/apps/ios/Shared/Model/SimpleXAPI.swift
+++ b/apps/ios/Shared/Model/SimpleXAPI.swift
@@ -2906,6 +2906,7 @@ func processReceivedMsg(_ res: ChatEvent) async {
         // e.g. when user did not grant permission to access local network yet.
         if let sess = m.remoteCtrlSession {
             await MainActor.run {
+                RemoteCtrlBGKeepAlive.shared.stopKeepingSession()
                 m.remoteCtrlSession = nil
                 dismissAllSheets() {
                     switch rcStopReason {

--- a/apps/ios/Shared/Model/SuspendChat.swift
+++ b/apps/ios/Shared/Model/SuspendChat.swift
@@ -50,12 +50,18 @@ let seSubscriber = seMessageSubscriber {
 
 func suspendChat() {
     suspendLockQueue.sync {
+        if ChatModel.shared.activeRemoteCtrl {
+            return
+        }
         _suspendChat(timeout: appSuspendTimeout)
     }
 }
 
 func suspendBgRefresh() {
     suspendLockQueue.sync {
+        if ChatModel.shared.activeRemoteCtrl {
+            return
+        }
         if case .bgRefresh = AppChatState.shared.value  {
             _suspendChat(timeout: bgSuspendTimeout)
         }

--- a/apps/ios/Shared/SimpleXApp.swift
+++ b/apps/ios/Shared/SimpleXApp.swift
@@ -76,7 +76,9 @@ struct SimpleXApp: App {
                         chatModel.contentViewAccessAuthenticated = false
                         // authentication ---
 
-                        if CallController.useCallKit() && chatModel.activeCall != nil {
+                        if chatModel.activeRemoteCtrl {
+                            RemoteCtrlBGKeepAlive.shared.start()
+                        } else if CallController.useCallKit() && chatModel.activeCall != nil {
                             CallController.shared.shouldSuspendChat = true
                         } else {
                             suspendChat()
@@ -84,6 +86,7 @@ struct SimpleXApp: App {
                         }
                         NtfManager.shared.setNtfBadgeCount(chatModel.totalUnreadCountForAllUsers())
                     case .active:
+                        RemoteCtrlBGKeepAlive.shared.stopKeepingSession()
                         CallController.shared.shouldSuspendChat = false
                         let appState = AppChatState.shared.value
 

--- a/apps/ios/Shared/Views/Chat/ChatView.swift
+++ b/apps/ios/Shared/Views/Chat/ChatView.swift
@@ -47,7 +47,7 @@ struct ChatView: View {
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.presentationMode) var presentationMode
     @Environment(\.scenePhase) var scenePhase
-    @State @ObservedObject var chat: Chat
+    @State var chat: Chat
     @ObservedObject var im: ItemsModel
     @State var mergedItems: BoxedValue<MergedItems>
     @State var floatingButtonModel: FloatingButtonModel
@@ -93,6 +93,18 @@ struct ChatView: View {
     @AppStorage(DEFAULT_TOOLBAR_MATERIAL) private var toolbarMaterial = ToolbarMaterial.defaultMaterial
 
     let userSupportScopeInfo: GroupChatScopeInfo = .memberSupport(groupMember_: nil)
+
+    private var selectedChatItemsCount: Int {
+        selectedChatItems?.count ?? 0
+    }
+
+    private var deleteSelectedMessagesTitle: LocalizedStringKey {
+        selectedChatItemsCount == 1 ? "Delete message?" : "Delete \(selectedChatItemsCount) messages?"
+    }
+
+    private var archiveSelectedReportsTitle: LocalizedStringKey {
+        selectedChatItemsCount == 1 ? "Archive report?" : "Archive \(selectedChatItemsCount) reports?"
+    }
 
     // Spec: spec/client/chat-view.md#body
     var body: some View {
@@ -228,7 +240,7 @@ struct ChatView: View {
         .background(theme.colors.background)
         .navigationBarTitleDisplayMode(.inline)
         .environmentObject(theme)
-        .confirmationDialog(selectedChatItems?.count == 1 ? "Delete message?" : "Delete \((selectedChatItems?.count ?? 0)) messages?", isPresented: $showDeleteSelectedMessages, titleVisibility: .visible) {
+        .confirmationDialog(deleteSelectedMessagesTitle, isPresented: $showDeleteSelectedMessages, titleVisibility: .visible) {
             Button("Delete for me", role: .destructive) {
                 if let selected = selectedChatItems {
                     deleteMessages(chat, selected.sorted(), .cidmInternal, moderate: false, deletedSelectedMessages)                }
@@ -242,7 +254,7 @@ struct ChatView: View {
                 }
             }
         }
-        .confirmationDialog(selectedChatItems?.count == 1 ? "Archive report?" : "Archive \((selectedChatItems?.count ?? 0)) reports?", isPresented: $showArchiveSelectedReports, titleVisibility: .visible) {
+        .confirmationDialog(archiveSelectedReportsTitle, isPresented: $showArchiveSelectedReports, titleVisibility: .visible) {
             Button("For me", role: .destructive) {
                 if let selected = selectedChatItems {
                     archiveReports(chat, selected.sorted(), false, deletedSelectedMessages)
@@ -418,25 +430,7 @@ struct ChatView: View {
                 }
             }
         }
-        .onDisappear {
-            ConnectProgressManager.shared.cancelConnectProgress()
-            VideoPlayerView.players.removeAll()
-            stopAudioPlayer()
-            if chatModel.chatId == cInfo.id && !presentationMode.wrappedValue.isPresented {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
-                    if chatModel.chatId == nil {
-                        chatModel.chatAgentConnId = nil
-                        chatModel.chatSubStatus = nil
-                        im.reversedChatItems = []
-                        im.chatState.clear()
-                        chatModel.groupMembers = []
-                        chatModel.groupMembersIndexes.removeAll()
-                        chatModel.membersLoaded = false
-                        ChannelRelaysModel.shared.reset()
-                    }
-                }
-            }
-        }
+        .onDisappear(perform: handleChatViewDisappear)
         .onChange(of: colorScheme) { _ in
             theme = buildTheme()
         }
@@ -792,6 +786,43 @@ struct ChatView: View {
         floatingButtonModel.updateOnListChange(scrollView.listState)
     }
 
+    private func handleChatViewDisappear() {
+        ConnectProgressManager.shared.cancelConnectProgress()
+        VideoPlayerView.players.removeAll()
+        stopAudioPlayer()
+        cleanupChatOnDisappear(chat.id)
+    }
+
+    private func cleanupChatOnDisappear(_ chatId: ChatId) {
+        guard chatModel.chatId == chatId && !presentationMode.wrappedValue.isPresented else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+            guard chatModel.chatId == nil else { return }
+            chatModel.chatAgentConnId = nil
+            chatModel.chatSubStatus = nil
+            im.reversedChatItems = []
+            im.chatState.clear()
+            chatModel.groupMembers = []
+            chatModel.groupMembersIndexes.removeAll()
+            chatModel.membersLoaded = false
+            ChannelRelaysModel.shared.reset()
+        }
+    }
+
+    private func updateMergedItems(_ revealed: Set<Int64>) {
+        let items = MergedItems.create(im, revealed)
+        mergedItems.boxedValue = items
+        scrollView.updateItems(items.items)
+    }
+
+    private func chatItemMaxWidth(_ cInfo: ChatInfo, width: CGFloat, voiceNoFrame: Bool, channelReceived: Bool, channelReceivedNoAvatar: Bool) -> CGFloat {
+        if cInfo.chatType == .group {
+            if channelReceivedNoAvatar { return width - 26 }
+            if voiceNoFrame || channelReceived { return (width - 28) - 42 }
+            return (width - 28) * 0.84 - 42
+        }
+        return voiceNoFrame ? width - 32 : (width - 32) * 0.84
+    }
+
     private func updateAvailableContent() {
         Task {
             let content: [ContentFilter]
@@ -923,15 +954,13 @@ struct ChatView: View {
                         // left padding (see .leading padding below), so they get the full row width here
                         // too — otherwise the reserved avatar inset would leave a gap on the right
                         let channelReceivedNoAvatar = channelReceived && !shouldShowAvatar(mergedItem.newest().item, mergedItem.oldest().nextItem)
-                        let maxWidth = cInfo.chatType == .group
-                        ? channelReceivedNoAvatar
-                        ? g.size.width - 26
-                        : voiceNoFrame || channelReceived
-                        ? (g.size.width - 28) - 42
-                        : (g.size.width - 28) * 0.84 - 42
-                        : voiceNoFrame
-                        ? (g.size.width - 32)
-                        : (g.size.width - 32) * 0.84
+                        let maxWidth = chatItemMaxWidth(
+                            cInfo,
+                            width: g.size.width,
+                            voiceNoFrame: voiceNoFrame,
+                            channelReceived: channelReceived,
+                            channelReceivedNoAvatar: channelReceivedNoAvatar
+                        )
                         ChatItemWithMenu(
                             im: im,
                             chat: $chat,
@@ -982,8 +1011,7 @@ struct ChatView: View {
                 }
             }
             .onChange(of: revealedItems) { revealed in
-                mergedItems.boxedValue = MergedItems.create(im, revealed)
-                scrollView.updateItems(mergedItems.boxedValue.items)
+                updateMergedItems(revealed)
             }
             .onChange(of: chat.id) { _ in
                 allowLoadMoreItems = false
@@ -1004,7 +1032,7 @@ struct ChatView: View {
     struct ChatBannerView: View {
         @EnvironmentObject var theme: AppTheme
         @AppStorage(DEFAULT_CHAT_ITEM_ROUNDNESS) private var roundness = defaultChatItemRoundness
-        @Binding @ObservedObject var chat: Chat
+        @Binding var chat: Chat
         @State private var showSecrets: Set<Int> = []
 
         var body: some View {
@@ -1695,7 +1723,7 @@ struct ChatView: View {
         @EnvironmentObject var m: ChatModel
         @EnvironmentObject var theme: AppTheme
         @AppStorage(DEFAULT_PROFILE_IMAGE_CORNER_RADIUS) private var profileRadius = defaultProfileImageCorner
-        @Binding @ObservedObject var chat: Chat
+        @Binding var chat: Chat
         @ObservedObject var dummyModel: ChatItemDummyModel = .shared
         let index: Int
         let isLastItem: Bool

--- a/apps/ios/Shared/Views/ChatList/ChatListView.swift
+++ b/apps/ios/Shared/Views/ChatList/ChatListView.swift
@@ -347,10 +347,28 @@ struct ChatListView: View {
     
     @ViewBuilder var trailingToolbarItem: some View {
         switch chatModel.chatRunning {
-        case .some(true): NewChatMenuButton(showNewChatSheet: $showNewChatSheet)
+        case .some(true):
+            HStack(spacing: 10) {
+                if chatModel.activeRemoteCtrl {
+                    remoteCtrlIndicator()
+                }
+                NewChatMenuButton(showNewChatSheet: $showNewChatSheet)
+            }
         case .some(false): chatStoppedIcon()
         case .none: EmptyView()
         }
+    }
+
+    private func remoteCtrlIndicator() -> some View {
+        Button {
+            activeUserPickerSheet = .useFromDesktop
+        } label: {
+            Image(systemName: "wifi")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(.accentColor)
+                .frame(width: 28, height: 28)
+        }
+        .accessibilityLabel("Desktop connected")
     }
     
     private var shouldShowOnboarding: Bool {

--- a/apps/ios/Shared/Views/RemoteAccess/ConnectDesktopView.swift
+++ b/apps/ios/Shared/Views/RemoteAccess/ConnectDesktopView.swift
@@ -89,7 +89,9 @@ struct ConnectDesktopView: View {
             updateRemoteCtrls()
             showConnectScreen = !useMulticast
             if m.remoteCtrlSession != nil {
-                disconnectDesktop()
+                if !m.activeRemoteCtrl {
+                    disconnectDesktop()
+                }
             } else if useMulticast {
                 findKnownDesktop()
             }
@@ -103,16 +105,13 @@ struct ConnectDesktopView: View {
             }
         }
         .onDisappear {
-            if m.remoteCtrlSession != nil {
+            if m.remoteCtrlSession != nil && !m.activeRemoteCtrl {
                 showConnectScreen = false
                 disconnectDesktop()
             }
         }
         .onChange(of: deviceName) {
             setDeviceName($0)
-        }
-        .onChange(of: m.activeRemoteCtrl) {
-            UIApplication.shared.isIdleTimerDisabled = $0
         }
         .alert(item: $alert) { a in
             switch a {
@@ -145,7 +144,7 @@ struct ConnectDesktopView: View {
                 mkAlert(title: title, message: error)
             }
         }
-        .interactiveDismissDisabled(m.activeRemoteCtrl)
+        .interactiveDismissDisabled(m.remoteCtrlSession != nil && !m.activeRemoteCtrl)
     }
 
     private func connectDesktopView(showScanner: Bool = true) -> some View {
@@ -299,7 +298,7 @@ struct ConnectDesktopView: View {
                 disconnectButton()
             } footer: {
                 // This is specific to iOS
-                Text("Keep the app open to use it from desktop")
+                Text("Desktop can stay connected while this app is in background")
                     .foregroundColor(theme.colors.secondary)
             }
         }
@@ -475,9 +474,8 @@ struct ConnectDesktopView: View {
                 let rc = try await verifyRemoteCtrlSession(sessCode)
                 await MainActor.run {
                     m.remoteCtrlSession = m.remoteCtrlSession?.updateState(.connected(remoteCtrl: rc, sessionCode: sessCode))
-                }
-                await MainActor.run {
                     updateRemoteCtrls()
+                    dismiss()
                 }
             } catch let error {
                 await MainActor.run {
@@ -498,13 +496,8 @@ struct ConnectDesktopView: View {
     private func disconnectDesktop(_ action: UserDisconnectAction? = nil) {
         Task {
             do {
-                try await stopRemoteCtrl()
+                try await RemoteCtrlBGKeepAlive.shared.explicitDisconnect()
                 await MainActor.run {
-                    if case .connected = m.remoteCtrlSession?.sessionState {
-                        switchToLocalSession()
-                    } else {
-                        m.remoteCtrlSession = nil
-                    }
                     switch action {
                     case .back: dismiss()
                     case .dismiss: dismiss()

--- a/apps/ios/SimpleX--iOS--Info.plist
+++ b/apps/ios/SimpleX--iOS--Info.plist
@@ -5,6 +5,7 @@
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>chat.simplex.app.receive</string>
+		<string>chat.simplex.app.remote-control.keepalive.*</string>
 	</array>
 	<key>CFBundleIcons</key>
 	<dict>
@@ -53,6 +54,7 @@
 	<array>
 		<string>audio</string>
 		<string>fetch</string>
+		<string>processing</string>
 		<string>remote-notification</string>
 		<string>voip</string>
 	</array>

--- a/apps/ios/SimpleX.xcodeproj/project.pbxproj
+++ b/apps/ios/SimpleX.xcodeproj/project.pbxproj
@@ -265,6 +265,7 @@
 		E5DDBE702DC4217900A0EFF0 /* NSEAPITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5DDBE6F2DC4217900A0EFF0 /* NSEAPITypes.swift */; };
 		E5E418012F83D2CA00252B9E /* OnboardingCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E418002F83D2CA00252B9E /* OnboardingCards.swift */; };
 		E5E418022F83D2CA00252B9E /* ChannelWebAccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E418032F83D2CA00252B9E /* ChannelWebAccessView.swift */; };
+		E5F000022FE0000000000001 /* RemoteCtrlBGKeepAlive.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F000012FE0000000000001 /* RemoteCtrlBGKeepAlive.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -372,6 +373,7 @@
 		5C2E261127A30FEA00F70299 /* TerminalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalView.swift; sourceTree = "<group>"; };
 		5C35CFC727B2782E00FB6C6D /* BGManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BGManager.swift; sourceTree = "<group>"; };
 		5C35CFCA27B2E91D00FB6C6D /* NtfManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NtfManager.swift; sourceTree = "<group>"; };
+		E5F000012FE0000000000001 /* RemoteCtrlBGKeepAlive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteCtrlBGKeepAlive.swift; sourceTree = "<group>"; };
 		5C36027227F47AD5009F19D9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		5C371E4E2BA9AAA200100AD3 /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/Localizable.strings; sourceTree = "<group>"; };
 		5C371E4F2BA9AB6400100AD3 /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = "hu.lproj/SimpleX--iOS--InfoPlist.strings"; sourceTree = "<group>"; };
@@ -848,6 +850,7 @@
 				5C2E260627A2941F00F70299 /* SimpleXAPI.swift */,
 				5C35CFC727B2782E00FB6C6D /* BGManager.swift */,
 				5C35CFCA27B2E91D00FB6C6D /* NtfManager.swift */,
+				E5F000012FE0000000000001 /* RemoteCtrlBGKeepAlive.swift */,
 				5CB346E42868AA7F001FD2EF /* SuspendChat.swift */,
 				5CF937212B25034A00E1D781 /* NSESubscriber.swift */,
 				5CB346E82869E8BA001FD2EF /* PushEnvironment.swift */,
@@ -1571,6 +1574,7 @@
 				D72A9088294BD7A70047C86D /* NativeTextEditor.swift in Sources */,
 				B70CE9E62D4BE5930080F36D /* GroupMentions.swift in Sources */,
 				CE984D4B2C36C5D500E3AEFF /* ChatItemClipShape.swift in Sources */,
+				E5F000022FE0000000000001 /* RemoteCtrlBGKeepAlive.swift in Sources */,
 				64D0C2C629FAC1EC00B38D5F /* AddContactLearnMore.swift in Sources */,
 				5C3A88D127DF57800060F1C2 /* FramedItemView.swift in Sources */,
 				5C65F343297D45E100B67AF3 /* VersionView.swift in Sources */,

--- a/apps/ios/spec/architecture.md
+++ b/apps/ios/spec/architecture.md
@@ -223,12 +223,16 @@ See [Database & Storage specification](database.md) for full details.
 ### [Scene Phase Handling (SimpleXApp.swift)](../Shared/SimpleXApp.swift#L38-L123)
 
 - **`.active`**: Calls `startChatAndActivate()`, processes pending notification responses, refreshes chat list and call invitations
-- **`.background`**: Records authentication timestamp, calls `suspendChat()` (unless CallKit call active), schedules `BGManager` background refresh, updates badge count
+- **`.background`**: Records authentication timestamp. If a remote desktop session is active, starts `RemoteCtrlBGKeepAlive` and skips normal chat suspension/background-refresh scheduling; otherwise calls `suspendChat()` (unless CallKit call active), schedules `BGManager` background refresh, and updates badge count
 - **`.inactive`**: No explicit handling (transitional state)
 
 ### CallKit Exception
 
 When a CallKit call is active during backgrounding, chat suspension is deferred (`CallController.shared.shouldSuspendChat = true`) until the call ends, to maintain the WebRTC session.
+
+### Remote Desktop Exception
+
+When a desktop remote-control session is connected, the mobile app remains the local UI owner and shows a small Wi-Fi-style indicator on the chat list toolbar. Dismissing the connect sheet after verification does not disconnect the session, allowed chat events are delivered to the local queue and to the desktop queue when the desktop queue has capacity, and `RemoteCtrlBGKeepAlive` runs only while the app is backgrounded. If the desktop queue is full, or if iOS rejects or expires the keepalive, the remote-control session is stopped rather than leaving either side stale.
 
 ---
 
@@ -261,8 +265,10 @@ Optional desktop pairing allows controlling the mobile app from a desktop client
 - **Pairing**: Encrypted QR code scanned by desktop client establishes a session
 - **Commands**: [`connectRemoteCtrl`](../Shared/Model/SimpleXAPI.swift#L1613), [`findKnownRemoteCtrl`](../Shared/Model/SimpleXAPI.swift#L1620), [`confirmRemoteCtrl`](../Shared/Model/SimpleXAPI.swift#L1624), [`verifyRemoteCtrlSession`](../Shared/Model/SimpleXAPI.swift#L1630), [`listRemoteCtrls`](../Shared/Model/SimpleXAPI.swift#L1636), [`stopRemoteCtrl`](../Shared/Model/SimpleXAPI.swift#L1642), [`deleteRemoteCtrl`](../Shared/Model/SimpleXAPI.swift#L1646)
 - **State**: [`ChatModel.remoteCtrlSession`](../Shared/Model/ChatModel.swift#L395)`: RemoteCtrlSession?` tracks the active session
+- **Connected behavior**: Once verified, the connect sheet dismisses, the chat list toolbar shows a small desktop indicator that opens the desktop connection page, and explicit Disconnect remains the user-controlled stop path
+- **Background keepalive**: `RemoteCtrlBGKeepAlive` starts when the app backgrounds with a connected desktop session, uses a bounded iOS continued-processing task when available, falls back to a short `UIApplication` background task when continued processing is unavailable, and stops the desktop session when the user disconnects or the keepalive expires
 - **Transport**: Encrypted reverse HTTP transport between mobile and desktop
-- **Source**: [`Shared/Views/RemoteAccess/ConnectDesktopView.swift`](../Shared/Views/RemoteAccess/ConnectDesktopView.swift#L1-L545), see `Remote.hs` in `../../src/Simplex/Chat/`
+- **Source**: [`Shared/Views/RemoteAccess/ConnectDesktopView.swift`](../Shared/Views/RemoteAccess/ConnectDesktopView.swift#L1-L545), [`Shared/Model/RemoteCtrlBGKeepAlive.swift`](../Shared/Model/RemoteCtrlBGKeepAlive.swift), see `Remote.hs` and `Controller.hs` in `../../src/Simplex/Chat/`
 
 ---
 

--- a/src/Simplex/Chat/Controller.hs
+++ b/src/Simplex/Chat/Controller.hs
@@ -1608,6 +1608,7 @@ data RemoteCtrlSession
         rcsSession :: RCCtrlSession,
         http2Server :: Async (),
         remoteOutputQ :: TBQueue (Either ChatError ChatEvent),
+        remoteOutputQFull :: TMVar (),
         ctrlAppInfo :: CtrlAppInfo
       }
 
@@ -1708,8 +1709,11 @@ toView_ ev = do
     Nothing -> pure ev
   atomically $
     readTVar session >>= \case
-      Just (_, RCSessionConnected {remoteOutputQ})
-        | either (const True) allowRemoteEvent event -> writeTBQueue remoteOutputQ event
+      Just (_, RCSessionConnected {remoteOutputQ, remoteOutputQFull})
+        | either (const True) allowRemoteEvent event -> do
+            remoteQFull <- isFullTBQueue remoteOutputQ
+            if remoteQFull then tryPutTMVar remoteOutputQFull () >> pure () else writeTBQueue remoteOutputQ event
+            writeTBQueue localQ (Nothing, event)
       -- TODO potentially, it should hold some events while connecting
       _ -> writeTBQueue localQ (Nothing, event)
 

--- a/src/Simplex/Chat/Remote.hs
+++ b/src/Simplex/Chat/Remote.hs
@@ -629,12 +629,16 @@ verifyRemoteCtrlSession execCC sessCode' = do
     (rcsSession@RCCtrlSession {tls, sessionKeys}, rcCtrlPairing) <- timeoutThrow (ChatErrorRemoteCtrl RCETimeout) networkIOTimeout $ takeRCStep vars
     rc@RemoteCtrl {remoteCtrlId} <- upsertRemoteCtrl ctrlName rcCtrlPairing
     remoteOutputQ <- asks (tbqSize . config) >>= newTBQueueIO
+    remoteOutputQFull <- newEmptyTMVarIO
     encryption@RemoteCrypto {compression} <- mkCtrlRemoteCrypto sessionKeys (tlsUniq tls) =<< getRemoteCtrlAppInfo sseq
     cc <- ask
-    http2Server <- liftIO . async $ attachHTTP2Server tls $ \req -> handleRemoteCommand execCC encryption remoteOutputQ req `runReaderT` cc
+    http2Server <- liftIO . async $
+      race_
+        (attachHTTP2Server tls $ \req -> handleRemoteCommand execCC encryption remoteOutputQ req `runReaderT` cc)
+        (atomically $ takeTMVar remoteOutputQFull)
     void . forkIO $ monitor sseq http2Server
     updateRemoteCtrlSession sseq $ \case
-      RCSessionPendingConfirmation {ctrlAppInfo} -> Right RCSessionConnected {remoteCtrlId, rcsClient = client, rcsSession, tls, http2Server, remoteOutputQ, ctrlAppInfo}
+      RCSessionPendingConfirmation {ctrlAppInfo} -> Right RCSessionConnected {remoteCtrlId, rcsClient = client, rcsSession, tls, http2Server, remoteOutputQ, remoteOutputQFull, ctrlAppInfo}
       _ -> Left $ ChatErrorRemoteCtrl RCEBadState
     let remoteCtrl = remoteCtrlInfo rc $ Just RCSConnected {sessionCode = tlsSessionCode tls}
     pure CRRemoteCtrlConnected {remoteCtrl, compression}

--- a/tests/RemoteTests.hs
+++ b/tests/RemoteTests.hs
@@ -11,6 +11,7 @@ import ChatTests.DBUtils
 import ChatTests.Utils
 import Control.Logger.Simple
 import Control.Monad
+import Control.Monad.Reader (runReaderT)
 import qualified Data.Aeson as J
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy.Char8 as LB
@@ -55,6 +56,7 @@ runRemoteTests = do
     it "refuses invalid client cert" remoteHandshakeRejectTest
     it "connects with stored server bindings" storedBindingsTest
   it "sends messages" remoteMessageTest
+  it "disconnects desktop when remote event queue is full" remoteQueueOverflowTest
   describe "remote files" $ do
     it "store/get/send/receive files" remoteStoreFileTest
     it "should send files from CLI without /store" remoteCLIFileTest
@@ -200,12 +202,14 @@ remoteMessageTest :: HasCallStack => ((Bool, Bool), TestParams) -> IO ()
 remoteMessageTest = testRemote3 $ \compress mobile desktop bob -> do  
   startRemote compress mobile desktop
   contactBob desktop bob
+  mobile <## "bob (Bob): contact is connected"
 
   logNote "sending messages"
   desktop #> "@bob hello there 🙂"
   bob <# "alice> hello there 🙂"
   bob #> "@alice hi"
   desktop <# "bob> hi"
+  mobile <# "bob> hi"
 
   logNote "post-remote checks"
   stopMobile mobile desktop
@@ -221,6 +225,24 @@ remoteMessageTest = testRemote3 $ \compress mobile desktop bob -> do
 
   threadDelay 1000000
   logNote "done"
+
+remoteQueueOverflowTest :: HasCallStack => ((Bool, Bool), TestParams) -> IO ()
+remoteQueueOverflowTest = testRemote $ \compress mobile desktop -> do
+  startRemote compress mobile desktop
+
+  Just (sseq, rcSession@(Controller.RCSessionConnected {})) <-
+    readTVarIO (Controller.remoteCtrlSession $ chatController mobile)
+  remoteQ <- newTBQueueIO 1
+  atomically $ do
+    writeTBQueue remoteQ (Left $ Controller.ChatError $ Controller.CECommandError "queued")
+    writeTVar
+      (Controller.remoteCtrlSession $ chatController mobile)
+      (Just (sseq, rcSession {Controller.remoteOutputQ = remoteQ}))
+
+  runReaderT (Controller.toView' $ Controller.CEvtCustomChatEvent Nothing "overflow") (chatController mobile)
+  mobile <## "overflow"
+  mobile <## "remote controller stopped"
+  eventually 3 $ desktop <## "remote host 1 stopped"
 
 remoteStoreFileTest :: HasCallStack => ((Bool, Bool), TestParams) -> IO ()
 remoteStoreFileTest =


### PR DESCRIPTION
## Summary
- keep verified desktop remote-control sessions connected when the iOS app backgrounds by skipping normal chat suspension and running a bounded keepalive
- preserve normal mobile usage: dismiss the connected desktop sheet, keep explicit Disconnect as the stop path, and show a small chat-list indicator that opens the desktop connection screen
- keep mobile UI current while desktop is connected by forwarding allowed remote events to both local and desktop queues; stop desktop if the remote event queue fills instead of leaving stale state

## Implementation notes
- `RemoteCtrlBGKeepAlive` starts only from the iOS background scene-phase path and stops on active without disconnecting desktop
- iOS 26+ uses `BGContinuedProcessingTaskRequest` with a wildcard permitted identifier and falls back to `UIApplication.beginBackgroundTask`
- manual disconnect and expiration are serialized through one helper so `stopRemoteCtrl()` is not called concurrently
- normal suspend/background-refresh behavior is unchanged when no desktop is connected

## Testing
- `git diff --check`
- `plutil -lint apps/ios/SimpleX--iOS--Info.plist`
- `cabal test simplex-chat-test --test-options='--match "Remote/With compression/disconnects desktop when remote event queue is full"'`
- attempted iOS simulator build with `xcodebuild -project apps/ios/SimpleX.xcodeproj -scheme 'SimpleX (iOS)' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -configuration Debug build`; it reached Swift compilation and then failed at the existing local missing Haskell simulator static library `HSsimplex-chat-7.0.0.8...ghc9.6.3`

## Notes
- The iOS 26 system-visible continued-processing activity only starts when the app backgrounds. Starting it immediately on desktop connect was intentionally not kept because this change is scoped to background hold, not foreground behavior.