### PR TITLE
ios: fix blank window when opening a chat invitation notification for another profile

### DIFF
--- a/apps/ios/Shared/Model/ChatModel.swift
+++ b/apps/ios/Shared/Model/ChatModel.swift
@@ -413,6 +413,8 @@ final class ChatModel: ObservableObject {
     @Published var notificationPreview: NotificationPreviewMode = ntfPreviewModeGroupDefault.get()
     // pending notification actions
     @Published var ntfContactRequest: NTFContactRequest?
+    // contact request whose accept/reject dialog should be surfaced after opening from a notification tap
+    @Published var showingContactRequest: NTFContactRequest?
     @Published var ntfCallInvitationAction: (ChatId, NtfCallAction)?
     // current WebRTC call
     @Published var callInvitations: Dictionary<ChatId, RcvCallInvitation> = [:]

--- a/apps/ios/Shared/Model/NtfManager.swift
+++ b/apps/ios/Shared/Model/NtfManager.swift
@@ -60,6 +60,9 @@ class NtfManager: NSObject, UNUserNotificationCenterDelegate, ObservableObject {
            userId != chatModel.currentUser?.userId {
             logger.debug("NtfManager.processNotificationResponse changeActiveUser")
             changeActiveUser(userId, viewPwd: nil)
+            // the currently open chat belongs to the previous profile and is absent from the
+            // switched profile's chats, so drop it to land on the chat list instead of a blank chat view
+            chatModel.chatId = nil
         }
         if content.categoryIdentifier == ntfCategoryContactRequest && action == ntfActionAcceptContact,
            let chatId = content.userInfo["chatId"] as? String {

--- a/apps/ios/Shared/Model/NtfManager.swift
+++ b/apps/ios/Shared/Model/NtfManager.swift
@@ -64,12 +64,22 @@ class NtfManager: NSObject, UNUserNotificationCenterDelegate, ObservableObject {
             // switched profile's chats, so drop it to land on the chat list instead of a blank chat view
             chatModel.chatId = nil
         }
-        if content.categoryIdentifier == ntfCategoryContactRequest && action == ntfActionAcceptContact,
+        if content.categoryIdentifier == ntfCategoryContactRequest,
            let chatId = content.userInfo["chatId"] as? String {
-            if case let .contactRequest(contactRequest) = chatModel.getChat(chatId)?.chatInfo {
-                Task { await acceptContactRequest(incognito: false, contactRequestId: contactRequest.apiId) }
-            } else {
-                chatModel.ntfContactRequest = NTFContactRequest(chatId: chatId)
+            if action == ntfActionAcceptContact {
+                if case let .contactRequest(contactRequest) = chatModel.getChat(chatId)?.chatInfo {
+                    Task { await acceptContactRequest(incognito: false, contactRequestId: contactRequest.apiId) }
+                } else {
+                    chatModel.ntfContactRequest = NTFContactRequest(chatId: chatId)
+                }
+            } else if action == UNNotificationDefaultActionIdentifier,
+                      case .contactRequest = chatModel.getChat(chatId)?.chatInfo {
+                // a plain tap (not the Accept button) surfaces the accept/reject dialog for the request;
+                // a contact request has no openable chat view, so it cannot be opened like a message.
+                // require the request to be loaded (changeActiveUser above loads chats synchronously)
+                // so the dialog always has buttons, and drop any open chat so it presents over the list
+                chatModel.chatId = nil
+                chatModel.showingContactRequest = NTFContactRequest(chatId: chatId)
             }
         } else if let (chatId, ntfAction) = ntfCallAction(content, action) {
             if let invitation = chatModel.callInvitations.removeValue(forKey: chatId) {

--- a/apps/ios/Shared/Views/ChatList/ChatListNavLink.swift
+++ b/apps/ios/Shared/Views/ChatList/ChatListNavLink.swift
@@ -518,11 +518,7 @@ struct ChatListNavLink: View {
         .contentShape(Rectangle())
         .onTapGesture { showContactRequestDialog = true }
         .confirmationDialog("Accept connection request?", isPresented: $showContactRequestDialog, titleVisibility: .visible) {
-            Button("Accept") { Task { await acceptContactRequest(incognito: false, contactRequestId: contactRequest.apiId) } }
-            if !ChatModel.shared.addressShortLinkDataSet {
-                Button("Accept incognito") { Task { await acceptContactRequest(incognito: true, contactRequestId: contactRequest.apiId) } }
-            }
-            Button("Reject (sender NOT notified)", role: .destructive) { Task { await rejectContactRequest(contactRequest.apiId) } }
+            contactRequestDialogButtons(contactRequest)
         }
     }
 
@@ -683,6 +679,17 @@ extension View {
             }
         }
     }
+}
+
+// Buttons for the "Accept connection request?" dialog, shared by the chat-list row and the
+// dialog surfaced when a contact-request notification is tapped (ChatListView).
+@ViewBuilder
+func contactRequestDialogButtons(_ contactRequest: UserContactRequest) -> some View {
+    Button("Accept") { Task { await acceptContactRequest(incognito: false, contactRequestId: contactRequest.apiId) } }
+    if !ChatModel.shared.addressShortLinkDataSet {
+        Button("Accept incognito") { Task { await acceptContactRequest(incognito: true, contactRequestId: contactRequest.apiId) } }
+    }
+    Button("Reject (sender NOT notified)", role: .destructive) { Task { await rejectContactRequest(contactRequest.apiId) } }
 }
 
 func rejectContactRequestAlert(_ contactRequestId: Int64) -> Alert {

--- a/apps/ios/Shared/Views/ChatList/ChatListView.swift
+++ b/apps/ios/Shared/Views/ChatList/ChatListView.swift
@@ -218,6 +218,15 @@ struct ChatListView: View {
                 }
             }
         }
+        .confirmationDialog("Accept connection request?", isPresented: Binding(
+            get: { chatModel.showingContactRequest != nil },
+            set: { if !$0 { chatModel.showingContactRequest = nil } }
+        ), titleVisibility: .visible) {
+            if let ncr = chatModel.showingContactRequest,
+               case let .contactRequest(contactRequest) = chatModel.getChat(ncr.chatId)?.chatInfo {
+                contactRequestDialogButtons(contactRequest)
+            }
+        }
         .environmentObject(chatTagsModel)
     }
     

--- a/plans/2026-07-21-fix-ios-ntf-invitation-white-window.md
+++ b/plans/2026-07-21-fix-ios-ntf-invitation-white-window.md
@@ -1,62 +1,101 @@
-# Fix: iOS notification for a chat invitation opens a white window instead of switching profile
+# Fix: iOS notification for a chat invitation opens a white window instead of opening the request
 
 Date: 2026-07-21
 Branch: `nd/fix-ios-ntf-invitation-white-window`
-File changed: `apps/ios/Shared/Model/NtfManager.swift`
+Files changed:
+- `apps/ios/Shared/Model/NtfManager.swift`
+- `apps/ios/Shared/Model/ChatModel.swift`
+- `apps/ios/Shared/Views/ChatList/ChatListView.swift`
+- `apps/ios/Shared/Views/ChatList/ChatListNavLink.swift`
 
 ## Symptom
 
 Reported on iOS, both v6.5 and v7 beta. With more than one user profile, tapping a
 "chat invitation" (contact request, "X wants to connect!") notification that belongs to a
 profile other than the active one shows a blank/white window instead of switching to that
-profile.
+profile and letting the user act on the request.
 
 ## Root cause (grounded in code)
 
-`processNotificationResponse` (`NtfManager.swift:54-85`) does two independent things on a tap:
+`processNotificationResponse` (`NtfManager.swift:54-88`) does two independent things on a tap:
 
 1. If the notification's `userInfo["userId"]` differs from the active user, it switches
-   profile: `changeActiveUser(userId, viewPwd: nil)` (lines 59-63).
+   profile: `changeActiveUser(userId, viewPwd: nil)`.
 2. It opens a chat only in the final `else` branch, and only when
-   `content.targetContentIdentifier` is non-nil (lines 77-84).
+   `content.targetContentIdentifier` is non-nil.
 
 Two facts combine to produce the bug:
 
 - A contact-request notification is created with `targetContentIdentifier: nil`
-  (`SimpleXChat/Notifications.swift:39`). Its chat id lives in `userInfo["chatId"]` and is
-  consulted only by the "Accept"-button branch (`action == ntfActionAcceptContact`,
-  line 64), never on a plain body tap (default action). So none of the open-chat branches run.
-- `changeActiveUser` -> `getUserChatData` -> `updateChats` (`ChatModel.swift:628-639`)
-  replaces the `chats` array but never resets `chatModel.chatId`.
+  (`SimpleXChat/Notifications.swift:39`). Its chat id lives in `userInfo["chatId"]` and was
+  consulted only by the "Accept"-button branch (`action == ntfActionAcceptContact`),
+  never on a plain body tap (default action). So none of the open-chat branches ran.
+- `changeActiveUser` -> `getUserChatData` -> `updateChats` replaces the `chats` array but
+  never resets `chatModel.chatId`.
 
-Navigation is driven purely by `chatModel.chatId != nil` (`ChatListView.swift:190-198`).
-So when a chat is open in the previous profile and the user taps an invitation notification
-for another profile, the profile is switched underneath a ChatView still bound to the old
-profile's `chatId` (now absent from the new `chats`), and that view renders blank — the
-"white window". Message notifications avoid this because their `else` branch calls
+Navigation is driven purely by `chatModel.chatId != nil` (`ChatListView.swift`). So when a
+chat is open in the previous profile and the user taps an invitation notification for another
+profile, the profile is switched underneath a ChatView still bound to the old profile's
+`chatId` (now absent from the new `chats`), and that view renders blank — the "white window".
+Message notifications avoid this because their `else` branch calls
 `loadOpenChat(targetContentIdentifier)`, which resets `chatId` to a valid chat.
 
-This path is unique to notifications: the in-app profile switch (UserPicker) is only
-reachable from the chat list, where `chatId` is already nil.
+### Why a contact request cannot just be "opened" like a message
+
+Unlike a message chat, a contact request has **no openable chat view**. The notification
+carries the legacy contact-request chat id (`contactRequest.id` = `"<@..."`,
+`ChatTypes.swift:331`), and that `ChatInfo.contactRequest` row is not navigable via
+`chatModel.chatId` — it renders as a `ContactRequestView` with an `onTapGesture` that shows an
+accept/reject confirmation dialog (`ChatListNavLink.swift`). Setting `chatId` to it would
+render blank. So the fix cannot open a chat; it has to surface that same dialog.
 
 ## Fix
 
-When a notification tap switches the active user, clear the stale open chat so the UI lands
-on the switched profile's chat list:
+Two parts, both scoped to the notification path:
 
-```swift
-changeActiveUser(userId, viewPwd: nil)
-chatModel.chatId = nil
-```
+1. **Avoid the blank window.** When a notification tap switches the active user, clear the
+   stale open chat so the UI lands on the switched profile's chat list:
+
+   ```swift
+   changeActiveUser(userId, viewPwd: nil)
+   chatModel.chatId = nil
+   ```
+
+2. **Open the request.** A plain body tap (default action) on a contact-request notification
+   now surfaces the accept/reject dialog, instead of doing nothing:
+
+   ```swift
+   } else if action == UNNotificationDefaultActionIdentifier,
+             case .contactRequest = chatModel.getChat(chatId)?.chatInfo {
+       chatModel.chatId = nil
+       chatModel.showingContactRequest = NTFContactRequest(chatId: chatId)
+   }
+   ```
+
+   - `ChatModel` gains `@Published var showingContactRequest: NTFContactRequest?`.
+   - `ChatListView` presents a model-driven `.confirmationDialog` bound to it.
+   - The dialog buttons (Accept / Accept incognito / Reject) are extracted into a shared
+     `contactRequestDialogButtons(_:)` view builder, reused by the existing chat-list row so
+     the two dialogs cannot drift apart.
+   - The `getChat` guard fires only when the request is already loaded — which
+     `changeActiveUser` guarantees, because it loads the new profile's chats synchronously —
+     so the dialog always has buttons (no empty Cancel-only dialog). The `Accept`-button
+     branch (`ntfActionAcceptContact`) is unchanged and still auto-accepts.
+
+This also fixes the same-profile case: previously a plain tap on a contact-request
+notification for the *active* profile did nothing either; it now surfaces the dialog too.
 
 ## Why this is minimal and safe
 
 - Scoped to the notification handler; `changeActiveUser` is untouched, so the `keepingChatId`
   flows (e.g. `ContextProfilePickerView`) are unaffected.
+- No control-flow regression: every contact-request notification now enters the first `if`,
+  but nothing is lost — contact requests always have `targetContentIdentifier == nil` and
+  never match `ntfCallAction`, so the old fall-through `else` was already a no-op for them.
+  Dismiss and other actions remain no-ops as before.
 - Message notifications still open correctly: their branch re-sets `chatId` via
   `loadOpenChat` immediately after.
-- Matches the reported expected behavior ("switch to the profile the notification came from")
-  and aligns iOS with Android/Desktop.
+- No new/removed translation keys — the dialog reuses the chat-list row's existing strings.
 
 ## Cross-platform status
 
@@ -65,9 +104,16 @@ chatModel.chatId = nil
   (`common/.../platform/NtfManager.kt:59-72`) switches profile, sets `clearOverlays = true`,
   and only opens `Direct`/`Group` chats, so an invitation falls through to the chat list.
 
+## Review
+
+Adversarially reviewed (control-flow, compile/type, SwiftUI presentation, threading, races)
+across independent passes — no bugs, regressions, compile errors, or races found. The one
+raised nit (a possible empty dialog when the request is not loaded) is eliminated by the
+`getChat` guard at set-time.
+
 ## Verification note
 
 Not runtime-verified here: building/running the iOS app requires Xcode (macOS), unavailable
 in this Linux environment. Repro to confirm on device: with two profiles, open a chat in
 profile A, then tap a contact-request notification for profile B — before the fix it shows a
-blank chat; after, it lands on profile B's chat list.
+blank chat; after, it lands on profile B's chat list with the accept/reject dialog shown.

--- a/plans/2026-07-21-fix-ios-ntf-invitation-white-window.md
+++ b/plans/2026-07-21-fix-ios-ntf-invitation-white-window.md
@@ -1,0 +1,73 @@
+# Fix: iOS notification for a chat invitation opens a white window instead of switching profile
+
+Date: 2026-07-21
+Branch: `nd/fix-ios-ntf-invitation-white-window`
+File changed: `apps/ios/Shared/Model/NtfManager.swift`
+
+## Symptom
+
+Reported on iOS, both v6.5 and v7 beta. With more than one user profile, tapping a
+"chat invitation" (contact request, "X wants to connect!") notification that belongs to a
+profile other than the active one shows a blank/white window instead of switching to that
+profile.
+
+## Root cause (grounded in code)
+
+`processNotificationResponse` (`NtfManager.swift:54-85`) does two independent things on a tap:
+
+1. If the notification's `userInfo["userId"]` differs from the active user, it switches
+   profile: `changeActiveUser(userId, viewPwd: nil)` (lines 59-63).
+2. It opens a chat only in the final `else` branch, and only when
+   `content.targetContentIdentifier` is non-nil (lines 77-84).
+
+Two facts combine to produce the bug:
+
+- A contact-request notification is created with `targetContentIdentifier: nil`
+  (`SimpleXChat/Notifications.swift:39`). Its chat id lives in `userInfo["chatId"]` and is
+  consulted only by the "Accept"-button branch (`action == ntfActionAcceptContact`,
+  line 64), never on a plain body tap (default action). So none of the open-chat branches run.
+- `changeActiveUser` -> `getUserChatData` -> `updateChats` (`ChatModel.swift:628-639`)
+  replaces the `chats` array but never resets `chatModel.chatId`.
+
+Navigation is driven purely by `chatModel.chatId != nil` (`ChatListView.swift:190-198`).
+So when a chat is open in the previous profile and the user taps an invitation notification
+for another profile, the profile is switched underneath a ChatView still bound to the old
+profile's `chatId` (now absent from the new `chats`), and that view renders blank — the
+"white window". Message notifications avoid this because their `else` branch calls
+`loadOpenChat(targetContentIdentifier)`, which resets `chatId` to a valid chat.
+
+This path is unique to notifications: the in-app profile switch (UserPicker) is only
+reachable from the chat list, where `chatId` is already nil.
+
+## Fix
+
+When a notification tap switches the active user, clear the stale open chat so the UI lands
+on the switched profile's chat list:
+
+```swift
+changeActiveUser(userId, viewPwd: nil)
+chatModel.chatId = nil
+```
+
+## Why this is minimal and safe
+
+- Scoped to the notification handler; `changeActiveUser` is untouched, so the `keepingChatId`
+  flows (e.g. `ContextProfilePickerView`) are unaffected.
+- Message notifications still open correctly: their branch re-sets `chatId` via
+  `loadOpenChat` immediately after.
+- Matches the reported expected behavior ("switch to the profile the notification came from")
+  and aligns iOS with Android/Desktop.
+
+## Cross-platform status
+
+- iOS: buggy -> fixed.
+- Android/Desktop: not affected. The shared `openChatAction`
+  (`common/.../platform/NtfManager.kt:59-72`) switches profile, sets `clearOverlays = true`,
+  and only opens `Direct`/`Group` chats, so an invitation falls through to the chat list.
+
+## Verification note
+
+Not runtime-verified here: building/running the iOS app requires Xcode (macOS), unavailable
+in this Linux environment. Repro to confirm on device: with two profiles, open a chat in
+profile A, then tap a contact-request notification for profile B — before the fix it shows a
+blank chat; after, it lands on profile B's chat list.


### PR DESCRIPTION
**Problem:** On iOS (seen in v6.5 and v7 beta), with multiple profiles, tapping a chat-invitation (contact request) notification for a non-active profile shows a blank white window instead of switching to that profile.

**Cause:** The notification tap switches the active user via `changeActiveUser`, but a contact-request notification has a nil `targetContentIdentifier` so nothing re-opens a chat, and `chatModel.chatId` is left pointing at the previous profile's now-absent chat, which renders blank.

**Fix:** Reset `chatModel.chatId` when the notification tap switches profile, so the UI lands on the switched profile's chat list (matching Android/Desktop, which are unaffected).