### PR TITLE
Bump cli docs to avoid ambiguity

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -144,7 +144,7 @@ You may need to amend cabal.project.local to point to the actual openssl locatio
 
 ```shell
 cabal update
-cabal install simplex-chat
+cabal install .
 ```
 
 ## Usage


### PR DESCRIPTION
Solves for Cabal-7132 error, see below:

```sh
Error: [Cabal-7132] Ambiguous target 'simplex-chat'. It could be: exe:simplex-chat (component) lib:simplex-chat (component)
```

```sh
cabal --version
cabal-install version 3.12.1.0
compiled using version 3.12.1.0 of the Cabal library
```