### PR TITLE
ios, android, desktop: fix draft in support chat appearing in group chat

### DIFF
--- a/apps/ios/Shared/Model/ChatModel.swift
+++ b/apps/ios/Shared/Model/ChatModel.swift
@@ -429,6 +429,7 @@ final class ChatModel: ObservableObject {
     // audio recording and playback
     @Published var stopPreviousRecPlay: URL? = nil // coordinates currently playing source
     @Published var draft: ComposeState?
+    // chat id with chat scope, see draftChatId() - group chat and its support chats have the same chat id
     @Published var draftChatId: String?
     @Published var networkInfo = UserNetworkInfo(networkType: .other, online: true)
     // usage conditions

--- a/apps/ios/Shared/Views/Chat/ChatView.swift
+++ b/apps/ios/Shared/Views/Chat/ChatView.swift
@@ -780,7 +780,7 @@ struct ChatView: View {
             }
             updateAvailableContent()
         }
-        if chatModel.draftChatId == cInfo.id && !composeState.forwarding,
+        if chatModel.draftChatId == draftChatId(cInfo.id, cInfo.groupChatScope()) && !composeState.forwarding,
            let draft = chatModel.draft {
             composeState = draft
         }

--- a/apps/ios/Shared/Views/Chat/ComposeMessage/ComposeView.swift
+++ b/apps/ios/Shared/Views/Chat/ComposeMessage/ComposeView.swift
@@ -1548,7 +1548,7 @@ struct ComposeView: View {
             let wasForwarding = composeState.forwarding
             clearState(live: live)
             if wasForwarding,
-               chatModel.draftChatId == chat.chatInfo.id,
+               chatModel.draftChatId == draftChatId(chat.chatInfo.id, chat.chatInfo.groupChatScope()),
                let draft = chatModel.draft {
                 composeState = draft
             }
@@ -1851,12 +1851,12 @@ struct ComposeView: View {
     // Spec: spec/client/compose.md#saveCurrentDraft
     private func saveCurrentDraft() {
         chatModel.draft = composeState
-        chatModel.draftChatId = chat.id
+        chatModel.draftChatId = draftChatId(chat.id, chat.chatInfo.groupChatScope())
     }
 
     // Spec: spec/client/compose.md#clearCurrentDraft
     private func clearCurrentDraft() {
-        if chatModel.draftChatId == chat.id {
+        if chatModel.draftChatId == draftChatId(chat.id, chat.chatInfo.groupChatScope()) {
             chatModel.draft = nil
             chatModel.draftChatId = nil
         }

--- a/apps/ios/SimpleXChat/ChatTypes.swift
+++ b/apps/ios/SimpleXChat/ChatTypes.swift
@@ -2137,6 +2137,14 @@ public func sameChatScope(_ scope1: GroupChatScope, _ scope2: GroupChatScope) ->
     }
 }
 
+public func draftChatId(_ chatId: ChatId?, _ scope: GroupChatScope?) -> ChatId? {
+    guard let chatId, let scope else { return chatId }
+    return switch scope {
+    case let .memberSupport(groupMemberId_): "\(chatId) support:\(groupMemberId_?.description ?? "")"
+    case .reports: "\(chatId) reports"
+    }
+}
+
 public enum GroupChatScopeInfo: Decodable, Hashable {
     case memberSupport(groupMember_: GroupMember?)
     case reports // surrogate scope used for matching new items to opened Reports "chat scope" in UI, this type is not present in backend

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
@@ -202,6 +202,7 @@ object ChatModel {
   val migrationState: MutableState<MigrationToState?> by lazy { mutableStateOf(MigrationToDeviceState.makeMigrationState()) }
 
   var draft = mutableStateOf(null as ComposeState?)
+  // chat id with chat scope, see draftChatId() - group chat and its support chats have the same chat id
   var draftChatId = mutableStateOf(null as String?)
 
   // working with external intents or internal forwarding of chat items
@@ -1258,6 +1259,12 @@ fun sameChatScope(scope1: GroupChatScope, scope2: GroupChatScope) =
   scope1 is GroupChatScope.MemberSupport
       && scope2 is GroupChatScope.MemberSupport
       && scope1.groupMemberId_ == scope2.groupMemberId_
+
+fun draftChatId(chatId: String?, scope: GroupChatScope?): String? =
+  if (chatId == null || scope == null) chatId
+  else when (scope) {
+    is GroupChatScope.MemberSupport -> "$chatId support:${scope.groupMemberId_ ?: ""}"
+  }
 
 @Serializable
 sealed class GroupChatScopeInfo {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
@@ -135,7 +135,7 @@ fun ChatView(
       val draft = chatModel.draft.value
       val sharedContent = chatModel.sharedContent.value
       mutableStateOf(
-        if (chatModel.draftChatId.value == staleChatId.value && draft != null && (sharedContent !is SharedContent.Forward || sharedContent.fromChatInfo.id == staleChatId.value)) {
+        if (chatModel.draftChatId.value == draftChatId(staleChatId.value, chatsCtx.groupScopeInfo?.toChatScope()) && draft != null && (sharedContent !is SharedContent.Forward || sharedContent.fromChatInfo.id == staleChatId.value)) {
           draft
         } else {
           ComposeState(useLinkPreviews = useLinkPreviews)

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ComposeView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ComposeView.kt
@@ -394,6 +394,8 @@ fun ComposeView(
   focusRequester: FocusRequester?,
 ) {
   val cancelledLinks = rememberSaveable { mutableSetOf<String>() }
+  val chatScope = remember(chatsCtx) { chatsCtx.groupScopeInfo?.toChatScope() }
+  val scopeChatId = remember { chat.id }
   fun isSimplexLink(link: String): Boolean =
     link.startsWith("https://simplex.chat", true) || link.startsWith("http://simplex.chat", true)
 
@@ -489,14 +491,14 @@ fun ComposeView(
   }
 
   fun clearPrevDraft(prevChatId: String?) {
-    if (chatModel.draftChatId.value == prevChatId) {
+    if (chatModel.draftChatId.value == draftChatId(prevChatId, chatScope)) {
       chatModel.draft.value = null
       chatModel.draftChatId.value = null
     }
   }
 
   fun clearCurrentDraft() {
-    if (chatModel.draftChatId.value == chat.id) {
+    if (chatModel.draftChatId.value == draftChatId(chat.id, chatScope)) {
       chatModel.draft.value = null
       chatModel.draftChatId.value = null
     }
@@ -936,7 +938,7 @@ fun ComposeView(
       composeState.value = lastFailed
     }
     val draft = chatModel.draft.value
-    if (wasForwarding && chatModel.draftChatId.value == chat.chatInfo.id && forwardingFromChatId != chat.chatInfo.id && draft != null) {
+    if (wasForwarding && chatModel.draftChatId.value == draftChatId(chat.chatInfo.id, chatScope) && forwardingFromChatId != chat.chatInfo.id && draft != null) {
       composeState.value = draft
     } else {
       clearCurrentDraft()
@@ -1326,10 +1328,10 @@ fun ComposeView(
       }
       if (saveLastDraft) {
         chatModel.draft.value = composeState.value
-        chatModel.draftChatId.value = prevChatId
+        chatModel.draftChatId.value = draftChatId(prevChatId, chatScope)
       }
       composeState.value = ComposeState(useLinkPreviews = useLinkPreviews)
-    } else if (chatModel.draftChatId.value == chatModel.chatId.value && chatModel.draft.value != null) {
+    } else if (chatModel.draftChatId.value == draftChatId(chatModel.chatId.value, chatScope) && chatModel.draft.value != null) {
       composeState.value = chatModel.draft.value ?: ComposeState(useLinkPreviews = useLinkPreviews)
     } else {
       clearPrevDraft(prevChatId)
@@ -1359,9 +1361,21 @@ fun ComposeView(
       onDispose {
         if (chatModel.sharedContent.value is SharedContent.Forward && saveLastDraft && !composeState.value.empty) {
           chatModel.draft.value = composeState.value
-          chatModel.draftChatId.value = currentChatId.value
+          chatModel.draftChatId.value = draftChatId(currentChatId.value, chatScope)
         }
       }
+    }
+  }
+  // support chat is closed without changing chat id, and then `KeyChangeEffect(chatModel.chatId.value)` doesn't save the draft
+  DisposableEffect(Unit) {
+    onDispose {
+      val cs = composeState.value
+      // chat change is handled by KeyChangeEffect, unfinished voice recording should not replace the saved draft
+      if (chatScope == null || chatModel.chatId.value != scopeChatId || (cs.preview is ComposePreview.VoicePreview && !cs.preview.finished)) return@onDispose
+      if (saveLastDraft && !cs.empty) {
+        chatModel.draft.value = cs
+        chatModel.draftChatId.value = draftChatId(scopeChatId, chatScope)
+      } else clearPrevDraft(scopeChatId)
     }
   }
 


### PR DESCRIPTION
A message draft typed in a support chat ("chat with admins" or a member support chat) reappears in the group chat and is shown as the group's draft in the chat list, and vice versa. The draft is stored in a single slot keyed by chat id, and a group chat and all of its support chats have the same chat id — the chat scope was not part of the key.

Include the chat scope in the stored draft chat id, so the draft is only restored in the chat it was typed in. Also save the draft when a support chat is closed without changing chat id (back button), where the chat change effect that saves drafts doesn't run.