### PR TITLE
core: prohibit file and media content in groups where files are not allowed, check content of updated messages

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ComposeView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ComposeView.kt
@@ -1630,9 +1630,11 @@ fun ComposeView(
       ReportReasonView(ctx.reason)
     }
 
+    // when editing, the media is already in the message and only its text is changed,
+    // so file and voice prohibitions don't apply (a link can be added by editing text, so it still does)
     val simplexLinkProhibited = chatsCtx.secondaryContextFilter == null && hasSimplexLink.value && !chat.groupFeatureEnabled(GroupFeature.SimplexLinks)
-    val fileProhibited = chatsCtx.secondaryContextFilter == null && composeState.value.attachmentPreview && !chat.groupFeatureEnabled(GroupFeature.Files)
-    val voiceProhibited = composeState.value.preview is ComposePreview.VoicePreview && !chat.chatInfo.featureEnabled(ChatFeature.Voice)
+    val fileProhibited = chatsCtx.secondaryContextFilter == null && composeState.value.attachmentPreview && !composeState.value.editing && !chat.groupFeatureEnabled(GroupFeature.Files)
+    val voiceProhibited = composeState.value.preview is ComposePreview.VoicePreview && !composeState.value.editing && !chat.chatInfo.featureEnabled(ChatFeature.Voice)
     val disableSendButton = simplexLinkProhibited || fileProhibited || voiceProhibited
     if (composeState.value.preview !is ComposePreview.VoicePreview || composeState.value.editing) {
       if (simplexLinkProhibited) {

--- a/plans/2026-07-23-fix-group-media-without-file.md
+++ b/plans/2026-07-23-fix-group-media-without-file.md
@@ -115,6 +115,14 @@ groups.
 Support-scope behaviour is unchanged: the Files guard remains skipped when
 `scopeInfo` is set, as before.
 
+The compose view (`ComposeView.kt`) disabled the send button whenever it held an
+attachment preview in a group with files disabled, which also blocked editing
+the text of an existing image, video or file message — so the core allowing the
+update was not enough. The file and voice prohibitions are now skipped when
+editing: the media is already in the message and the edit only changes its text
+(the attach button is disabled while editing, so no new media can be added). The
+links prohibition still applies when editing, as a link can be added to the text.
+
 ## Also: SimpleX links in support chats
 
 The update path carried its own `prohibitedSimplexLinks` check on both sides —
@@ -194,9 +202,11 @@ still rejected on sending and ignored on receiving, as before.
   the same edit with different image data, which is rejected. With the media
   comparison removed the test fails on the accepted edit.
 - `testGroupHistoryProhibitedMedia` (`tests/ChatTests/Groups.hs`): a member
-  joining a group that disabled media after an image was sent receives the text
-  of that message in history. With the content unchanged in `sendHistory` the
-  test fails — the joining member receives a prohibited item instead.
+  joining a group that disabled media receives the captions as text, for both an
+  inline image and an image sent with an XFTP file, with no file to receive.
+  With the downgrade narrowed to file-less items the test fails on the
+  image-with-file case — the joining member receives the prohibited image
+  instead of its caption.
 - `testProhibitVoiceUpdate` (`tests/ChatTests/Profiles.hs`): a contact chat with
   voice not allowed rejects an update of a message to voice content, and, with
   the contact preferences reset in the sender's database, the recipient ignores

--- a/plans/2026-07-23-fix-group-media-without-file.md
+++ b/plans/2026-07-23-fix-group-media-without-file.md
@@ -135,8 +135,9 @@ ignored, which is what a new message containing a link already did.
   `group live message`, the four channel message update tests, and
   `group preferences for specific member role` (direct messages, files & media,
   SimpleX links).
-- `testGroupPrefsSimplexLinksForRole` extended with the support chat case: with
-  links restricted to owners, a member can post a link in their support chat and
-  can edit a message there to contain one, while both remain rejected in the
-  main chat. The edit fails on the previous code with
-  `bad chat command: feature not allowed SimpleX links`.
+- `testGroupPrefsSimplexLinksForRole` extended with both sides of the scope
+  boundary: with links restricted to owners, a member cannot post a link in the
+  main chat and cannot edit a main chat message to contain one (and nothing
+  reaches the other members), while in their support chat both the new message
+  and the edit are allowed. The support chat edit fails on the previous code
+  with `bad chat command: feature not allowed SimpleX links`.

--- a/plans/2026-07-23-fix-group-media-without-file.md
+++ b/plans/2026-07-23-fix-group-media-without-file.md
@@ -52,25 +52,63 @@ media required a file.
 Judge media by content type, the same way voice already is:
 
 ```haskell
-| isNothing scopeInfo && not (isVoice mc) && (isJust file_ || isMedia mc) && not (groupFeatureMemberAllowed SGFFiles m gInfo) = Just GFFiles
+| isNothing scopeInfo && not (isVoice mc) && (isJust file_ || (isMedia mc && newMedia)) && not (groupFeatureMemberAllowed SGFFiles m gInfo) = Just GFFiles
 ```
 
 with `isMedia` next to `isVoice`/`isReport` in `Protocol.hs`, matching
 `MCImage`, `MCVideo` and `MCFile` — the preference is "Files and media", and all
 three are its content, whether or not a file is attached.
 
+What the preference forbids is adding media, not the media that a message
+already has, so `prohibitedGroupContent` takes the content of the message being
+updated and both media guards ignore an update that keeps it:
+
+```haskell
+newMedia = not $ maybe False (sameMedia mc) oldMC_
+```
+
+`sameMedia` (`Protocol.hs`) compares the media itself — the image preview and
+duration — so editing the text of an image, video, file or voice message is
+allowed even after the group disables the feature, while replacing the media
+with different media is not. For new messages there is no previous content and
+the guards are unchanged.
+
 Both sides of the update path now run the same shared check:
 
 - `APIUpdateChatItem` for groups runs `prohibitedGroupContent` in place of its
   links-only check, restoring the symmetry #4330 established (it also covers
-  voice, which was equally unchecked there). `getChatScopeInfo` is hoisted above
-  the check to supply the scope; it is a read-only store lookup, so this changes
-  only error ordering.
+  voice, which was equally unchecked there). The check moved after the item is
+  read, so it uses the item's own scope from `getGroupChatScopeInfoForItem` and
+  the item's previous content. Using the scope of the command instead would let
+  a main chat item be edited with `#1(_support)` to skip the scope-gated guards.
 - `updateCI` in `groupMessageUpdate` runs it before applying the update, so it
   is reached for items that exist, which the `catchCINotFound` handler's call
   never was. A prohibited update is ignored with a warning and the previously
   received content remains — the shape the links check there already had, now
   applied to every feature and correctly gated on the item's scope.
+
+An update of a message the recipient does not have creates the item, so it is a
+way to send content. Only `updateCI` passes the previous content; the
+`catchCINotFound` handler passes none, so an update that creates an item is
+checked as a new message and a prohibited one is stored as
+`CIRcvGroupFeatureRejected`. Such an item cannot be updated into content later
+either — `updateRcvChatItem` only matches items with `CIRcvMsgContent`, anything
+else is an invalid update. The sending side cannot create an item this way at
+all, as it reads the item being updated.
+
+The same two holes existed in direct chats and are closed the same way: the
+voice check in `messageUpdate` only ever ran in its `catchCINotFound` handler,
+and `APIUpdateChatItem` for contacts had no check at all, so a text message
+could be turned into a voice message where voice is not allowed.
+
+History is sent with the file invitation only while the file is neither expired
+nor cancelled (`itemForwardMsgs`), so an older image, file or voice item is
+forwarded as media content with no file. `sendHistory` now sends the text of
+such an item when the group no longer allows the feature, instead of content
+that every receiving member would reject. A signed item cannot be changed to
+text without breaking its signature, so a signed item whose now-prohibited media
+has no file is dropped from history rather than sent as a prohibited item —
+signing is a channel/relay feature, off in ordinary groups.
 
 Support-scope behaviour is unchanged: the Files guard remains skipped when
 `scopeInfo` is set, as before.
@@ -115,11 +153,15 @@ still rejected on sending and ignored on receiving, as before.
 - Forwarding an image whose file is unavailable into a media-off group is now
   rejected. `forwardContent` keeps `MCImage` without a file in that case
   (`Library/Commands.hs`), and that payload is exactly what the preference
-  forbids.
-- Editing the caption of an image or of a file message that was sent while media
-  was still enabled is now rejected in a group that has since disabled media — by
-  the sender, and by recipients, which ignore the update and keep the previously
-  received content. Previously such an edit was delivered.
+  forbids. Video and file content without a file is forwarded as text there, so
+  it is unaffected.
+- The text of an image, video, file or voice message can still be edited after
+  the group disables the feature — the update keeps the media it had. Replacing
+  the media with different media is rejected by the sender and ignored by
+  recipients.
+- Editing a message with the scope of another chat now applies the rules of the
+  chat the message is in, so a member support chat can no longer be named in the
+  command to edit a main chat message.
 
 ## Verification
 
@@ -145,12 +187,28 @@ still rejected on sending and ignored on receiving, as before.
   both tests fail with the prohibited edit applied at the recipients —
   `but got: Just "#team bob> [edited] hi"` and
   `but got: Just "#team bob> [edited] https://simplex.chat/invitation#/..."`.
-- No regression in `group message update`, `group message edit history`,
-  `group live message`, the 29 channel message tests, `update group profile`,
-  and `group preferences` (direct messages, files & media, SimpleX links).
+- `testProhibitFiles` also covers editing the text of an image message sent
+  before media was disabled — it is accepted and delivered to the members — and
+  the same edit with different image data, which is rejected. With the media
+  comparison removed the test fails on the accepted edit.
+- `testGroupHistoryProhibitedMedia` (`tests/ChatTests/Groups.hs`): a member
+  joining a group that disabled media after an image was sent receives the text
+  of that message in history. With the content unchanged in `sendHistory` the
+  test fails — the joining member receives a prohibited item instead.
+- `testProhibitVoiceUpdate` (`tests/ChatTests/Profiles.hs`): a contact chat with
+  voice not allowed rejects an update of a message to voice content, and, with
+  the contact preferences reset in the sender's database, the recipient ignores
+  such an update and keeps the previous message. With the check in
+  `messageUpdate` removed the test fails.
 - `testGroupPrefsSimplexLinksForRole` extended with both sides of the scope
   boundary: with links restricted to owners, a member cannot post a link in the
   main chat and cannot edit a main chat message to contain one (and nothing
   reaches the other members), while in their support chat both the new message
   and the edit are allowed. The support chat edit fails on the previous code
-  with `bad chat command: feature not allowed SimpleX links`.
+  with `bad chat command: feature not allowed SimpleX links`. It also checks
+  that a main chat message cannot be edited with the support chat scope in the
+  command; with the check using the command's scope that edit is accepted.
+- No regression in `group message update`, `group message edit history`,
+  `group live message`, the 29 channel message tests, `update group profile`,
+  and `group preferences` (direct messages, files & media, SimpleX links); full
+  `chat groups`, `file tests` and `profile tests` suites pass.

--- a/plans/2026-07-23-fix-group-media-without-file.md
+++ b/plans/2026-07-23-fix-group-media-without-file.md
@@ -26,23 +26,26 @@ Files/media rule from the presence of a *file*, not from the *content type*:
 But `MCImage {text, image :: ImageData}` and `MCVideo {text, image, duration}`
 (`src/Simplex/Chat/Protocol.hs`) carry the media preview inline, independent of
 any file transfer. With `fileSource` omitted, `file_` is `Nothing`, the guard
-never fires, and the message is treated as ordinary text.
+never fires, and the message is treated as ordinary text. `MCFile {text}` is
+also file content the preference names, whatever is attached to it.
 
 The guard immediately above it shows the correct shape — voice is judged by
 content type (`isVoice mc`), never by file presence.
 
-Two further consequences of the same assumption:
+The update path had the same hole on both sides:
 
-- `groupMessageUpdate` (`Library/Subscriber.hs`) calls `prohibitedGroupContent`
-  with the file argument hardcoded to `Nothing`, so on the receiving side the
-  Files guard could never fire for `x.msg.update` — an update could always turn
-  a text item into an image.
 - `APIUpdateChatItem` for groups (`Library/Commands.hs`) only checked
-  `prohibitedSimplexLinks`, so the same substitution was unchecked when sending.
-  That check was added in #4330 on both the send and receive side of the update
-  path; links were then the only feature reachable by editing a message, which
-  held only while media required a file. #6870 later upgraded the receive side to
-  the full `prohibitedGroupContent`, leaving the two sides out of sync.
+  `prohibitedSimplexLinks`, so replacing a text item with image content was
+  unchecked when sending.
+- `groupMessageUpdate` (`Library/Subscriber.hs`) checked only
+  `prohibitedSimplexLinks` on the ordinary path. Its `prohibitedGroupContent`
+  call, added in #6870, sits inside the `catchCINotFound` handler — the branch
+  that recreates an item deleted locally — so for an item that exists, which is
+  the normal case, the Files guard was never reached at all.
+
+The links-only pair predates chat scopes: #4330 added it to both sides when a
+text edit could introduce no other prohibited content, which held only while
+media required a file.
 
 ## Fix
 
@@ -53,15 +56,21 @@ Judge media by content type, the same way voice already is:
 ```
 
 with `isMedia` next to `isVoice`/`isReport` in `Protocol.hs`, matching
-`MCImage`/`MCVideo`. Because all content paths share `prohibitedGroupContent`,
-this one guard covers sending (`/_send`), receiving `x.msg.new`, and receiving
-`x.msg.update`.
+`MCImage`, `MCVideo` and `MCFile` — the preference is "Files and media", and all
+three are its content, whether or not a file is attached.
 
-`APIUpdateChatItem` for groups now runs `prohibitedGroupContent` in place of its
-links-only check, restoring the symmetry #4330 established and closing the same
-substitution at the source (it also covers voice, which was equally unchecked
-there). `getChatScopeInfo` is hoisted above the check to supply the scope; it is
-a read-only store lookup, so this changes only error ordering.
+Both sides of the update path now run the same shared check:
+
+- `APIUpdateChatItem` for groups runs `prohibitedGroupContent` in place of its
+  links-only check, restoring the symmetry #4330 established (it also covers
+  voice, which was equally unchecked there). `getChatScopeInfo` is hoisted above
+  the check to supply the scope; it is a read-only store lookup, so this changes
+  only error ordering.
+- `updateCI` in `groupMessageUpdate` runs it before applying the update, so it
+  is reached for items that exist, which the `catchCINotFound` handler's call
+  never was. A prohibited update is ignored with a warning and the previously
+  received content remains — the shape the links check there already had, now
+  applied to every feature and correctly gated on the item's scope.
 
 Support-scope behaviour is unchanged: the Files guard remains skipped when
 `scopeInfo` is set, as before.
@@ -75,17 +84,12 @@ gated on `isNothing scopeInfo`. So a **new** message containing a link could be
 posted in a member support chat, but **editing** a message there to contain one
 was rejected.
 
-That check predates chat scopes: #4330 added it to both sides of the update path
-when a text edit could introduce no other prohibited content, and the scope gate
-added later never reached it. Support chats are not meant to prohibit content —
-that is why the files, reports and links guards are all scope-gated — so the
-special case is removed from both sides, and links in updates are judged by the
-same scope-gated guard as links in new messages.
-
-Main-chat updates containing links are still prohibited, via
-`prohibitedGroupContent`. The only visible difference is on receiving: such an
-update now creates a `CIRcvGroupFeatureRejected` item instead of being silently
-ignored, which is what a new message containing a link already did.
+Support chats are not meant to prohibit content — that is why the files, reports
+and links guards are all scope-gated — so the special case is removed from both
+sides, and links in updates are judged by the same scope-gated guard as links in
+new messages. Nothing stops being validated: the scope-gated guard is what the
+send and receive update paths now run, so main-chat updates containing links are
+still rejected on sending and ignored on receiving, as before.
 
 ## Alternatives considered
 
@@ -93,7 +97,7 @@ ignored, which is what a new message containing a link already did.
   modified client or a direct API caller never runs the sender's check. The
   receiving side is the boundary that matters.
 - **Include `MCImage` only.** `MCVideo` carries the identical inline preview and
-  would leave the hole open.
+  would leave the hole open; `MCFile` is named by the same preference.
 - **Also gate `MCLink` previews and `MCChat` profile images.** Both embed images
   too, but they belong to the SimpleX-links/link-preview features, and gating
   them would change ordinary link messages in media-off groups. Out of scope.
@@ -112,29 +116,38 @@ ignored, which is what a new message containing a link already did.
   rejected. `forwardContent` keeps `MCImage` without a file in that case
   (`Library/Commands.hs`), and that payload is exactly what the preference
   forbids.
-- Editing the caption of an image that was sent while media was still enabled is
-  now rejected in a group that has since disabled media — by the sender, and by
-  recipients, which run the same guard. Previously such an edit was delivered:
-  #6870 made the receiving side of the update path run the full check, but the
-  Files guard there could not fire, as it tested the file that an update never
-  carries.
+- Editing the caption of an image or of a file message that was sent while media
+  was still enabled is now rejected in a group that has since disabled media — by
+  the sender, and by recipients, which ignore the update and keep the previously
+  received content. Previously such an edit was delivered.
 
 ## Verification
 
 - `cabal build lib:simplex-chat` and `cabal build simplex-chat-test` — clean.
-- `testProhibitFiles` (`tests/ChatTests/Files.hs`) extended with three vectors:
-  `/_send` of image content and of video content with no `filePath`, and
-  `/_update item` replacing a text message with image content; each expects
+- `testProhibitFiles` (`tests/ChatTests/Files.hs`) extended with four sending
+  vectors: `/_send` of image, of video and of file content with no `filePath`,
+  and `/_update item` replacing a text message with image content; each expects
   `bad chat command: feature not allowed Files and media` and no delivery to the
   other members.
 - Negative control: with the source fix reverted and the test kept, the test
   fails — the send succeeds and the other member receives the message
   (`expected: Nothing but got: Just "09:31 #team alice>"`), reproducing the
   report.
+- Both tests also cover the receiving side, which is the boundary that matters,
+  by resetting group preferences in the sender's database — the client that does
+  not check them. A new message with prohibited content becomes
+  `Files and media: received, prohibited` / `SimpleX links: received, prohibited`
+  in the recipients' chats, and an update to prohibited content leaves the
+  previously received message unchanged. The recipients' state is asserted with
+  `/_get chat`, because items that are not `CIRcvMsgContent` are not printed by
+  the terminal view for new item events.
+- Negative control for the receiving side: with the check in `updateCI` removed,
+  both tests fail with the prohibited edit applied at the recipients —
+  `but got: Just "#team bob> [edited] hi"` and
+  `but got: Just "#team bob> [edited] https://simplex.chat/invitation#/..."`.
 - No regression in `group message update`, `group message edit history`,
-  `group live message`, the four channel message update tests, and
-  `group preferences for specific member role` (direct messages, files & media,
-  SimpleX links).
+  `group live message`, the 29 channel message tests, `update group profile`,
+  and `group preferences` (direct messages, files & media, SimpleX links).
 - `testGroupPrefsSimplexLinksForRole` extended with both sides of the scope
   boundary: with links restricted to owners, a member cannot post a link in the
   main chat and cannot edit a main chat message to contain one (and nothing

--- a/plans/2026-07-23-fix-group-media-without-file.md
+++ b/plans/2026-07-23-fix-group-media-without-file.md
@@ -101,14 +101,16 @@ voice check in `messageUpdate` only ever ran in its `catchCINotFound` handler,
 and `APIUpdateChatItem` for contacts had no check at all, so a text message
 could be turned into a voice message where voice is not allowed.
 
-History is sent with the file invitation only while the file is neither expired
-nor cancelled (`itemForwardMsgs`), so an older image, file or voice item is
-forwarded as media content with no file. `sendHistory` now sends the text of
-such an item when the group no longer allows the feature, instead of content
-that every receiving member would reject. A signed item cannot be changed to
-text without breaking its signature, so a signed item whose now-prohibited media
-has no file is dropped from history rather than sent as a prohibited item —
-signing is a channel/relay feature, off in ordinary groups.
+History forwards each item's media content (`itemForwardMsgs`), with the file
+invitation attached while the file is neither expired nor cancelled. When the
+group no longer allows the feature, `sendHistory` now sends only the text of
+such an item, dropping the media and the file invitation, so the members
+receiving history don't reject it as prohibited content — for images sent with a
+file (the usual case) as well as inline images or items whose file has expired.
+Items with no text are dropped. A signed item cannot be changed to text without
+breaking its signature, so a signed item with now-prohibited media is dropped
+from history instead — signing is a channel/relay feature, off in ordinary
+groups.
 
 Support-scope behaviour is unchanged: the Files guard remains skipped when
 `scopeInfo` is set, as before.

--- a/plans/2026-07-23-fix-group-media-without-file.md
+++ b/plans/2026-07-23-fix-group-media-without-file.md
@@ -1,0 +1,122 @@
+# Fix: images can be sent to groups with "Files and media" disabled
+
+## Problem
+
+In a group where the "Files and media" preference is off, this command is
+accepted and delivers a visible image to every member:
+
+```
+/_send #1 json [{"msgContent":{"type":"image","text":" ","image":"data:image/jpg;base64,..."}}]
+```
+
+No file is attached — the picture travels inside the message content itself.
+Receiving clients render it normally, so the group preference is bypassed in
+both directions: the sender's client raises no error, and recipients display the
+image.
+
+## Root cause
+
+`prohibitedGroupContent` (`src/Simplex/Chat/Library/Internal.hs`) decided the
+Files/media rule from the presence of a *file*, not from the *content type*:
+
+```haskell
+| isNothing scopeInfo && not (isVoice mc) && isJust file_ && not (groupFeatureMemberAllowed SGFFiles m gInfo) = Just GFFiles
+```
+
+But `MCImage {text, image :: ImageData}` and `MCVideo {text, image, duration}`
+(`src/Simplex/Chat/Protocol.hs`) carry the media preview inline, independent of
+any file transfer. With `fileSource` omitted, `file_` is `Nothing`, the guard
+never fires, and the message is treated as ordinary text.
+
+The guard immediately above it shows the correct shape — voice is judged by
+content type (`isVoice mc`), never by file presence.
+
+Two further consequences of the same assumption:
+
+- `groupMessageUpdate` (`Library/Subscriber.hs`) calls `prohibitedGroupContent`
+  with the file argument hardcoded to `Nothing`, so on the receiving side the
+  Files guard could never fire for `x.msg.update` — an update could always turn
+  a text item into an image.
+- `APIUpdateChatItem` for groups (`Library/Commands.hs`) only checked
+  `prohibitedSimplexLinks`, so the same substitution was unchecked when sending.
+  That check was added in #4330 on both the send and receive side of the update
+  path; links were then the only feature reachable by editing a message, which
+  held only while media required a file. #6870 later upgraded the receive side to
+  the full `prohibitedGroupContent`, leaving the two sides out of sync.
+
+## Fix
+
+Judge media by content type, the same way voice already is:
+
+```haskell
+| isNothing scopeInfo && not (isVoice mc) && (isJust file_ || isMedia mc) && not (groupFeatureMemberAllowed SGFFiles m gInfo) = Just GFFiles
+```
+
+with `isMedia` next to `isVoice`/`isReport` in `Protocol.hs`, matching
+`MCImage`/`MCVideo`. Because all content paths share `prohibitedGroupContent`,
+this one guard covers sending (`/_send`), receiving `x.msg.new`, and receiving
+`x.msg.update`.
+
+`APIUpdateChatItem` for groups now also runs `prohibitedGroupContent`, restoring
+the symmetry #4330 established and closing the same substitution at the source
+(it also covers voice, which was equally unchecked there). Its existing
+`prohibitedSimplexLinks` check is kept and runs first: inside
+`prohibitedGroupContent` that guard is gated on `isNothing scopeInfo`, but the
+update path prohibits links in every scope, exactly as `groupMessageUpdate` does
+when receiving. Replacing the links check rather than keeping it would let an
+update with a link in a member support scope be sent while every recipient
+dropped it — silent divergence in place of an error. `getChatScopeInfo` is
+hoisted above the check to supply the scope; it is a read-only store lookup, so
+this changes only error ordering.
+
+Support-scope behaviour is unchanged: the Files guard remains skipped when
+`scopeInfo` is set, as before.
+
+## Alternatives considered
+
+- **Check only on send (`assertGroupContentAllowed`).** Does not fix anything: a
+  modified client or a direct API caller never runs the sender's check. The
+  receiving side is the boundary that matters.
+- **Include `MCImage` only.** `MCVideo` carries the identical inline preview and
+  would leave the hole open.
+- **Also gate `MCLink` previews and `MCChat` profile images.** Both embed images
+  too, but they belong to the SimpleX-links/link-preview features, and gating
+  them would change ordinary link messages in media-off groups. Out of scope.
+- **Validate quoted content (`QuotedMsg.content`).** A crafted quote can also
+  carry an inline image, and quote content is stored verbatim from the wire
+  (`Store/Messages.hs`) — there is no local item to validate it against for a
+  member who joined later or deleted the item. A check there could only reject
+  the whole message, which would break the legitimate case of replying to an
+  image sent while media was still enabled, destroying a text reply over
+  incidental context. If that surface is closed later, the right shape is to
+  degrade the quote preview to text in the UI, not to reject the message.
+
+## Known effects
+
+- Forwarding an image whose file is unavailable into a media-off group is now
+  rejected. `forwardContent` keeps `MCImage` without a file in that case
+  (`Library/Commands.hs`), and that payload is exactly what the preference
+  forbids.
+- Editing the caption of an image that was sent while media was still enabled is
+  now rejected in a group that has since disabled media — by the sender, and by
+  recipients, which run the same guard. Previously such an edit was delivered:
+  #6870 made the receiving side of the update path run the full check, but the
+  Files guard there could not fire, as it tested the file that an update never
+  carries.
+
+## Verification
+
+- `cabal build lib:simplex-chat` and `cabal build simplex-chat-test` — clean.
+- `testProhibitFiles` (`tests/ChatTests/Files.hs`) extended with three vectors:
+  `/_send` of image content and of video content with no `filePath`, and
+  `/_update item` replacing a text message with image content; each expects
+  `bad chat command: feature not allowed Files and media` and no delivery to the
+  other members.
+- Negative control: with the source fix reverted and the test kept, the test
+  fails — the send succeeds and the other member receives the message
+  (`expected: Nothing but got: Just "09:31 #team alice>"`), reproducing the
+  report.
+- No regression in `group message update`, `group message edit history`,
+  `group live message`, the four channel message update tests, and
+  `group preferences for specific member role` (direct messages, files & media,
+  SimpleX links).

--- a/plans/2026-07-23-fix-group-media-without-file.md
+++ b/plans/2026-07-23-fix-group-media-without-file.md
@@ -57,20 +57,35 @@ with `isMedia` next to `isVoice`/`isReport` in `Protocol.hs`, matching
 this one guard covers sending (`/_send`), receiving `x.msg.new`, and receiving
 `x.msg.update`.
 
-`APIUpdateChatItem` for groups now also runs `prohibitedGroupContent`, restoring
-the symmetry #4330 established and closing the same substitution at the source
-(it also covers voice, which was equally unchecked there). Its existing
-`prohibitedSimplexLinks` check is kept and runs first: inside
-`prohibitedGroupContent` that guard is gated on `isNothing scopeInfo`, but the
-update path prohibits links in every scope, exactly as `groupMessageUpdate` does
-when receiving. Replacing the links check rather than keeping it would let an
-update with a link in a member support scope be sent while every recipient
-dropped it — silent divergence in place of an error. `getChatScopeInfo` is
-hoisted above the check to supply the scope; it is a read-only store lookup, so
-this changes only error ordering.
+`APIUpdateChatItem` for groups now runs `prohibitedGroupContent` in place of its
+links-only check, restoring the symmetry #4330 established and closing the same
+substitution at the source (it also covers voice, which was equally unchecked
+there). `getChatScopeInfo` is hoisted above the check to supply the scope; it is
+a read-only store lookup, so this changes only error ordering.
 
 Support-scope behaviour is unchanged: the Files guard remains skipped when
 `scopeInfo` is set, as before.
+
+## Also: SimpleX links in support chats
+
+The update path carried its own `prohibitedSimplexLinks` check on both sides —
+`APIUpdateChatItem` when sending and `groupMessageUpdate` when receiving — with
+no scope condition, while the same guard inside `prohibitedGroupContent` is
+gated on `isNothing scopeInfo`. So a **new** message containing a link could be
+posted in a member support chat, but **editing** a message there to contain one
+was rejected.
+
+That check predates chat scopes: #4330 added it to both sides of the update path
+when a text edit could introduce no other prohibited content, and the scope gate
+added later never reached it. Support chats are not meant to prohibit content —
+that is why the files, reports and links guards are all scope-gated — so the
+special case is removed from both sides, and links in updates are judged by the
+same scope-gated guard as links in new messages.
+
+Main-chat updates containing links are still prohibited, via
+`prohibitedGroupContent`. The only visible difference is on receiving: such an
+update now creates a `CIRcvGroupFeatureRejected` item instead of being silently
+ignored, which is what a new message containing a link already did.
 
 ## Alternatives considered
 
@@ -120,3 +135,8 @@ Support-scope behaviour is unchanged: the Files guard remains skipped when
   `group live message`, the four channel message update tests, and
   `group preferences for specific member role` (direct messages, files & media,
   SimpleX links).
+- `testGroupPrefsSimplexLinksForRole` extended with the support chat case: with
+  links restricted to owners, a member can post a link in their support chat and
+  can edit a message there to contain one, while both remain rejected in the
+  main chat. The edit fails on the previous code with
+  `bad chat command: feature not allowed SimpleX links`.

--- a/src/Simplex/Chat/Library/Commands.hs
+++ b/src/Simplex/Chat/Library/Commands.hs
@@ -763,6 +763,8 @@ processChatCommand cxt nm = \case
         CChatItem SMDSnd ci@ChatItem {meta = CIMeta {itemSharedMsgId, itemTimed, itemLive, editable}, content = ciContent} -> do
           case (ciContent, itemSharedMsgId, editable) of
             (CISndMsgContent oldMC, Just itemSharedMId, True) -> do
+              when (isVoice mc && not (sameMedia mc oldMC) && not (featureAllowed SCFVoice forUser ct)) $
+                throwCmdError $ "feature not allowed " <> T.unpack (chatFeatureNameText CFVoice)
               let changed = mc /= oldMC
               if changed || fromMaybe False itemLive
                 then do
@@ -784,37 +786,38 @@ processChatCommand cxt nm = \case
       when (isNothing scope) $ assertUserGroupRole gInfo GRAuthor
       chatScopeInfo <- mapM (getChatScopeInfo cxt user) scope
       let (_, ft_) = msgContentTexts mc
-      case prohibitedGroupContent gInfo membership chatScopeInfo mc ft_ (Nothing :: Maybe CryptoFile) True of
-        Just f -> throwCmdError $ "feature not allowed " <> T.unpack (groupFeatureNameText f)
-        Nothing -> do
-          -- TODO [knocking] check chat item scope?
-          cci <- withFastStore $ \db -> getGroupCIWithReactions db user gInfo itemId
-          case cci of
-            CChatItem SMDSnd ci@ChatItem {meta = CIMeta {itemSharedMsgId, itemTimed, itemLive, editable, showGroupAsSender, msgVerified}, content = ciContent} -> do
-              case (ciContent, itemSharedMsgId, editable) of
-                (CISndMsgContent oldMC, Just itemSharedMId, True) -> do
-                  recipients <- getGroupRecipients cxt user gInfo chatScopeInfo groupKnockingVersion
-                  let changed = mc /= oldMC
-                  if changed || fromMaybe False itemLive
-                    then do
-                      ciMentions <- withFastStore $ \db -> getCIMentions db user gInfo ft_ mentions
-                      let msgScope = toMsgScope gInfo <$> chatScopeInfo
-                          mentions' = M.map (\CIMention {memberId} -> MsgMention {memberId}) ciMentions
-                          event = XMsgUpdate itemSharedMId mc mentions' (ttl' <$> itemTimed) (justTrue . (live &&) =<< itemLive) msgScope (Just showGroupAsSender)
-                          reuseSign = case msgVerified of Just (MVSigned _) -> True; _ -> False
-                      SndMessage {msgId} <- sendGroupMessage user gInfo scope recipients reuseSign event
-                      ci' <- withFastStore' $ \db -> do
-                        currentTs <- liftIO getCurrentTime
-                        when changed $
-                          addInitialAndNewCIVersions db itemId (chatItemTs' ci, oldMC) (currentTs, mc)
-                        let edited = itemLive /= Just True
-                        ci' <- updateGroupChatItem db user groupId ci (CISndMsgContent mc) edited live $ Just msgId
-                        updateGroupCIMentions db gInfo ci' ciMentions
-                      startUpdatedTimedItemThread user (ChatRef CTGroup groupId scope) ci ci'
-                      pure $ CRChatItemUpdated user (AChatItem SCTGroup SMDSnd (GroupChat gInfo chatScopeInfo) ci')
-                    else pure $ CRChatItemNotChanged user (AChatItem SCTGroup SMDSnd (GroupChat gInfo chatScopeInfo) ci)
-                _ -> throwChatError CEInvalidChatItemUpdate
-            CChatItem SMDRcv _ -> throwChatError CEInvalidChatItemUpdate
+      -- TODO [knocking] check chat item scope?
+      (cci, itemScopeInfo) <- withFastStore $ \db ->
+        (,) <$> getGroupCIWithReactions db user gInfo itemId <*> getGroupChatScopeInfoForItem db cxt user gInfo itemId
+      case cci of
+        CChatItem SMDSnd ci@ChatItem {meta = CIMeta {itemSharedMsgId, itemTimed, itemLive, editable, showGroupAsSender, msgVerified}, content = ciContent} -> do
+          case (ciContent, itemSharedMsgId, editable) of
+            -- the content is checked with the scope of the updated item, not with the scope of the command
+            (CISndMsgContent oldMC, Just itemSharedMId, True) -> case prohibitedGroupContent gInfo membership itemScopeInfo mc (Just oldMC) ft_ (Nothing :: Maybe CryptoFile) True of
+              Just f -> throwCmdError $ "feature not allowed " <> T.unpack (groupFeatureNameText f)
+              Nothing -> do
+                recipients <- getGroupRecipients cxt user gInfo chatScopeInfo groupKnockingVersion
+                let changed = mc /= oldMC
+                if changed || fromMaybe False itemLive
+                  then do
+                    ciMentions <- withFastStore $ \db -> getCIMentions db user gInfo ft_ mentions
+                    let msgScope = toMsgScope gInfo <$> chatScopeInfo
+                        mentions' = M.map (\CIMention {memberId} -> MsgMention {memberId}) ciMentions
+                        event = XMsgUpdate itemSharedMId mc mentions' (ttl' <$> itemTimed) (justTrue . (live &&) =<< itemLive) msgScope (Just showGroupAsSender)
+                        reuseSign = case msgVerified of Just (MVSigned _) -> True; _ -> False
+                    SndMessage {msgId} <- sendGroupMessage user gInfo scope recipients reuseSign event
+                    ci' <- withFastStore' $ \db -> do
+                      currentTs <- liftIO getCurrentTime
+                      when changed $
+                        addInitialAndNewCIVersions db itemId (chatItemTs' ci, oldMC) (currentTs, mc)
+                      let edited = itemLive /= Just True
+                      ci' <- updateGroupChatItem db user groupId ci (CISndMsgContent mc) edited live $ Just msgId
+                      updateGroupCIMentions db gInfo ci' ciMentions
+                    startUpdatedTimedItemThread user (ChatRef CTGroup groupId scope) ci ci'
+                    pure $ CRChatItemUpdated user (AChatItem SCTGroup SMDSnd (GroupChat gInfo chatScopeInfo) ci')
+                  else pure $ CRChatItemNotChanged user (AChatItem SCTGroup SMDSnd (GroupChat gInfo chatScopeInfo) ci)
+            _ -> throwChatError CEInvalidChatItemUpdate
+        CChatItem SMDRcv _ -> throwChatError CEInvalidChatItemUpdate
     CTLocal -> do
       unless (null mentions) $ throwCmdError "mentions are not supported in this chat"
       (nf@NoteFolder {noteFolderId}, cci) <- withFastStore $ \db -> (,) <$> getNoteFolder db user chatId <*> getLocalChatItem db user chatId itemId
@@ -4769,7 +4772,7 @@ processChatCommand cxt nm = \case
             findProhibited :: [ComposedMessageReq] -> Maybe GroupFeature
             findProhibited =
               foldr'
-                (\(ComposedMessage {fileSource, msgContent = mc}, _, (_, ft), _) acc -> prohibitedGroupContent gInfo membership chatScopeInfo mc ft fileSource True <|> acc)
+                (\(ComposedMessage {fileSource, msgContent = mc}, _, (_, ft), _) acc -> prohibitedGroupContent gInfo membership chatScopeInfo mc Nothing ft fileSource True <|> acc)
                 Nothing
         processComposedMessages ::  CM ChatResponse
         processComposedMessages = do

--- a/src/Simplex/Chat/Library/Commands.hs
+++ b/src/Simplex/Chat/Library/Commands.hs
@@ -784,11 +784,7 @@ processChatCommand cxt nm = \case
       when (isNothing scope) $ assertUserGroupRole gInfo GRAuthor
       chatScopeInfo <- mapM (getChatScopeInfo cxt user) scope
       let (_, ft_) = msgContentTexts mc
-          -- SimpleX links are prohibited in updates in all scopes, as on receiving side
-          prohibitedContent
-            | prohibitedSimplexLinks gInfo membership mc ft_ = Just GFSimplexLinks
-            | otherwise = prohibitedGroupContent gInfo membership chatScopeInfo mc ft_ (Nothing :: Maybe CryptoFile) True
-      case prohibitedContent of
+      case prohibitedGroupContent gInfo membership chatScopeInfo mc ft_ (Nothing :: Maybe CryptoFile) True of
         Just f -> throwCmdError $ "feature not allowed " <> T.unpack (groupFeatureNameText f)
         Nothing -> do
           -- TODO [knocking] check chat item scope?

--- a/src/Simplex/Chat/Library/Commands.hs
+++ b/src/Simplex/Chat/Library/Commands.hs
@@ -782,17 +782,21 @@ processChatCommand cxt nm = \case
     CTGroup -> withGroupLock "updateChatItem" chatId $ do
       gInfo@GroupInfo {groupId, membership} <- withFastStore $ \db -> getGroupInfo db cxt user chatId
       when (isNothing scope) $ assertUserGroupRole gInfo GRAuthor
+      chatScopeInfo <- mapM (getChatScopeInfo cxt user) scope
       let (_, ft_) = msgContentTexts mc
-      if prohibitedSimplexLinks gInfo membership mc ft_
-        then throwCmdError ("feature not allowed " <> T.unpack (groupFeatureNameText GFSimplexLinks))
-        else do
+          -- SimpleX links are prohibited in updates in all scopes, as on receiving side
+          prohibitedContent
+            | prohibitedSimplexLinks gInfo membership mc ft_ = Just GFSimplexLinks
+            | otherwise = prohibitedGroupContent gInfo membership chatScopeInfo mc ft_ (Nothing :: Maybe CryptoFile) True
+      case prohibitedContent of
+        Just f -> throwCmdError $ "feature not allowed " <> T.unpack (groupFeatureNameText f)
+        Nothing -> do
           -- TODO [knocking] check chat item scope?
           cci <- withFastStore $ \db -> getGroupCIWithReactions db user gInfo itemId
           case cci of
             CChatItem SMDSnd ci@ChatItem {meta = CIMeta {itemSharedMsgId, itemTimed, itemLive, editable, showGroupAsSender, msgVerified}, content = ciContent} -> do
               case (ciContent, itemSharedMsgId, editable) of
                 (CISndMsgContent oldMC, Just itemSharedMId, True) -> do
-                  chatScopeInfo <- mapM (getChatScopeInfo cxt user) scope
                   recipients <- getGroupRecipients cxt user gInfo chatScopeInfo groupKnockingVersion
                   let changed = mc /= oldMC
                   if changed || fromMaybe False itemLive

--- a/src/Simplex/Chat/Library/Internal.hs
+++ b/src/Simplex/Chat/Library/Internal.hs
@@ -343,7 +343,7 @@ prohibitedGroupContent :: GroupInfo -> GroupMember -> Maybe GroupChatScopeInfo -
 prohibitedGroupContent gInfo@GroupInfo {membership = mem@GroupMember {memberRole = userRole}} m scopeInfo mc ft file_ sent
   | not supportAllowed = Just GFSupport
   | isVoice mc && not (groupFeatureMemberAllowed SGFVoice m gInfo) && not hostApprovalVoice = Just GFVoice
-  | isNothing scopeInfo && not (isVoice mc) && isJust file_ && not (groupFeatureMemberAllowed SGFFiles m gInfo) = Just GFFiles
+  | isNothing scopeInfo && not (isVoice mc) && (isJust file_ || isMedia mc) && not (groupFeatureMemberAllowed SGFFiles m gInfo) = Just GFFiles
   | isNothing scopeInfo && isReport mc && (badReportUser || not (groupFeatureAllowed SGFReports gInfo)) = Just GFReports
   | isNothing scopeInfo && prohibitedSimplexLinks gInfo m mc ft = Just GFSimplexLinks
   | otherwise = Nothing

--- a/src/Simplex/Chat/Library/Internal.hs
+++ b/src/Simplex/Chat/Library/Internal.hs
@@ -1404,14 +1404,22 @@ sendHistory user gInfo@GroupInfo {membership} m@GroupMember {activeConn = Just c
                in Just (fInv, fileDescrText)
           | otherwise = Nothing
         processContentItem :: Maybe GroupMember -> ChatItem 'CTGroup d -> MsgContent -> Maybe (FileInvitation, RcvFileDescrText) -> CM [(GrpMsgForward, VerifiedMsg 'Json)]
-        processContentItem member_ ChatItem {formattedText, meta, quotedItem, mentions} mc fInvDescr_ =
-          if isNothing fInvDescr_ && not (msgContentHasText mc)
-            then pure []
-            else do
-              let CIMeta {itemTs, itemSharedMsgId, itemTimed, showGroupAsSender} = meta
+        processContentItem member_ ChatItem {formattedText, meta, quotedItem, mentions} mc fInvDescr_
+          | isNothing fInvDescr_ && not (msgContentHasText mc) = pure []
+          -- a signed item keeps its original content and signature, so its now-prohibited
+          -- media cannot be sent as text and the item is dropped from history instead
+          | isJust signedMsg_ && prohibitedMedia = pure []
+          | otherwise = do
+              let -- items with expired or cancelled files are sent without file invitation,
+                  -- and their media content would be prohibited by the members receiving history
+                  -- if the feature is now disabled, so only the text of such items is sent.
+                  historyMC
+                    | prohibitedMedia = MCText $ msgContentText mc
+                    | otherwise = mc
+                  CIMeta {itemTs, itemSharedMsgId, itemTimed, showGroupAsSender} = meta
                   quotedItemId_ = quoteItemId =<< quotedItem
                   fInv_ = fst <$> fInvDescr_
-                  (mc', _, mentions') = updatedMentionNames mc formattedText mentions
+                  (mc', _, mentions') = updatedMentionNames historyMC formattedText mentions
                   mentions'' = M.map (\CIMention {memberId} -> MsgMention {memberId}) mentions'
                   -- for channel messages default chat version range to membership range
                   senderVRange = maybe (memberChatVRange' membership) memberChatVRange' member_
@@ -1436,6 +1444,14 @@ sendHistory user gInfo@GroupInfo {membership} m@GroupMember {activeConn = Just c
                 _ -> pure []
               let fileDescrVMs = map (VMUnsigned . ChatMessage senderVRange Nothing) fileDescrEvents
               pure $ map ((,) fwd) (contentVM : fileDescrVMs)
+          where
+            author = fromMaybe membership member_
+            -- media without a file invitation is prohibited when the group no longer allows it
+            prohibitedMedia =
+              isNothing fInvDescr_
+                && ( (isMedia mc && not (groupFeatureMemberAllowed SGFFiles author gInfo))
+                       || (isVoice mc && not (groupFeatureMemberAllowed SGFVoice author gInfo))
+                   )
 
 memberShortenedName :: GroupMember -> ContactName
 memberShortenedName GroupMember {memberProfile = LocalProfile {displayName}}

--- a/src/Simplex/Chat/Library/Internal.hs
+++ b/src/Simplex/Chat/Library/Internal.hs
@@ -1405,20 +1405,21 @@ sendHistory user gInfo@GroupInfo {membership} m@GroupMember {activeConn = Just c
           | otherwise = Nothing
         processContentItem :: Maybe GroupMember -> ChatItem 'CTGroup d -> MsgContent -> Maybe (FileInvitation, RcvFileDescrText) -> CM [(GrpMsgForward, VerifiedMsg 'Json)]
         processContentItem member_ ChatItem {formattedText, meta, quotedItem, mentions} mc fInvDescr_
-          | isNothing fInvDescr_ && not (msgContentHasText mc) = pure []
+          -- prohibited media is sent as text without the file, so items with no text are dropped
+          | not (msgContentHasText mc) && (prohibitedMedia || isNothing fInvDescr_) = pure []
           -- a signed item keeps its original content and signature, so its now-prohibited
           -- media cannot be sent as text and the item is dropped from history instead
           | isJust signedMsg_ && prohibitedMedia = pure []
           | otherwise = do
-              let -- items with expired or cancelled files are sent without file invitation,
-                  -- and their media content would be prohibited by the members receiving history
-                  -- if the feature is now disabled, so only the text of such items is sent.
+              let -- media the group no longer allows is sent as text without the file, so
+                  -- the members receiving history don't reject it as prohibited content.
                   historyMC
                     | prohibitedMedia = MCText $ msgContentText mc
                     | otherwise = mc
+                  fInvDescr' = if prohibitedMedia then Nothing else fInvDescr_
                   CIMeta {itemTs, itemSharedMsgId, itemTimed, showGroupAsSender} = meta
                   quotedItemId_ = quoteItemId =<< quotedItem
-                  fInv_ = fst <$> fInvDescr_
+                  fInv_ = fst <$> fInvDescr'
                   (mc', _, mentions') = updatedMentionNames historyMC formattedText mentions
                   mentions'' = M.map (\CIMention {memberId} -> MsgMention {memberId}) mentions'
                   -- for channel messages default chat version range to membership range
@@ -1436,7 +1437,7 @@ sendHistory user gInfo@GroupInfo {membership} m@GroupMember {activeConn = Just c
                   -- TODO [knocking] send history to other scopes too?
                   (chatMsgEvent, _) <- withStore $ \db -> prepareGroupMsg db user gInfo Nothing showGroupAsSender mc' mentions'' quotedItemId_ Nothing fInv_ itemTimed False
                   pure $ VMUnsigned ChatMessage {chatVRange = senderVRange, msgId = itemSharedMsgId, chatMsgEvent}
-              fileDescrEvents <- case (snd <$> fInvDescr_, itemSharedMsgId) of
+              fileDescrEvents <- case (snd <$> fInvDescr', itemSharedMsgId) of
                 (Just fileDescrText, Just msgId) -> do
                   partSize <- asks $ xftpDescrPartSize . config
                   let parts = splitFileDescr partSize fileDescrText
@@ -1446,12 +1447,10 @@ sendHistory user gInfo@GroupInfo {membership} m@GroupMember {activeConn = Just c
               pure $ map ((,) fwd) (contentVM : fileDescrVMs)
           where
             author = fromMaybe membership member_
-            -- media without a file invitation is prohibited when the group no longer allows it
+            -- media content the group no longer allows, with or without a file
             prohibitedMedia =
-              isNothing fInvDescr_
-                && ( (isMedia mc && not (groupFeatureMemberAllowed SGFFiles author gInfo))
-                       || (isVoice mc && not (groupFeatureMemberAllowed SGFVoice author gInfo))
-                   )
+              (isMedia mc && not (groupFeatureMemberAllowed SGFFiles author gInfo))
+                || (isVoice mc && not (groupFeatureMemberAllowed SGFVoice author gInfo))
 
 memberShortenedName :: GroupMember -> ContactName
 memberShortenedName GroupMember {memberProfile = LocalProfile {displayName}}

--- a/src/Simplex/Chat/Library/Internal.hs
+++ b/src/Simplex/Chat/Library/Internal.hs
@@ -339,15 +339,17 @@ quoteContent mc qmc ciFile_
     qFileName = maybe qText (T.pack . getFileName) ciFile_
     qTextOrFile = if T.null qText then qFileName else qText
 
-prohibitedGroupContent :: GroupInfo -> GroupMember -> Maybe GroupChatScopeInfo -> MsgContent -> Maybe MarkdownList -> Maybe f -> Bool -> Maybe GroupFeature
-prohibitedGroupContent gInfo@GroupInfo {membership = mem@GroupMember {memberRole = userRole}} m scopeInfo mc ft file_ sent
+prohibitedGroupContent :: GroupInfo -> GroupMember -> Maybe GroupChatScopeInfo -> MsgContent -> Maybe MsgContent -> Maybe MarkdownList -> Maybe f -> Bool -> Maybe GroupFeature
+prohibitedGroupContent gInfo@GroupInfo {membership = mem@GroupMember {memberRole = userRole}} m scopeInfo mc oldMC_ ft file_ sent
   | not supportAllowed = Just GFSupport
-  | isVoice mc && not (groupFeatureMemberAllowed SGFVoice m gInfo) && not hostApprovalVoice = Just GFVoice
-  | isNothing scopeInfo && not (isVoice mc) && (isJust file_ || isMedia mc) && not (groupFeatureMemberAllowed SGFFiles m gInfo) = Just GFFiles
+  | isVoice mc && newMedia && not (groupFeatureMemberAllowed SGFVoice m gInfo) && not hostApprovalVoice = Just GFVoice
+  | isNothing scopeInfo && not (isVoice mc) && (isJust file_ || (isMedia mc && newMedia)) && not (groupFeatureMemberAllowed SGFFiles m gInfo) = Just GFFiles
   | isNothing scopeInfo && isReport mc && (badReportUser || not (groupFeatureAllowed SGFReports gInfo)) = Just GFReports
   | isNothing scopeInfo && prohibitedSimplexLinks gInfo m mc ft = Just GFSimplexLinks
   | otherwise = Nothing
   where
+    -- the updated message keeps the media it already had, only added media is prohibited
+    newMedia = not $ maybe False (sameMedia mc) oldMC_
     supportAllowed = case scopeInfo of
       Just (GCSIMemberSupport scopeMem_) ->
         groupFeatureAllowed SGFSupport gInfo || isJust (supportChat $ fromMaybe mem scopeMem_)

--- a/src/Simplex/Chat/Library/Subscriber.hs
+++ b/src/Simplex/Chat/Library/Subscriber.hs
@@ -2238,44 +2238,41 @@ processAgentMessageConn cxt user@User {userId} corrId agentConnId agentMessage =
           groupMsgToView cInfo ci' {reactions}
 
     groupMessageUpdate :: GroupInfo -> Maybe GroupMember -> SharedMsgId -> MsgContent -> Map MemberName MsgMention -> Maybe MsgScope -> RcvMessage -> UTCTime -> Maybe Int -> Maybe Bool -> Maybe Bool -> CM (Maybe DeliveryTaskContext)
-    groupMessageUpdate gInfo@GroupInfo {groupId} m_ sharedMsgId mc mentions msgScope_ msg@RcvMessage {msgId, msgSigned, signedMsg_, signedByGMId_} brokerTs ttl_ live_ asGroup_
-      | Just m <- m_, prohibitedSimplexLinks gInfo m mc ft_ =
-          messageWarning ("x.msg.update ignored: feature not allowed " <> groupFeatureNameText GFSimplexLinks) $> Nothing
-      | otherwise = do
-          updateRcvChatItem `catchCINotFound` \_ -> do
-            -- This patches initial sharedMsgId into chat item when locally deleted chat item
-            -- received an update from the sender, so that it can be referenced later (e.g. by broadcast delete).
-            -- Chat item and update message which created it will have different sharedMsgId in this case...
-            let timed_ = rcvGroupCITimed gInfo ttl_
-                showGroupAsSender = fromMaybe (isNothing m_) asGroup_
-            if showGroupAsSender && maybe False (\m -> memberRole' m < GROwner) m_
-              then messageError "x.msg.update: member attempted to update as group" $> Nothing
-              else do
-                (gInfo', chatDir, mentions', scopeInfo) <-
-                  if showGroupAsSender
-                    then pure (gInfo, CDChannelRcv gInfo Nothing, mentions, Nothing)
-                    else case m_ of
-                      Just m -> do
-                        let mentions' = if memberBlocked m then [] else mentions
-                        (gInfo', m', scopeInfo) <- mkGetMessageChatScope cxt user gInfo m mc msgScope_
-                        pure (gInfo', CDGroupRcv gInfo' scopeInfo m', mentions', scopeInfo)
-                      Nothing -> pure (gInfo, CDChannelRcv gInfo Nothing, mentions, Nothing)
-                case m_ >>= \m -> prohibitedGroupContent gInfo' m scopeInfo mc ft_ (Nothing :: Maybe String) False of
-                  Just f -> do
-                    let ciContent = ciContentNoParse $ CIRcvGroupFeatureRejected f
-                    (ci, cInfo) <- saveRcvChatItem' user chatDir msg (Just sharedMsgId) brokerTs ciContent Nothing timed_ False M.empty
-                    groupMsgToView cInfo ci
-                    pure Nothing
-                  Nothing -> do
-                    (ci, cInfo) <- saveRcvChatItem' user chatDir msg (Just sharedMsgId) brokerTs (content, ts) Nothing timed_ live mentions'
-                    ci' <- withStore' $ \db -> do
-                      createChatItemVersion db (chatItemId' ci) brokerTs mc
-                      updateGroupChatItem db user groupId ci content True live Nothing
-                    ci'' <- case chatDir of
-                      CDGroupRcv gi' _ m' -> blockedMemberCI gi' m' ci'
-                      CDChannelRcv {} -> pure ci'
-                    toView $ CEvtChatItemUpdated user (AChatItem SCTGroup SMDRcv cInfo ci'')
-                    pure $ Just $ infoToDeliveryContext gInfo' scopeInfo showGroupAsSender
+    groupMessageUpdate gInfo@GroupInfo {groupId} m_ sharedMsgId mc mentions msgScope_ msg@RcvMessage {msgId, msgSigned, signedMsg_, signedByGMId_} brokerTs ttl_ live_ asGroup_ = do
+      updateRcvChatItem `catchCINotFound` \_ -> do
+        -- This patches initial sharedMsgId into chat item when locally deleted chat item
+        -- received an update from the sender, so that it can be referenced later (e.g. by broadcast delete).
+        -- Chat item and update message which created it will have different sharedMsgId in this case...
+        let timed_ = rcvGroupCITimed gInfo ttl_
+            showGroupAsSender = fromMaybe (isNothing m_) asGroup_
+        if showGroupAsSender && maybe False (\m -> memberRole' m < GROwner) m_
+          then messageError "x.msg.update: member attempted to update as group" $> Nothing
+          else do
+            (gInfo', chatDir, mentions', scopeInfo) <-
+              if showGroupAsSender
+                then pure (gInfo, CDChannelRcv gInfo Nothing, mentions, Nothing)
+                else case m_ of
+                  Just m -> do
+                    let mentions' = if memberBlocked m then [] else mentions
+                    (gInfo', m', scopeInfo) <- mkGetMessageChatScope cxt user gInfo m mc msgScope_
+                    pure (gInfo', CDGroupRcv gInfo' scopeInfo m', mentions', scopeInfo)
+                  Nothing -> pure (gInfo, CDChannelRcv gInfo Nothing, mentions, Nothing)
+            case m_ >>= \m -> prohibitedGroupContent gInfo' m scopeInfo mc ft_ (Nothing :: Maybe String) False of
+              Just f -> do
+                let ciContent = ciContentNoParse $ CIRcvGroupFeatureRejected f
+                (ci, cInfo) <- saveRcvChatItem' user chatDir msg (Just sharedMsgId) brokerTs ciContent Nothing timed_ False M.empty
+                groupMsgToView cInfo ci
+                pure Nothing
+              Nothing -> do
+                (ci, cInfo) <- saveRcvChatItem' user chatDir msg (Just sharedMsgId) brokerTs (content, ts) Nothing timed_ live mentions'
+                ci' <- withStore' $ \db -> do
+                  createChatItemVersion db (chatItemId' ci) brokerTs mc
+                  updateGroupChatItem db user groupId ci content True live Nothing
+                ci'' <- case chatDir of
+                  CDGroupRcv gi' _ m' -> blockedMemberCI gi' m' ci'
+                  CDChannelRcv {} -> pure ci'
+                toView $ CEvtChatItemUpdated user (AChatItem SCTGroup SMDRcv cInfo ci'')
+                pure $ Just $ infoToDeliveryContext gInfo' scopeInfo showGroupAsSender
       where
         content = CIRcvMsgContent mc
         ts@(_, ft_) = msgContentTexts mc

--- a/src/Simplex/Chat/Library/Subscriber.hs
+++ b/src/Simplex/Chat/Library/Subscriber.hs
@@ -2306,25 +2306,29 @@ processAgentMessageConn cxt user@User {userId} corrId agentConnId agentMessage =
                     Nothing -> createInternalChatItem user cd (CIRcvGroupEvent RGEMsgBadSignature) (Just brokerTs) $> Nothing
               | otherwise = action
         updateCI :: ShowGroupAsSender -> ChatItem 'CTGroup 'MDRcv -> Maybe GroupChatScopeInfo -> MsgContent -> Maybe Bool -> Maybe MemberId -> CM (Maybe DeliveryTaskContext)
-        updateCI showGroupAsSender ci scopeInfo oldMC itemLive memberId = do
-          let changed = mc /= oldMC
-          if changed || fromMaybe False itemLive
-            then do
-              ci' <- withStore' $ \db -> do
-                when changed $
-                  addInitialAndNewCIVersions db (chatItemId' ci) (chatItemTs' ci, oldMC) (brokerTs, mc)
-                reactions <- getGroupCIReactions db gInfo memberId sharedMsgId
-                let edited = itemLive /= Just True
-                ciMentions <- getRcvCIMentions db user gInfo ft_ mentions
-                ci' <- updateGroupChatItem db user groupId ci {reactions} content edited live $ Just msgId
-                updateChatItemSignedMsg db (chatItemId' ci) signedMsg_ signedByGMId_
-                updateGroupCIMentions db gInfo ci' ciMentions
-              toView $ CEvtChatItemUpdated user (AChatItem SCTGroup SMDRcv (GroupChat gInfo scopeInfo) ci')
-              startUpdatedTimedItemThread user (ChatRef CTGroup groupId $ toChatScope <$> scopeInfo) ci ci'
-              pure $ Just $ infoToDeliveryContext gInfo scopeInfo showGroupAsSender
-            else do
-              toView $ CEvtChatItemNotChanged user (AChatItem SCTGroup SMDRcv (GroupChat gInfo scopeInfo) ci)
-              pure Nothing
+        updateCI showGroupAsSender ci scopeInfo oldMC itemLive memberId =
+          case m_ >>= \m -> prohibitedGroupContent gInfo m scopeInfo mc ft_ (Nothing :: Maybe String) False of
+            -- the update is ignored, the previously received content remains
+            Just f -> messageWarning ("x.msg.update ignored: feature not allowed " <> groupFeatureNameText f) $> Nothing
+            Nothing -> do
+              let changed = mc /= oldMC
+              if changed || fromMaybe False itemLive
+                then do
+                  ci' <- withStore' $ \db -> do
+                    when changed $
+                      addInitialAndNewCIVersions db (chatItemId' ci) (chatItemTs' ci, oldMC) (brokerTs, mc)
+                    reactions <- getGroupCIReactions db gInfo memberId sharedMsgId
+                    let edited = itemLive /= Just True
+                    ciMentions <- getRcvCIMentions db user gInfo ft_ mentions
+                    ci' <- updateGroupChatItem db user groupId ci {reactions} content edited live $ Just msgId
+                    updateChatItemSignedMsg db (chatItemId' ci) signedMsg_ signedByGMId_
+                    updateGroupCIMentions db gInfo ci' ciMentions
+                  toView $ CEvtChatItemUpdated user (AChatItem SCTGroup SMDRcv (GroupChat gInfo scopeInfo) ci')
+                  startUpdatedTimedItemThread user (ChatRef CTGroup groupId $ toChatScope <$> scopeInfo) ci ci'
+                  pure $ Just $ infoToDeliveryContext gInfo scopeInfo showGroupAsSender
+                else do
+                  toView $ CEvtChatItemNotChanged user (AChatItem SCTGroup SMDRcv (GroupChat gInfo scopeInfo) ci)
+                  pure Nothing
 
     groupMessageDelete :: GroupInfo -> Maybe GroupMember -> SharedMsgId -> Maybe MemberId -> Maybe MsgScope -> Bool -> RcvMessage -> UTCTime -> CM (Maybe DeliveryTaskContext)
     groupMessageDelete gInfo@GroupInfo {membership} m_ sharedMsgId sndMemberId_ scope_ onlyHistory rcvMsg brokerTs =

--- a/src/Simplex/Chat/Library/Subscriber.hs
+++ b/src/Simplex/Chat/Library/Subscriber.hs
@@ -2035,19 +2035,23 @@ processAgentMessageConn cxt user@User {userId} corrId agentConnId agentMessage =
           cci <- withStore $ \db -> getDirectChatItemBySharedMsgId db user contactId sharedMsgId
           case cci of
             CChatItem SMDRcv ci@ChatItem {meta = CIMeta {itemForwarded, itemLive}, content = CIRcvMsgContent oldMC}
-              | isNothing itemForwarded -> do
-                  let changed = mc /= oldMC
-                  if changed || fromMaybe False itemLive
-                    then do
-                      ci' <- withStore' $ \db -> do
-                        when changed $
-                          addInitialAndNewCIVersions db (chatItemId' ci) (chatItemTs' ci, oldMC) (brokerTs, mc)
-                        reactions <- getDirectCIReactions db ct sharedMsgId
-                        let edited = itemLive /= Just True
-                        updateDirectChatItem' db user contactId ci {reactions} content edited live Nothing $ Just msgId
-                      toView $ CEvtChatItemUpdated user (AChatItem SCTDirect SMDRcv (DirectChat ct) ci')
-                      startUpdatedTimedItemThread user (ChatRef CTDirect contactId Nothing) ci ci'
-                    else toView $ CEvtChatItemNotChanged user (AChatItem SCTDirect SMDRcv (DirectChat ct) ci)
+              | isNothing itemForwarded ->
+                  if isVoice mc && not (sameMedia mc oldMC) && not (featureAllowed SCFVoice forContact ct)
+                    -- the update is ignored, the previously received content remains
+                    then messageWarning ("x.msg.update ignored: feature not allowed " <> chatFeatureNameText CFVoice)
+                    else do
+                      let changed = mc /= oldMC
+                      if changed || fromMaybe False itemLive
+                        then do
+                          ci' <- withStore' $ \db -> do
+                            when changed $
+                              addInitialAndNewCIVersions db (chatItemId' ci) (chatItemTs' ci, oldMC) (brokerTs, mc)
+                            reactions <- getDirectCIReactions db ct sharedMsgId
+                            let edited = itemLive /= Just True
+                            updateDirectChatItem' db user contactId ci {reactions} content edited live Nothing $ Just msgId
+                          toView $ CEvtChatItemUpdated user (AChatItem SCTDirect SMDRcv (DirectChat ct) ci')
+                          startUpdatedTimedItemThread user (ChatRef CTDirect contactId Nothing) ci ci'
+                        else toView $ CEvtChatItemNotChanged user (AChatItem SCTDirect SMDRcv (DirectChat ct) ci)
             _ -> messageError "x.msg.update: contact attempted invalid message update"
 
     messageDelete :: Contact -> SharedMsgId -> RcvMessage -> MsgMeta -> CM ()
@@ -2164,7 +2168,7 @@ processAgentMessageConn cxt user@User {userId} corrId agentConnId agentMessage =
             (gInfo', m', scopeInfo) <- mkGetMessageChatScope cxt user gInfo m content msgScope_
             if blockedByAdmin m'
               then createBlockedByAdmin gInfo' (Just m') scopeInfo $> Nothing
-              else case prohibitedGroupContent gInfo' m' scopeInfo content ft_ fInv_ False of
+              else case prohibitedGroupContent gInfo' m' scopeInfo content Nothing ft_ fInv_ False of
                 Just f -> rejected gInfo' (Just m') scopeInfo f $> Nothing
                 Nothing ->
                   withStore' (\db -> getCIModeration db cxt user gInfo' memberId sharedMsgId_) >>= \case
@@ -2257,7 +2261,7 @@ processAgentMessageConn cxt user@User {userId} corrId agentConnId agentMessage =
                     (gInfo', m', scopeInfo) <- mkGetMessageChatScope cxt user gInfo m mc msgScope_
                     pure (gInfo', CDGroupRcv gInfo' scopeInfo m', mentions', scopeInfo)
                   Nothing -> pure (gInfo, CDChannelRcv gInfo Nothing, mentions, Nothing)
-            case m_ >>= \m -> prohibitedGroupContent gInfo' m scopeInfo mc ft_ (Nothing :: Maybe String) False of
+            case m_ >>= \m -> prohibitedGroupContent gInfo' m scopeInfo mc Nothing ft_ (Nothing :: Maybe String) False of
               Just f -> do
                 let ciContent = ciContentNoParse $ CIRcvGroupFeatureRejected f
                 (ci, cInfo) <- saveRcvChatItem' user chatDir msg (Just sharedMsgId) brokerTs ciContent Nothing timed_ False M.empty
@@ -2307,7 +2311,7 @@ processAgentMessageConn cxt user@User {userId} corrId agentConnId agentMessage =
               | otherwise = action
         updateCI :: ShowGroupAsSender -> ChatItem 'CTGroup 'MDRcv -> Maybe GroupChatScopeInfo -> MsgContent -> Maybe Bool -> Maybe MemberId -> CM (Maybe DeliveryTaskContext)
         updateCI showGroupAsSender ci scopeInfo oldMC itemLive memberId =
-          case m_ >>= \m -> prohibitedGroupContent gInfo m scopeInfo mc ft_ (Nothing :: Maybe String) False of
+          case m_ >>= \m -> prohibitedGroupContent gInfo m scopeInfo mc (Just oldMC) ft_ (Nothing :: Maybe String) False of
             -- the update is ignored, the previously received content remains
             Just f -> messageWarning ("x.msg.update ignored: feature not allowed " <> groupFeatureNameText f) $> Nothing
             Nothing -> do

--- a/src/Simplex/Chat/Protocol.hs
+++ b/src/Simplex/Chat/Protocol.hs
@@ -815,6 +815,14 @@ isVoice = \case
   MCVoice {} -> True
   _ -> False
 
+-- image and video contents include media preview, so they are prohibited
+-- when files are not allowed even without the attached file.
+isMedia :: MsgContent -> Bool
+isMedia = \case
+  MCImage {} -> True
+  MCVideo {} -> True
+  _ -> False
+
 isReport :: MsgContent -> Bool
 isReport = \case
   MCReport {} -> True

--- a/src/Simplex/Chat/Protocol.hs
+++ b/src/Simplex/Chat/Protocol.hs
@@ -815,12 +815,13 @@ isVoice = \case
   MCVoice {} -> True
   _ -> False
 
--- image and video contents include media preview, so they are prohibited
--- when files are not allowed even without the attached file.
+-- file and media contents are prohibited when files are not allowed
+-- even without the attached file, as image and video include preview.
 isMedia :: MsgContent -> Bool
 isMedia = \case
   MCImage {} -> True
   MCVideo {} -> True
+  MCFile {} -> True
   _ -> False
 
 isReport :: MsgContent -> Bool

--- a/src/Simplex/Chat/Protocol.hs
+++ b/src/Simplex/Chat/Protocol.hs
@@ -824,6 +824,16 @@ isMedia = \case
   MCFile {} -> True
   _ -> False
 
+-- media of the updated message is the same when only its text is changed,
+-- in this case the update does not add media that is not already in the message.
+sameMedia :: MsgContent -> MsgContent -> Bool
+sameMedia mc mc' = case (mc, mc') of
+  (MCImage {image}, MCImage {image = image'}) -> image == image'
+  (MCVideo {image, duration}, MCVideo {image = image', duration = duration'}) -> image == image' && duration == duration'
+  (MCVoice {duration}, MCVoice {duration = duration'}) -> duration == duration'
+  (MCFile _, MCFile _) -> True
+  _ -> False
+
 isReport :: MsgContent -> Bool
 isReport = \case
   MCReport {} -> True

--- a/tests/ChatTests/Files.hs
+++ b/tests/ChatTests/Files.hs
@@ -1049,12 +1049,14 @@ testProhibitFiles =
     alice <## "bad chat command: feature not allowed Files and media"
     (bob </)
     (cath </)
-    -- image and video content is prohibited without file, as it includes preview
+    -- file and media content is prohibited without file, as image and video include preview
     alice ##> ("/_send #1 json [{\"msgContent\": {\"text\":\"\",\"type\":\"image\",\"image\":\"" <> imageData <> "\"}}]")
     alice <## "bad chat command: feature not allowed Files and media"
     (bob </)
     (cath </)
     alice ##> ("/_send #1 json [{\"msgContent\": {\"text\":\"\",\"type\":\"video\",\"image\":\"" <> imageData <> "\",\"duration\":5}}]")
+    alice <## "bad chat command: feature not allowed Files and media"
+    alice ##> "/_send #1 json [{\"msgContent\": {\"text\":\"\",\"type\":\"file\"}}]"
     alice <## "bad chat command: feature not allowed Files and media"
     -- image content cannot be sent by updating message
     alice #> "#team hi"

--- a/tests/ChatTests/Files.hs
+++ b/tests/ChatTests/Files.hs
@@ -1049,6 +1049,24 @@ testProhibitFiles =
     alice <## "bad chat command: feature not allowed Files and media"
     (bob </)
     (cath </)
+    -- image and video content is prohibited without file, as it includes preview
+    alice ##> ("/_send #1 json [{\"msgContent\": {\"text\":\"\",\"type\":\"image\",\"image\":\"" <> imageData <> "\"}}]")
+    alice <## "bad chat command: feature not allowed Files and media"
+    (bob </)
+    (cath </)
+    alice ##> ("/_send #1 json [{\"msgContent\": {\"text\":\"\",\"type\":\"video\",\"image\":\"" <> imageData <> "\",\"duration\":5}}]")
+    alice <## "bad chat command: feature not allowed Files and media"
+    -- image content cannot be sent by updating message
+    alice #> "#team hi"
+    bob <# "#team alice> hi"
+    cath <# "#team alice> hi"
+    aliceItemId <- lastItemId alice
+    alice ##> ("/_update item #1 " <> aliceItemId <> " json {\"msgContent\": {\"text\":\"\",\"type\":\"image\",\"image\":\"" <> imageData <> "\"}, \"mentions\": {}}")
+    alice <## "bad chat command: feature not allowed Files and media"
+    (bob </)
+    (cath </)
+  where
+    imageData = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII="
 
 testXFTPStandaloneSmall :: HasCallStack => TestParams -> IO ()
 testXFTPStandaloneSmall = testChat2 aliceProfile aliceDesktopProfile $ \src dst -> do

--- a/tests/ChatTests/Files.hs
+++ b/tests/ChatTests/Files.hs
@@ -20,6 +20,7 @@ import Simplex.Chat.Library.Internal (roundedFDCount)
 import Simplex.Chat.Mobile.File
 import Simplex.Chat.Options (ChatOpts (..))
 import Simplex.FileTransfer.Server.Env (XFTPServerConfig (..), XFTPStoreConfig (..))
+import qualified Simplex.Messaging.Agent.Store.DB as DB
 import Simplex.Messaging.Crypto.File (CryptoFile (..), CryptoFileArgs (..))
 import Simplex.Messaging.Encoding.String
 import System.Directory (copyFile, createDirectoryIfMissing, doesFileExist, getFileSize)
@@ -1067,6 +1068,26 @@ testProhibitFiles =
     alice <## "bad chat command: feature not allowed Files and media"
     (bob </)
     (cath </)
+    -- reset preferences in bob's database to emulate the client that doesn't check them
+    withCCTransaction bob $ \db ->
+      DB.execute_ db "UPDATE group_profiles SET preferences = NULL"
+    -- image content in new message is rejected by recipients
+    bob ##> ("/_send #1 json [{\"msgContent\": {\"text\":\"hi\",\"type\":\"image\",\"image\":\"" <> imageData <> "\"}}]")
+    bob <# "#team hi"
+    bob #> "#team hello"
+    alice <# "#team bob> hello"
+    cath <# "#team bob> hello"
+    -- image content in updated message is ignored by recipients, previously received content remains
+    bobItemId <- lastItemId bob
+    bob ##> ("/_update item #1 " <> bobItemId <> " json {\"msgContent\": {\"text\":\"hi\",\"type\":\"image\",\"image\":\"" <> imageData <> "\"}, \"mentions\": {}}")
+    bob <# "#team [edited] hi"
+    (alice </)
+    (cath </)
+    bob #> "#team hey"
+    alice <# "#team bob> hey"
+    cath <# "#team bob> hey"
+    alice #$> ("/_get chat #1 count=3", chat, [(0, "Files and media: received, prohibited"), (0, "hello"), (0, "hey")])
+    cath #$> ("/_get chat #1 count=3", chat, [(0, "Files and media: received, prohibited"), (0, "hello"), (0, "hey")])
   where
     imageData = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII="
 

--- a/tests/ChatTests/Files.hs
+++ b/tests/ChatTests/Files.hs
@@ -1033,6 +1033,12 @@ testProhibitFiles :: HasCallStack => TestParams -> IO ()
 testProhibitFiles =
   testChat3 aliceProfile bobProfile cathProfile $ \alice bob cath -> withXFTPServer $ do
     createGroup3 "team" alice bob cath
+    -- image content sent while files are allowed
+    alice ##> ("/_send #1 json [{\"msgContent\": {\"text\":\"picture\",\"type\":\"image\",\"image\":\"" <> imageData <> "\"}}]")
+    alice <# "#team picture"
+    bob <# "#team alice> picture"
+    cath <# "#team alice> picture"
+    imageItemId <- lastItemId alice
     alice ##> "/set files #team off"
     alice <## "updated group preferences:"
     alice <## "Files and media: off"
@@ -1068,6 +1074,16 @@ testProhibitFiles =
     alice <## "bad chat command: feature not allowed Files and media"
     (bob </)
     (cath </)
+    -- text of the message with media can be updated, as the update does not add media
+    alice ##> ("/_update item #1 " <> imageItemId <> " json {\"msgContent\": {\"text\":\"picture!\",\"type\":\"image\",\"image\":\"" <> imageData <> "\"}, \"mentions\": {}}")
+    alice <# "#team [edited] picture!"
+    bob <# "#team alice> [edited] picture!"
+    cath <# "#team alice> [edited] picture!"
+    -- changing media in the message is prohibited
+    alice ##> ("/_update item #1 " <> imageItemId <> " json {\"msgContent\": {\"text\":\"picture!\",\"type\":\"image\",\"image\":\"" <> imageData' <> "\"}, \"mentions\": {}}")
+    alice <## "bad chat command: feature not allowed Files and media"
+    (bob </)
+    (cath </)
     -- reset preferences in bob's database to emulate the client that doesn't check them
     withCCTransaction bob $ \db ->
       DB.execute_ db "UPDATE group_profiles SET preferences = NULL"
@@ -1088,8 +1104,22 @@ testProhibitFiles =
     cath <# "#team bob> hey"
     alice #$> ("/_get chat #1 count=3", chat, [(0, "Files and media: received, prohibited"), (0, "hello"), (0, "hey")])
     cath #$> ("/_get chat #1 count=3", chat, [(0, "Files and media: received, prohibited"), (0, "hello"), (0, "hey")])
+    -- update of the message deleted by the recipient creates the item, and is rejected as a new message
+    bob #> "#team hi there"
+    alice <# "#team bob> hi there"
+    cath <# "#team bob> hi there"
+    aliceItemId' <- lastItemId alice
+    alice #$> ("/_delete item #1 " <> aliceItemId' <> " internal", id, "message deleted")
+    bobItemId' <- lastItemId bob
+    bob ##> ("/_update item #1 " <> bobItemId' <> " json {\"msgContent\": {\"text\":\"hi there\",\"type\":\"image\",\"image\":\"" <> imageData <> "\"}, \"mentions\": {}}")
+    bob <# "#team [edited] hi there"
+    bob #> "#team hey again"
+    alice <# "#team bob> hey again"
+    cath <# "#team bob> hey again"
+    alice #$> ("/_get chat #1 count=2", chat, [(0, "Files and media: received, prohibited"), (0, "hey again")])
   where
     imageData = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII="
+    imageData' = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAAApJREFUCNdjYAAAAAIAAeIhvDMAAAAASUVORK5CYII="
 
 testXFTPStandaloneSmall :: HasCallStack => TestParams -> IO ()
 testXFTPStandaloneSmall = testChat2 aliceProfile aliceDesktopProfile $ \src dst -> do

--- a/tests/ChatTests/Groups.hs
+++ b/tests/ChatTests/Groups.hs
@@ -184,6 +184,7 @@ chatGroupTests = do
     it "forward group deletion (x.grp.del)" testGroupMsgForwardGroupDeletion
   describe "group history" $ do
     it "text messages" testGroupHistory
+    it "media content is sent as text when files are prohibited" testGroupHistoryProhibitedMedia
     it "history is sent when joining via group link" testGroupHistoryGroupLink
     it "history is not sent if preference is disabled" testGroupHistoryPreferenceOff
     it "host's file" testGroupHistoryHostFile
@@ -5573,6 +5574,51 @@ testGroupHistory =
       [alice, cath] *<# "#team bob> 2"
       cath #> "#team 3"
       [alice, bob] *<# "#team cath> 3"
+
+testGroupHistoryProhibitedMedia :: HasCallStack => TestParams -> IO ()
+testGroupHistoryProhibitedMedia =
+  testChat3 aliceProfile bobProfile cathProfile $
+    \alice bob cath -> do
+      createGroup2 "team" alice bob
+
+      threadDelay 1000000
+
+      -- image content sent while files are allowed; history items with expired
+      -- files are sent without file invitations, as this one is sent
+      alice ##> ("/_send #1 json [{\"msgContent\": {\"text\":\"picture\",\"type\":\"image\",\"image\":\"" <> imageData <> "\"}}]")
+      alice <# "#team picture"
+      bob <# "#team alice> picture"
+
+      threadDelay 1000000
+
+      alice ##> "/set files #team off"
+      alice <## "updated group preferences:"
+      alice <## "Files and media: off"
+      bob <## "alice updated group #team:"
+      bob <## "updated group preferences:"
+      bob <## "Files and media: off"
+
+      connectUsers alice cath
+      addMember "team" alice cath GRAdmin
+      cath ##> "/j team"
+      concurrentlyN_
+        [ alice <## "#team: cath joined the group",
+          cath
+            <### [ "#team: you joined the group",
+                   WithTime "#team alice> picture [>>]",
+                   "#team: member bob (Bob) is connected"
+                 ],
+          do
+            bob <## "#team: alice added cath (Catherine) to the group (connecting...)"
+            bob <## "#team: new member cath is connected"
+        ]
+
+      -- the text of the message is received in history, not the prohibited media
+      cath ##> "/_get chat #1 count=100"
+      r <- chat <$> getTermLine cath
+      r `shouldContain` [(0, "picture")]
+  where
+    imageData = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII="
 
 testGroupHistoryGroupLink :: HasCallStack => TestParams -> IO ()
 testGroupHistoryGroupLink =

--- a/tests/ChatTests/Groups.hs
+++ b/tests/ChatTests/Groups.hs
@@ -5578,16 +5578,25 @@ testGroupHistory =
 testGroupHistoryProhibitedMedia :: HasCallStack => TestParams -> IO ()
 testGroupHistoryProhibitedMedia =
   testChat3 aliceProfile bobProfile cathProfile $
-    \alice bob cath -> do
+    \alice bob cath -> withXFTPServer $ do
       createGroup2 "team" alice bob
 
       threadDelay 1000000
 
-      -- image content sent while files are allowed; history items with expired
-      -- files are sent without file invitations, as this one is sent
-      alice ##> ("/_send #1 json [{\"msgContent\": {\"text\":\"picture\",\"type\":\"image\",\"image\":\"" <> imageData <> "\"}}]")
-      alice <# "#team picture"
-      bob <# "#team alice> picture"
+      -- image with a caption but no file (inline preview only), sent while files are allowed
+      alice ##> ("/_send #1 json [{\"msgContent\": {\"text\":\"inline pic\",\"type\":\"image\",\"image\":\"" <> imageData <> "\"}}]")
+      alice <# "#team inline pic"
+      bob <# "#team alice> inline pic"
+
+      -- image with an XFTP file and a caption, sent while files are allowed
+      alice ##> ("/_send #1 json [{\"filePath\": \"./tests/fixtures/test.jpg\", \"msgContent\": {\"text\":\"file pic\",\"type\":\"image\",\"image\":\"" <> imageData <> "\"}}]")
+      alice <# "#team file pic"
+      alice <# "/f #team ./tests/fixtures/test.jpg"
+      alice <## "use /fc 1 to cancel sending"
+      bob <# "#team alice> file pic"
+      bob <# "#team alice> sends file test.jpg (136.5 KiB / 139737 bytes)"
+      bob <## "use /fr 1 [<dir>/ | <path>] to receive it"
+      alice <## "completed uploading file 1 (test.jpg) for #team"
 
       threadDelay 1000000
 
@@ -5605,7 +5614,9 @@ testGroupHistoryProhibitedMedia =
         [ alice <## "#team: cath joined the group",
           cath
             <### [ "#team: you joined the group",
-                   WithTime "#team alice> picture [>>]",
+                   -- both captions are received as text, without the prohibited images or the file
+                   WithTime "#team alice> inline pic [>>]",
+                   WithTime "#team alice> file pic [>>]",
                    "#team: member bob (Bob) is connected"
                  ],
           do
@@ -5613,10 +5624,11 @@ testGroupHistoryProhibitedMedia =
             bob <## "#team: new member cath is connected"
         ]
 
-      -- the text of the message is received in history, not the prohibited media
+      -- both captions are received in history as plain messages with no file
+      -- (a file invitation would show as an unconsumed "sends file" line above)
       cath ##> "/_get chat #1 count=100"
-      r <- chat <$> getTermLine cath
-      r `shouldContain` [(0, "picture")]
+      r <- chatF <$> getTermLine cath
+      r `shouldContain` [((0, "inline pic"), Nothing), ((0, "file pic"), Nothing)]
   where
     imageData = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII="
 

--- a/tests/ChatTests/Profiles.hs
+++ b/tests/ChatTests/Profiles.hs
@@ -35,6 +35,7 @@ import Simplex.Chat.Types.Shared (GroupMemberRole (..))
 import Simplex.Chat.Types.UITheme
 import Simplex.Messaging.Agent.Env.SQLite
 import Simplex.Messaging.Agent.RetryInterval
+import qualified Simplex.Messaging.Agent.Store.DB as DB
 import Simplex.Messaging.Encoding.String (StrEncoding (..))
 import Simplex.Messaging.Server.Env.STM hiding (subscriptions)
 import Simplex.Messaging.Transport
@@ -3011,6 +3012,26 @@ testGroupPrefsSimplexLinksForRole = testChat3 aliceProfile bobProfile cathProfil
     bob <# ("#team (support) [edited] " <> inv)
     alice <# ("#team (support: bob) bob> [edited] " <> inv)
     cath <# ("#team (support: bob) bob> [edited] " <> inv)
+    -- reset preferences in bob's database to emulate the client that doesn't check them
+    withCCTransaction bob $ \db ->
+      DB.execute_ db "UPDATE group_profiles SET preferences = NULL"
+    -- link in new message is rejected by recipients
+    bob ##> ("/_send #1 json [{\"msgContent\": {\"type\": \"text\", \"text\": \"" <> inv <> "\"}}]")
+    bob <# ("#team " <> inv)
+    bob #> "#team hello"
+    alice <# "#team bob> hello"
+    cath <# "#team bob> hello"
+    -- link in updated message is ignored by recipients, previously received content remains
+    bobMainItemId' <- lastItemId bob
+    bob ##> ("/_update item #1 " <> bobMainItemId' <> " text " <> inv)
+    bob <# ("#team [edited] " <> inv)
+    (alice </)
+    (cath </)
+    bob #> "#team hey"
+    alice <# "#team bob> hey"
+    cath <# "#team bob> hey"
+    alice #$> ("/_get chat #1 count=3", chat, [(0, "SimpleX links: received, prohibited"), (0, "hello"), (0, "hey")])
+    cath #$> ("/_get chat #1 count=3", chat, [(0, "SimpleX links: received, prohibited"), (0, "hello"), (0, "hey")])
   where
     linksForOwners :: HasCallStack => TestCC -> IO ()
     linksForOwners cc = do

--- a/tests/ChatTests/Profiles.hs
+++ b/tests/ChatTests/Profiles.hs
@@ -107,6 +107,7 @@ chatProfileTests = do
     it "change user for user without matching servers creates new connection" testChangePCCUserDiffSrv
   describe "preferences" $ do
     it "set contact preferences" testSetContactPrefs
+    it "prohibit voice message content in updated message" testProhibitVoiceUpdate
     it "feature offers" testFeatureOffers
     it "update group preferences" testUpdateGroupPrefs
     it "allow full deletion to contact" testAllowFullDeletionContact
@@ -2443,6 +2444,33 @@ testSetGroupAlias = testChat2 aliceProfile bobProfile $
     alice ##> "/groups"
     alice <## "#team (2 members)"
 
+testProhibitVoiceUpdate :: HasCallStack => TestParams -> IO ()
+testProhibitVoiceUpdate = testChat2 aliceProfile bobProfile $
+  \alice bob -> do
+    connectUsers alice bob
+    alice ##> "/set voice @bob no"
+    alice <## "you updated preferences for bob:"
+    alice <## "Voice messages: off (you allow: no, contact allows: yes)"
+    bob <## "alice updated preferences for you:"
+    bob <## "Voice messages: off (you allow: default (yes), contact allows: no)"
+    alice #> "@bob hi"
+    bob <# "alice> hi"
+    aliceItemId <- lastItemId alice
+    -- voice message content cannot be sent by updating message
+    alice ##> ("/_update item @2 " <> aliceItemId <> " json {\"msgContent\": {\"type\":\"voice\",\"text\":\"\",\"duration\":10}, \"mentions\": {}}")
+    alice <## "bad chat command: feature not allowed Voice messages"
+    (bob </)
+    -- reset preferences in alice's database to emulate the client that doesn't check them
+    withCCTransaction alice $ \db ->
+      DB.execute_ db "UPDATE contacts SET user_preferences = '{}'"
+    alice ##> ("/_update item @2 " <> aliceItemId <> " json {\"msgContent\": {\"type\":\"voice\",\"text\":\"\",\"duration\":10}, \"mentions\": {}}")
+    alice <# "@bob [edited] voice message (00:10)"
+    -- the update is ignored by the recipient, previously received content remains
+    (bob </)
+    alice #> "@bob hey"
+    bob <# "alice> hey"
+    bob #$> ("/_get chat @2 count=2", chat, [(0, "hi"), (0, "hey")])
+
 testSetContactPrefs :: HasCallStack => TestParams -> IO ()
 testSetContactPrefs = testChat2 aliceProfile bobProfile $
   \alice bob -> withXFTPServer $ do
@@ -3012,6 +3040,11 @@ testGroupPrefsSimplexLinksForRole = testChat3 aliceProfile bobProfile cathProfil
     bob <# ("#team (support) [edited] " <> inv)
     alice <# ("#team (support: bob) bob> [edited] " <> inv)
     cath <# ("#team (support: bob) bob> [edited] " <> inv)
+    -- the content is checked with the scope of the updated item, not with the scope of the command
+    bob ##> ("/_update item #1(_support) " <> bobMainItemId <> " text " <> inv)
+    bob <## "bad chat command: feature not allowed SimpleX links"
+    (alice </)
+    (cath </)
     -- reset preferences in bob's database to emulate the client that doesn't check them
     withCCTransaction bob $ \db ->
       DB.execute_ db "UPDATE group_profiles SET preferences = NULL"

--- a/tests/ChatTests/Profiles.hs
+++ b/tests/ChatTests/Profiles.hs
@@ -2988,6 +2988,20 @@ testGroupPrefsSimplexLinksForRole = testChat3 aliceProfile bobProfile cathProfil
     alice #> ("#team " <> inv)
     bob <# ("#team alice> " <> inv)
     cath <# ("#team alice> " <> inv)
+    -- links are allowed in support chat, both in new and in updated messages
+    bob ##> ("/_send #1(_support) json [{\"msgContent\": {\"type\": \"text\", \"text\": \"" <> inv <> "\"}}]")
+    bob <# ("#team (support) " <> inv)
+    alice <# ("#team (support: bob) bob> " <> inv)
+    cath <# ("#team (support: bob) bob> " <> inv)
+    bob ##> "/_send #1(_support) text hi"
+    bob <# "#team (support) hi"
+    alice <# "#team (support: bob) bob> hi"
+    cath <# "#team (support: bob) bob> hi"
+    bobItemId <- lastItemId bob
+    bob ##> ("/_update item #1(_support) " <> bobItemId <> " text " <> inv)
+    bob <# ("#team (support) [edited] " <> inv)
+    alice <# ("#team (support: bob) bob> [edited] " <> inv)
+    cath <# ("#team (support: bob) bob> [edited] " <> inv)
   where
     linksForOwners :: HasCallStack => TestCC -> IO ()
     linksForOwners cc = do

--- a/tests/ChatTests/Profiles.hs
+++ b/tests/ChatTests/Profiles.hs
@@ -2988,6 +2988,15 @@ testGroupPrefsSimplexLinksForRole = testChat3 aliceProfile bobProfile cathProfil
     alice #> ("#team " <> inv)
     bob <# ("#team alice> " <> inv)
     cath <# ("#team alice> " <> inv)
+    -- links are prohibited when message is updated
+    bob #> "#team hello"
+    alice <# "#team bob> hello"
+    cath <# "#team bob> hello"
+    bobMainItemId <- lastItemId bob
+    bob ##> ("/_update item #1 " <> bobMainItemId <> " text " <> inv)
+    bob <## "bad chat command: feature not allowed SimpleX links"
+    (alice </)
+    (cath </)
     -- links are allowed in support chat, both in new and in updated messages
     bob ##> ("/_send #1(_support) json [{\"msgContent\": {\"type\": \"text\", \"text\": \"" <> inv <> "\"}}]")
     bob <# ("#team (support) " <> inv)


### PR DESCRIPTION
Images can be sent to a group that has "Files and media" disabled, e.g. `/_send #1 json [{"msgContent":{"type":"image","text":" ","image":"data:image/jpg;base64,..."}}]` — the sender's client raises no error and recipients display the image. `prohibitedGroupContent` decided the rule from the presence of a file, but `MCImage`/`MCVideo` carry the preview inline and `MCFile` is file content by itself, so with no file attached the check never fired; the update path was unchecked in the same way, on both the send and the receive side.

The fix tests the content type instead, the way voice messages already are, covering `/_send`, `x.msg.new` and `x.msg.update` through the shared check, on both sides. Editing only the text of a message that already has media or voice is allowed (the media is compared, not just the content type), so captions can still be edited after the feature is disabled, while replacing the media is not. An update is checked with the scope of the item being updated, not the scope of the command, so a main chat message cannot be edited with a support chat reference to skip the scope-gated guards. The same voice hole in direct chats, where the update path had no content check, is closed the same way.

The SimpleX links commit removes the update path's own links check, which applied in all scopes on both sides while the same guard inside `prohibitedGroupContent` is scope-gated — so a link could be posted in a support chat but not added by editing a message there. Nothing stops being validated: links in updates are now judged by the same scope-gated guard as links in new messages.

History items with expired or cancelled files are sent without a file invitation, so an older media item would be received as prohibited content by a member joining a group that has since disabled the feature; such items are now sent as text, and a signed item whose media cannot be changed is dropped from history instead.

Justification, alternatives considered and known effects are in `plans/2026-07-23-fix-group-media-without-file.md`. `testProhibitFiles`, `testGroupPrefsSimplexLinksForRole`, `testGroupHistoryProhibitedMedia` and `testProhibitVoiceUpdate` cover sending and receiving, with the receiving side driven by resetting preferences in the sender's database to emulate a client that does not check them; each behaviour has a negative control that fails when its fix is reverted.
