### PR TITLE
desktop: show only desktop .deb packages for current architecture in updater

### DIFF
--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/views/helpers/AppUpdater.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/views/helpers/AppUpdater.kt
@@ -388,8 +388,12 @@ private fun chooseGitHubReleaseAssets(release: GitHubRelease): List<GitHubAsset>
     // No need to show download options for Flatpak users
     emptyList()
   } else if (desktopPlatform.isLinux() && !isRunningFromAppImage() && Runtime.getRuntime().exec("which dpkg").onExit().join().exitValue() == 0) {
-    // Show all available .deb packages and user will choose the one that works on his system (for Debian derivatives)
-    release.assets.filter { it.name.lowercase().endsWith(".deb") }
+    // Show desktop .deb packages for the current architecture and user will choose the one that works on his system (for Debian derivatives)
+    val arch = if (desktopPlatform == DesktopPlatform.LINUX_AARCH64) "aarch64" else "x86_64"
+    release.assets.filter { asset ->
+      val name = asset.name.lowercase()
+      name.startsWith("simplex-desktop-") && name.endsWith("$arch.deb")
+    }
   } else {
     release.assets.filter { it.name == desktopPlatform.githubAssetName }
   }


### PR DESCRIPTION
Problem: on amd64 Linux with dpkg installed (non-AppImage installs), the update dialog offered all 8 .deb release assets, including aarch64 packages and CLI simplex-chat packages.

Cause: the updater filtered assets only by the .deb extension, which was written when releases contained just x86_64 desktop .deb files.

Fix: filter .deb assets by the simplex-desktop- prefix and the current architecture suffix (x86_64/aarch64), so only the matching desktop packages are shown.