### PR TITLE
ios: fix missing spinner for database export/import/start

### DIFF
--- a/apps/ios/Shared/Views/Database/DatabaseView.swift
+++ b/apps/ios/Shared/Views/Database/DatabaseView.swift
@@ -252,6 +252,11 @@ struct DatabaseView: View {
             runChatToggleView()
         }
         .modifier(ThemedBackground(grouped: true))
+        .overlay {
+            if progressIndicator {
+                ProgressView().scaleEffect(2)
+            }
+        }
     }
 
     private func databaseAlert(_ alertItem: DatabaseAlert) -> Alert {


### PR DESCRIPTION
**Problem:** On iOS, the loading spinner no longer appears during database Export, Import and Start chat.

**Cause:** The settings reorganization (#7005) moved these operations into the pushed "Database passphrase & export" sub-screen, but the progress spinner stayed as an overlay on the parent screen, hidden behind it.

**Fix:** Add the same spinner overlay to the sub-screen (matching DatabaseEncryptionView), so it shows while these operations run.