### PR TITLE
Add a native macOS interface and desktop UX overhaul

### DIFF
--- a/apps/macos-native/.gitignore
+++ b/apps/macos-native/.gitignore
@@ -1,0 +1,2 @@
+.build/
+build/

--- a/apps/macos-native/Package.swift
+++ b/apps/macos-native/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "SimpleXNative",
+    platforms: [.macOS(.v14)],
+    products: [
+        .executable(name: "SimpleXNative", targets: ["SimpleXNative"]),
+    ],
+    targets: [
+        .target(
+            name: "CoreBridge",
+            publicHeadersPath: "include",
+            linkerSettings: [.linkedLibrary("dl")]
+        ),
+        .executableTarget(
+            name: "SimpleXNative",
+            dependencies: ["CoreBridge"]
+        ),
+        .testTarget(
+            name: "SimpleXNativeTests",
+            dependencies: ["SimpleXNative", "CoreBridge"]
+        ),
+    ],
+    swiftLanguageModes: [.v5]
+)

--- a/apps/macos-native/README.md
+++ b/apps/macos-native/README.md
@@ -1,0 +1,15 @@
+# SimpleX Native for macOS
+
+This is the native SwiftUI/AppKit macOS frontend. It links to the existing desktop SimpleX core and opens the existing desktop database at `~/.local/share/simplex`.
+
+It does not use Compose, change the core protocol, or introduce a second message format.
+
+Build the app after the desktop core libraries have been staged:
+
+```sh
+./build-app.sh
+```
+
+The resulting application is `/private/tmp/simplex-native-build/SimpleX.app`. Set
+`SIMPLEX_NATIVE_OUTPUT_DIR` to stage it elsewhere. Only one SimpleX frontend may
+open the desktop database at a time.

--- a/apps/macos-native/Sources/CoreBridge/CoreBridge.c
+++ b/apps/macos-native/Sources/CoreBridge/CoreBridge.c
@@ -9,6 +9,8 @@ typedef void (*hs_init_with_rtsopts_fn)(int *, char ***);
 typedef char *(*chat_migrate_init_fn)(const char *, const char *, const char *, void **);
 typedef char *(*chat_send_cmd_retry_fn)(void *, const char *, int);
 typedef char *(*chat_recv_msg_wait_fn)(void *, int);
+typedef char *(*chat_encrypt_file_fn)(void *, const char *, const char *);
+typedef char *(*chat_decrypt_file_fn)(const char *, const char *, const char *, const char *);
 typedef char *(*chat_close_store_fn)(void *);
 
 static void *simplex_handle = NULL;
@@ -16,6 +18,8 @@ static hs_init_with_rtsopts_fn hs_initialize = NULL;
 static chat_migrate_init_fn migrate_init = NULL;
 static chat_send_cmd_retry_fn send_cmd_retry = NULL;
 static chat_recv_msg_wait_fn recv_msg_wait = NULL;
+static chat_encrypt_file_fn encrypt_file = NULL;
+static chat_decrypt_file_fn decrypt_file = NULL;
 static chat_close_store_fn close_store = NULL;
 static bool runtime_initialized = false;
 
@@ -43,9 +47,11 @@ bool sx_core_load(const char *library_directory, char *error_buffer, size_t erro
     migrate_init = (chat_migrate_init_fn)dlsym(simplex_handle, "chat_migrate_init");
     send_cmd_retry = (chat_send_cmd_retry_fn)dlsym(simplex_handle, "chat_send_cmd_retry");
     recv_msg_wait = (chat_recv_msg_wait_fn)dlsym(simplex_handle, "chat_recv_msg_wait");
+    encrypt_file = (chat_encrypt_file_fn)dlsym(simplex_handle, "chat_encrypt_file");
+    decrypt_file = (chat_decrypt_file_fn)dlsym(simplex_handle, "chat_decrypt_file");
     close_store = (chat_close_store_fn)dlsym(simplex_handle, "chat_close_store");
 
-    if (hs_initialize == NULL || migrate_init == NULL || send_cmd_retry == NULL || recv_msg_wait == NULL || close_store == NULL) {
+    if (hs_initialize == NULL || migrate_init == NULL || send_cmd_retry == NULL || recv_msg_wait == NULL || encrypt_file == NULL || decrypt_file == NULL || close_store == NULL) {
         set_error(error_buffer, error_buffer_size, "The SimpleX core is missing a required exported function");
         dlclose(simplex_handle);
         simplex_handle = NULL;
@@ -79,6 +85,14 @@ const char *sx_core_send_cmd(void *controller, const char *command, int retry_co
 
 const char *sx_core_recv_msg_wait(void *controller, int timeout_microseconds) {
     return recv_msg_wait == NULL ? NULL : recv_msg_wait(controller, timeout_microseconds);
+}
+
+const char *sx_core_encrypt_file(void *controller, const char *from_path, const char *to_path) {
+    return encrypt_file == NULL ? NULL : encrypt_file(controller, from_path, to_path);
+}
+
+const char *sx_core_decrypt_file(const char *from_path, const char *key, const char *nonce, const char *to_path) {
+    return decrypt_file == NULL ? NULL : decrypt_file(from_path, key, nonce, to_path);
 }
 
 const char *sx_core_close_store(void *controller) {

--- a/apps/macos-native/Sources/CoreBridge/CoreBridge.c
+++ b/apps/macos-native/Sources/CoreBridge/CoreBridge.c
@@ -1,0 +1,90 @@
+#include "CoreBridge.h"
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef void (*hs_init_with_rtsopts_fn)(int *, char ***);
+typedef char *(*chat_migrate_init_fn)(const char *, const char *, const char *, void **);
+typedef char *(*chat_send_cmd_retry_fn)(void *, const char *, int);
+typedef char *(*chat_recv_msg_wait_fn)(void *, int);
+typedef char *(*chat_close_store_fn)(void *);
+
+static void *simplex_handle = NULL;
+static hs_init_with_rtsopts_fn hs_initialize = NULL;
+static chat_migrate_init_fn migrate_init = NULL;
+static chat_send_cmd_retry_fn send_cmd_retry = NULL;
+static chat_recv_msg_wait_fn recv_msg_wait = NULL;
+static chat_close_store_fn close_store = NULL;
+static bool runtime_initialized = false;
+
+static void set_error(char *buffer, size_t size, const char *message) {
+    if (buffer == NULL || size == 0) return;
+    snprintf(buffer, size, "%s", message == NULL ? "Unknown SimpleX core error" : message);
+}
+
+bool sx_core_load(const char *library_directory, char *error_buffer, size_t error_buffer_size) {
+    if (simplex_handle != NULL) return true;
+    if (library_directory == NULL || library_directory[0] == '\0') {
+        set_error(error_buffer, error_buffer_size, "SimpleX core library directory is missing");
+        return false;
+    }
+
+    char library_path[4096];
+    snprintf(library_path, sizeof(library_path), "%s/libsimplex.dylib", library_directory);
+    simplex_handle = dlopen(library_path, RTLD_NOW | RTLD_GLOBAL);
+    if (simplex_handle == NULL) {
+        set_error(error_buffer, error_buffer_size, dlerror());
+        return false;
+    }
+
+    hs_initialize = (hs_init_with_rtsopts_fn)dlsym(RTLD_DEFAULT, "hs_init_with_rtsopts");
+    migrate_init = (chat_migrate_init_fn)dlsym(simplex_handle, "chat_migrate_init");
+    send_cmd_retry = (chat_send_cmd_retry_fn)dlsym(simplex_handle, "chat_send_cmd_retry");
+    recv_msg_wait = (chat_recv_msg_wait_fn)dlsym(simplex_handle, "chat_recv_msg_wait");
+    close_store = (chat_close_store_fn)dlsym(simplex_handle, "chat_close_store");
+
+    if (hs_initialize == NULL || migrate_init == NULL || send_cmd_retry == NULL || recv_msg_wait == NULL || close_store == NULL) {
+        set_error(error_buffer, error_buffer_size, "The SimpleX core is missing a required exported function");
+        dlclose(simplex_handle);
+        simplex_handle = NULL;
+        return false;
+    }
+    return true;
+}
+
+bool sx_core_initialize(char *error_buffer, size_t error_buffer_size) {
+    if (runtime_initialized) return true;
+    if (hs_initialize == NULL) {
+        set_error(error_buffer, error_buffer_size, "The SimpleX core must be loaded before initialization");
+        return false;
+    }
+
+    int argc = 5;
+    char *argv[] = {"simplex", "+RTS", "-A64m", "-H64m", "-xn", NULL};
+    char **arguments = argv;
+    hs_initialize(&argc, &arguments);
+    runtime_initialized = true;
+    return true;
+}
+
+const char *sx_core_migrate_init(const char *path, const char *key, const char *confirmation, void **controller) {
+    return migrate_init == NULL ? NULL : migrate_init(path, key, confirmation, controller);
+}
+
+const char *sx_core_send_cmd(void *controller, const char *command, int retry_count) {
+    return send_cmd_retry == NULL ? NULL : send_cmd_retry(controller, command, retry_count);
+}
+
+const char *sx_core_recv_msg_wait(void *controller, int timeout_microseconds) {
+    return recv_msg_wait == NULL ? NULL : recv_msg_wait(controller, timeout_microseconds);
+}
+
+const char *sx_core_close_store(void *controller) {
+    return close_store == NULL ? NULL : close_store(controller);
+}
+
+void sx_core_free(const char *value) {
+    free((void *)value);
+}

--- a/apps/macos-native/Sources/CoreBridge/CoreBridge.c
+++ b/apps/macos-native/Sources/CoreBridge/CoreBridge.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/file.h>
 
 typedef void (*hs_init_with_rtsopts_fn)(int *, char ***);
 typedef char *(*chat_migrate_init_fn)(const char *, const char *, const char *, void **);
@@ -101,4 +102,12 @@ const char *sx_core_close_store(void *controller) {
 
 void sx_core_free(const char *value) {
     free((void *)value);
+}
+
+bool sx_try_lock_file(int file_descriptor) {
+    return flock(file_descriptor, LOCK_EX | LOCK_NB) == 0;
+}
+
+void sx_unlock_file(int file_descriptor) {
+    flock(file_descriptor, LOCK_UN);
 }

--- a/apps/macos-native/Sources/CoreBridge/include/CoreBridge.h
+++ b/apps/macos-native/Sources/CoreBridge/include/CoreBridge.h
@@ -13,5 +13,7 @@ const char *sx_core_encrypt_file(void *controller, const char *from_path, const 
 const char *sx_core_decrypt_file(const char *from_path, const char *key, const char *nonce, const char *to_path);
 const char *sx_core_close_store(void *controller);
 void sx_core_free(const char *value);
+bool sx_try_lock_file(int file_descriptor);
+void sx_unlock_file(int file_descriptor);
 
 #endif

--- a/apps/macos-native/Sources/CoreBridge/include/CoreBridge.h
+++ b/apps/macos-native/Sources/CoreBridge/include/CoreBridge.h
@@ -1,0 +1,15 @@
+#ifndef SIMPLEX_CORE_BRIDGE_H
+#define SIMPLEX_CORE_BRIDGE_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+bool sx_core_load(const char *library_directory, char *error_buffer, size_t error_buffer_size);
+bool sx_core_initialize(char *error_buffer, size_t error_buffer_size);
+const char *sx_core_migrate_init(const char *path, const char *key, const char *confirmation, void **controller);
+const char *sx_core_send_cmd(void *controller, const char *command, int retry_count);
+const char *sx_core_recv_msg_wait(void *controller, int timeout_microseconds);
+const char *sx_core_close_store(void *controller);
+void sx_core_free(const char *value);
+
+#endif

--- a/apps/macos-native/Sources/CoreBridge/include/CoreBridge.h
+++ b/apps/macos-native/Sources/CoreBridge/include/CoreBridge.h
@@ -9,6 +9,8 @@ bool sx_core_initialize(char *error_buffer, size_t error_buffer_size);
 const char *sx_core_migrate_init(const char *path, const char *key, const char *confirmation, void **controller);
 const char *sx_core_send_cmd(void *controller, const char *command, int retry_count);
 const char *sx_core_recv_msg_wait(void *controller, int timeout_microseconds);
+const char *sx_core_encrypt_file(void *controller, const char *from_path, const char *to_path);
+const char *sx_core_decrypt_file(const char *from_path, const char *key, const char *nonce, const char *to_path);
 const char *sx_core_close_store(void *controller);
 void sx_core_free(const char *value);
 

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -4,6 +4,8 @@ import Foundation
 typealias DeleteMessagesOperation = @Sendable ([Int64], NativeChat) async throws -> [NativeMessage]
 typealias SendTextOperation = @Sendable (String, Int64?, NativeChat) async throws -> Void
 typealias SendAttachmentOperation = @Sendable (PendingAttachment, String, Int64?, NativeChat) async throws -> Void
+typealias LoadMessageOperation = @Sendable (NativeChat.ID, Int64) async throws -> NativeMessage?
+typealias OpenAttachmentOperation = @Sendable (NativeCryptoFile, String?) async throws -> Void
 
 @MainActor
 final class AppModel: ObservableObject {
@@ -43,6 +45,7 @@ final class AppModel: ObservableObject {
     @Published var pendingAttachments: [PendingAttachment] = []
     @Published var attachmentError: String?
     @Published var attachmentOpenError: String?
+    @Published var quoteNavigationError: String?
     @Published var openingAttachmentIDs: Set<Int64> = []
     @Published var replyingTo: NativeMessage?
     @Published var composerFocusRequest = 0
@@ -61,18 +64,22 @@ final class AppModel: ObservableObject {
     private let deleteMessagesOperation: DeleteMessagesOperation?
     private let sendTextOperation: SendTextOperation?
     private let sendAttachmentOperation: SendAttachmentOperation?
+    private let loadMessageOperation: LoadMessageOperation?
+    private let openAttachmentOperation: OpenAttachmentOperation?
     private weak var notificationManager: NativeNotificationManager?
     private var eventTask: Task<Void, Never>?
     private var conversationLoadTask: Task<Void, Never>?
     private var refreshTask: Task<Void, Never>?
     private(set) var sendTask: Task<Void, Never>?
     private var deleteTask: Task<Void, Never>?
+    private(set) var quoteNavigationTask: Task<Void, Never>?
     private var notificationRouteQueue = NotificationRouteQueue()
     private var pendingChatOperationErrors: [NativeChat.ID: String] = [:]
     private var composerStates: [NativeChat.ID: ConversationComposerState] = [:]
     private var selectionAnchor: Int64?
     private var replyingChatID: NativeChat.ID?
     private var conversationLoadRevision: UInt64 = 0
+    private var quoteNavigationRevision: UInt64 = 0
     private static let densityKey = "desktopChatDensity"
 
     init(
@@ -81,7 +88,9 @@ final class AppModel: ObservableObject {
         previewMode: Bool? = nil,
         deleteMessagesOperation: DeleteMessagesOperation? = nil,
         sendTextOperation: SendTextOperation? = nil,
-        sendAttachmentOperation: SendAttachmentOperation? = nil
+        sendAttachmentOperation: SendAttachmentOperation? = nil,
+        loadMessageOperation: LoadMessageOperation? = nil,
+        openAttachmentOperation: OpenAttachmentOperation? = nil
     ) {
         self.previewMode = previewMode
             ?? (ProcessInfo.processInfo.environment["SIMPLEX_NATIVE_UI_PREVIEW"] == "1")
@@ -89,6 +98,8 @@ final class AppModel: ObservableObject {
         self.deleteMessagesOperation = deleteMessagesOperation
         self.sendTextOperation = sendTextOperation
         self.sendAttachmentOperation = sendAttachmentOperation
+        self.loadMessageOperation = loadMessageOperation
+        self.openAttachmentOperation = openAttachmentOperation
         keychainPassphraseStorageAvailable = Bundle.main.object(
             forInfoDictionaryKey: "SimpleXKeychainPassphraseStorageEnabled"
         ) as? Bool == true
@@ -114,6 +125,7 @@ final class AppModel: ObservableObject {
         refreshTask?.cancel()
         sendTask?.cancel()
         deleteTask?.cancel()
+        quoteNavigationTask?.cancel()
     }
 
     var selectedChat: NativeChat? {
@@ -404,29 +416,96 @@ final class AppModel: ObservableObject {
         replyingChatID = nil
     }
 
-    func openQuotedMessage(_ messageID: Int64) {
-        if messages.contains(where: { $0.id == messageID }) {
-            targetMessageID = messageID
-            return
+    @discardableResult
+    func openQuotedMessage(_ quote: NativeQuote, from containingMessageID: Int64) -> Task<Void, Never>? {
+        guard let chatID = selectedChatID else { return nil }
+        if let messageID = quote.messageID {
+            navigateToMessage(messageID, in: chatID)
+            return nil
         }
-        conversationLoadTask?.cancel()
-        guard let chatID = selectedChatID else { return }
-        scheduleConversationLoad(chatID: chatID, around: messageID, scrollTo: messageID)
+
+        quoteNavigationTask?.cancel()
+        quoteNavigationRevision &+= 1
+        let revision = quoteNavigationRevision
+        let operation = loadMessageOperation
+        let task = Task {
+            defer {
+                if quoteNavigationRevision == revision {
+                    quoteNavigationTask = nil
+                }
+            }
+            do {
+                let refreshedMessage: NativeMessage?
+                if let operation {
+                    refreshedMessage = try await operation(chatID, containingMessageID)
+                } else {
+                    refreshedMessage = try await core.loadMessage(
+                        chatID: chatID,
+                        itemID: containingMessageID
+                    )
+                }
+                guard !Task.isCancelled, selectedChatID == chatID,
+                      quoteNavigationRevision == revision else { return }
+                guard let refreshedMessage,
+                      let quotedMessageID = refreshedMessage.quotedItem?.messageID else {
+                    quoteNavigationError = "The original quoted message is no longer available in this conversation."
+                    return
+                }
+                if let index = messages.firstIndex(where: { $0.id == containingMessageID }) {
+                    messages[index] = refreshedMessage
+                }
+                navigateToMessage(quotedMessageID, in: chatID)
+            } catch is CancellationError {
+                return
+            } catch {
+                guard selectedChatID == chatID, quoteNavigationRevision == revision else { return }
+                quoteNavigationError = error.localizedDescription
+            }
+        }
+        quoteNavigationTask = task
+        return task
     }
 
-    func openAttachment(_ message: NativeMessage) {
-        guard let source = message.fileSource,
-              !openingAttachmentIDs.contains(message.id) else { return }
+    @discardableResult
+    func openAttachment(_ message: NativeMessage) -> Task<Void, Never>? {
+        guard let initialSource = message.fileSource,
+              !openingAttachmentIDs.contains(message.id) else { return nil }
+        let chatID = selectedChatID
+        let loadMessageOperation = loadMessageOperation
+        let openAttachmentOperation = openAttachmentOperation
         openingAttachmentIDs.insert(message.id)
-        Task {
+        let task = Task {
             defer { openingAttachmentIDs.remove(message.id) }
             do {
-                let url = try await core.openableURL(
-                    for: source,
-                    fileName: message.content.attachmentDescription
-                )
-                guard NSWorkspace.shared.open(url) else {
-                    throw NativeChatError.unavailable("macOS could not open this attachment.")
+                var source = initialSource
+                if source.cryptoArgs == nil, let chatID {
+                    let refreshedMessage: NativeMessage?
+                    if let loadMessageOperation {
+                        refreshedMessage = try await loadMessageOperation(chatID, message.id)
+                    } else {
+                        refreshedMessage = try await core.loadMessage(chatID: chatID, itemID: message.id)
+                    }
+                    try Task.checkCancellation()
+                    if let refreshedMessage, let refreshedSource = refreshedMessage.fileSource {
+                        source = refreshedSource
+                        if selectedChatID == chatID,
+                           let index = messages.firstIndex(where: { $0.id == message.id }) {
+                            messages[index] = refreshedMessage
+                        }
+                    }
+                }
+
+                if let openAttachmentOperation {
+                    try await openAttachmentOperation(source, message.content.attachmentDescription)
+                } else {
+                    let url = try await core.openableURL(
+                        for: source,
+                        fileName: message.content.attachmentDescription
+                    )
+                    try Task.checkCancellation()
+                    guard NSWorkspace.shared.open(url) else {
+                        throw NativeChatError.unavailable("macOS could not open this attachment.")
+                    }
                 }
             } catch is CancellationError {
                 return
@@ -434,6 +513,17 @@ final class AppModel: ObservableObject {
                 attachmentOpenError = error.localizedDescription
             }
         }
+        return task
+    }
+
+    private func navigateToMessage(_ messageID: Int64, in chatID: NativeChat.ID) {
+        guard selectedChatID == chatID else { return }
+        if messages.contains(where: { $0.id == messageID }) {
+            targetMessageID = messageID
+            return
+        }
+        conversationLoadTask?.cancel()
+        scheduleConversationLoad(chatID: chatID, around: messageID, scrollTo: messageID)
     }
 
     func selectMessage(_ id: Int64, modifiers: NSEvent.ModifierFlags) {
@@ -608,6 +698,10 @@ final class AppModel: ObservableObject {
         guard changedChat || messageID != nil || scrollTarget != nil else { return }
 
         if changedChat {
+            quoteNavigationTask?.cancel()
+            quoteNavigationTask = nil
+            quoteNavigationRevision &+= 1
+            quoteNavigationError = nil
             if let previousChatID = selectedChatID {
                 saveComposerState(for: previousChatID)
             }

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -339,7 +339,8 @@ final class AppModel: ObservableObject {
                             messageID: $0.id,
                             text: $0.replyPreview,
                             sent: $0.sent,
-                            author: $0.author
+                            author: $0.author,
+                            visual: $0.content.replyContextVisual
                         )
                     }
                 ))

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -45,15 +45,21 @@ final class AppModel: ObservableObject {
     private weak var notificationManager: NativeNotificationManager?
     private var eventTask: Task<Void, Never>?
     private var conversationLoadTask: Task<Void, Never>?
+    private var refreshTask: Task<Void, Never>?
+    private var sendTask: Task<Void, Never>?
     private var notificationRouteQueue = NotificationRouteQueue()
     private var selectionAnchor: Int64?
+    private var replyingChatID: NativeChat.ID?
+    private var conversationLoadRevision: UInt64 = 0
     private static let densityKey = "desktopChatDensity"
 
     init(
         notificationManager: NativeNotificationManager? = nil,
-        passphraseStore: any DatabasePassphraseStore = DatabasePassphraseKeychain()
+        passphraseStore: any DatabasePassphraseStore = DatabasePassphraseKeychain(),
+        previewMode: Bool? = nil
     ) {
-        previewMode = ProcessInfo.processInfo.environment["SIMPLEX_NATIVE_UI_PREVIEW"] == "1"
+        self.previewMode = previewMode
+            ?? (ProcessInfo.processInfo.environment["SIMPLEX_NATIVE_UI_PREVIEW"] == "1")
         self.passphraseStore = passphraseStore
         keychainPassphraseStorageAvailable = Bundle.main.object(
             forInfoDictionaryKey: "SimpleXKeychainPassphraseStorageEnabled"
@@ -63,7 +69,7 @@ final class AppModel: ObservableObject {
         ) ?? .compact
         self.notificationManager = notificationManager
         notificationManager?.model = self
-        if previewMode {
+        if self.previewMode {
             phase = .ready
             profile = NativePreviewData.profile
             chats = NativePreviewData.chats
@@ -77,6 +83,8 @@ final class AppModel: ObservableObject {
     deinit {
         eventTask?.cancel()
         conversationLoadTask?.cancel()
+        refreshTask?.cancel()
+        sendTask?.cancel()
     }
 
     var selectedChat: NativeChat? {
@@ -144,30 +152,24 @@ final class AppModel: ObservableObject {
     }
 
     func selectChat(_ id: NativeChat.ID?) {
-        guard selectedChatID != id else { return }
-        selectedChatID = id
-        clearMessageSelection()
-        pendingAttachments = []
-        replyingTo = nil
-        targetMessageID = nil
-        conversationSearchText = ""
-        conversationSearchPresented = false
-        if let id { notificationManager?.removeDeliveredNotifications(chatID: id) }
-        if previewMode {
-            messages = id.map(NativePreviewData.messages) ?? []
-            return
-        }
-        conversationLoadTask?.cancel()
-        conversationLoadTask = Task { await loadSelectedConversation() }
+        transitionToChat(id)
     }
 
     func refresh() {
         guard !previewMode else { return }
         guard let userID = profile?.userID else { return }
-        Task {
+        refreshTask?.cancel()
+        refreshTask = Task {
             do {
-                chats = try await core.loadChats(userID: userID)
-                await loadSelectedConversation()
+                let loadedChats = try await core.loadChats(userID: userID)
+                guard !Task.isCancelled else { return }
+                chats = loadedChats
+                if let chatID = selectedChatID {
+                    conversationLoadTask?.cancel()
+                    _ = await loadConversation(chatID: chatID)
+                }
+            } catch is CancellationError {
+                return
             } catch {
                 phase = .failed(error.localizedDescription)
             }
@@ -177,8 +179,9 @@ final class AppModel: ObservableObject {
     func sendDraft() {
         let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         let attachments = pendingAttachments
-        let quotedMessage = replyingTo
         guard (!text.isEmpty || !attachments.isEmpty), let chat = selectedChat, !isSending else { return }
+        let quotedMessage = replyingChatID == chat.id ? replyingTo : nil
+        if replyingTo != nil, quotedMessage == nil { cancelReply() }
         if previewMode {
             if !text.isEmpty {
                 let nextID = (messages.map(\.id).max() ?? 0) + 1
@@ -202,20 +205,26 @@ final class AppModel: ObservableObject {
             }
             draft = ""
             pendingAttachments = []
-            replyingTo = nil
+            cancelReply()
             return
         }
         draft = ""
         isSending = true
-        Task {
+        sendTask = Task {
+            defer {
+                isSending = false
+                sendTask = nil
+            }
             var contentWasSent = false
             do {
                 if attachments.isEmpty {
                     try await core.sendText(text, quotedItemID: quotedMessage?.id, to: chat)
+                    try Task.checkCancellation()
                     contentWasSent = true
-                    if selectedChatID == chat.id, replyingTo?.id == quotedMessage?.id { replyingTo = nil }
+                    if selectedChatID == chat.id, replyingTo?.id == quotedMessage?.id { cancelReply() }
                 } else {
                     for (index, attachment) in attachments.enumerated() {
+                        try Task.checkCancellation()
                         let caption = index == attachments.index(before: attachments.endIndex) ? text : ""
                         let quotedItemID = index == attachments.startIndex ? quotedMessage?.id : nil
                         try await core.sendAttachment(
@@ -224,23 +233,30 @@ final class AppModel: ObservableObject {
                             quotedItemID: quotedItemID,
                             to: chat
                         )
+                        try Task.checkCancellation()
                         if index == attachments.index(before: attachments.endIndex) { contentWasSent = true }
                         if selectedChatID == chat.id {
                             pendingAttachments.removeAll { $0.id == attachment.id }
-                            if quotedItemID != nil, replyingTo?.id == quotedItemID { replyingTo = nil }
+                            if quotedItemID != nil, replyingTo?.id == quotedItemID { cancelReply() }
                         }
                     }
                 }
                 let sentMessages = try await core.loadMessages(chatID: chat.id)
+                try Task.checkCancellation()
                 if selectedChatID == chat.id { messages = sentMessages }
-                if let userID = profile?.userID { chats = try await core.loadChats(userID: userID) }
+                if let userID = profile?.userID {
+                    let loadedChats = try await core.loadChats(userID: userID)
+                    try Task.checkCancellation()
+                    chats = loadedChats
+                }
+            } catch is CancellationError {
+                return
             } catch {
                 if selectedChatID == chat.id {
                     if !contentWasSent { draft = text }
                     phase = .failed(error.localizedDescription)
                 }
             }
-            isSending = false
         }
     }
 
@@ -297,8 +313,10 @@ final class AppModel: ObservableObject {
     }
 
     func beginReply(to message: NativeMessage) {
-        guard selectedChat?.kind.canReply == true, !isSending else { return }
+        guard let chat = selectedChat, chat.kind.canReply, messages.contains(where: { $0.id == message.id }),
+              !isSending else { return }
         replyingTo = message
+        replyingChatID = chat.id
         clearMessageSelection()
         composerFocusRequest &+= 1
     }
@@ -311,6 +329,7 @@ final class AppModel: ObservableObject {
 
     func cancelReply() {
         replyingTo = nil
+        replyingChatID = nil
     }
 
     func openQuotedMessage(_ messageID: Int64) {
@@ -319,11 +338,8 @@ final class AppModel: ObservableObject {
             return
         }
         conversationLoadTask?.cancel()
-        conversationLoadTask = Task {
-            await loadSelectedConversation(around: messageID)
-            guard !Task.isCancelled, messages.contains(where: { $0.id == messageID }) else { return }
-            targetMessageID = messageID
-        }
+        guard let chatID = selectedChatID else { return }
+        scheduleConversationLoad(chatID: chatID, around: messageID, scrollTo: messageID)
     }
 
     func openAttachment(_ message: NativeMessage) {
@@ -422,7 +438,7 @@ final class AppModel: ObservableObject {
     func deleteSelectedMessages() {
         guard let chat = selectedChat, canDeleteSelectedMessages else { return }
         let identifiers = selectedMessagesInTranscriptOrder.map(\.id)
-        if let replyingTo, identifiers.contains(replyingTo.id) { self.replyingTo = nil }
+        if let replyingTo, identifiers.contains(replyingTo.id) { cancelReply() }
         showingDeleteConfirmation = false
         if previewMode {
             messages.removeAll { identifiers.contains($0.id) }
@@ -468,32 +484,82 @@ final class AppModel: ObservableObject {
             notificationRouteQueue.enqueue(route)
             return
         }
-        selectedChatID = route.chatID
-        clearMessageSelection()
-        targetMessageID = route.messageID
-        notificationManager?.removeDeliveredNotifications(chatID: route.chatID)
-        Task { await loadSelectedConversation(around: route.messageID) }
+        transitionToChat(route.chatID, around: route.messageID, scrollTo: route.messageID)
     }
 
-    private func loadSelectedConversation(around messageID: Int64? = nil) async {
-        guard let chat = selectedChat else {
+    private func transitionToChat(
+        _ id: NativeChat.ID?,
+        around messageID: Int64? = nil,
+        scrollTo scrollTarget: Int64? = nil
+    ) {
+        let changedChat = selectedChatID != id
+        guard changedChat || messageID != nil || scrollTarget != nil else { return }
+
+        if changedChat {
+            selectedChatID = id
+            clearMessageSelection()
+            pendingAttachments = []
+            cancelReply()
+            targetMessageID = nil
+            conversationSearchText = ""
+            conversationSearchPresented = false
+        }
+        if let id { notificationManager?.removeDeliveredNotifications(chatID: id) }
+
+        conversationLoadTask?.cancel()
+        guard let id else {
             messages = []
+            isLoadingConversation = false
             return
         }
-        let chatID = chat.id
+        if previewMode {
+            messages = NativePreviewData.messages(for: id)
+            if let scrollTarget, messages.contains(where: { $0.id == scrollTarget }) {
+                targetMessageID = scrollTarget
+            }
+            return
+        }
+        scheduleConversationLoad(chatID: id, around: messageID, scrollTo: scrollTarget)
+    }
+
+    private func scheduleConversationLoad(
+        chatID: NativeChat.ID,
+        around messageID: Int64? = nil,
+        scrollTo scrollTarget: Int64? = nil
+    ) {
+        conversationLoadTask?.cancel()
+        conversationLoadTask = Task {
+            let loaded = await loadConversation(chatID: chatID, around: messageID)
+            guard loaded, !Task.isCancelled, selectedChatID == chatID else { return }
+            if let scrollTarget, messages.contains(where: { $0.id == scrollTarget }) {
+                targetMessageID = scrollTarget
+            }
+        }
+    }
+
+    @discardableResult
+    private func loadConversation(chatID: NativeChat.ID, around messageID: Int64? = nil) async -> Bool {
+        guard selectedChatID == chatID else { return false }
+        conversationLoadRevision &+= 1
+        let revision = conversationLoadRevision
         isLoadingConversation = true
         defer {
-            if selectedChatID == chatID { isLoadingConversation = false }
+            if selectedChatID == chatID, conversationLoadRevision == revision {
+                isLoadingConversation = false
+            }
         }
         do {
             let loadedMessages = try await core.loadMessages(chatID: chatID, around: messageID)
-            guard !Task.isCancelled, selectedChatID == chatID else { return }
+            guard !Task.isCancelled, selectedChatID == chatID,
+                  conversationLoadRevision == revision else { return false }
             messages = loadedMessages
             selectedMessageIDs.formIntersection(messages.map(\.id))
+            return true
         } catch is CancellationError {
-            return
+            return false
         } catch {
             phase = .failed(error.localizedDescription)
+            return false
         }
     }
 
@@ -513,8 +579,8 @@ final class AppModel: ObservableObject {
         guard let userID = profile?.userID else { return }
         do {
             chats = try await core.loadChats(userID: userID)
-            if selectedChatID != nil {
-                await loadSelectedConversation()
+            if let chatID = selectedChatID {
+                _ = await loadConversation(chatID: chatID)
             }
             consumePendingNotificationRoutes()
         } catch {
@@ -568,7 +634,9 @@ final class AppModel: ObservableObject {
             self.chats = chats
             phase = .ready
             if selectedChatID == nil { selectedChatID = chats.first?.id }
-            await loadSelectedConversation()
+            if let chatID = selectedChatID {
+                _ = await loadConversation(chatID: chatID)
+            }
             startEventLoop()
             notificationManager?.chatSetupReady()
             consumePendingNotificationRoutes()

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -474,7 +474,11 @@ final class AppModel: ObservableObject {
               currentMessage.replyable else { return }
         replyingTo = currentMessage
         replyingChatID = chat.id
-        clearMessageSelection()
+        if conversationSearchPresented {
+            dismissConversationSearch()
+        } else {
+            clearMessageSelection()
+        }
         composerFocusRequest &+= 1
     }
 

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -36,6 +36,7 @@ final class AppModel: ObservableObject {
     @Published var conversationSearchPresented = false
     @Published var isLoadingConversation = false
     @Published var isSending = false
+    @Published private(set) var sendingChatID: NativeChat.ID?
     @Published private(set) var isDeletingMessages = false
     @Published var selectedMessageIDs: Set<Int64> = []
     @Published var transcriptFocused = false
@@ -130,6 +131,10 @@ final class AppModel: ObservableObject {
     var canSendDraft: Bool {
         let hasText = !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         return (hasText || !pendingAttachments.isEmpty) && !isSending && selectedChat?.kind.canSend == true
+    }
+
+    var isSendingSelectedChat: Bool {
+        isSending && sendingChatID == selectedChatID
     }
 
     var selectedMessagesInTranscriptOrder: [NativeMessage] {
@@ -239,6 +244,7 @@ final class AppModel: ObservableObject {
             return
         }
         draft = ""
+        sendingChatID = chat.id
         isSending = true
         let core = core
         let sendTextOperation = sendTextOperation
@@ -311,7 +317,7 @@ final class AppModel: ObservableObject {
     }
 
     func chooseAttachments() {
-        guard !isSending else { return }
+        guard !isSendingSelectedChat else { return }
         let panel = NSOpenPanel()
         panel.allowsMultipleSelection = true
         panel.canChooseDirectories = false
@@ -324,7 +330,7 @@ final class AppModel: ObservableObject {
     }
 
     func stageAttachments(_ urls: [URL]) {
-        guard !isSending else {
+        guard !isSendingSelectedChat else {
             attachmentError = "Wait for the current message to finish sending before changing attachments."
             return
         }
@@ -343,7 +349,7 @@ final class AppModel: ObservableObject {
     }
 
     func stageFilesFromPasteboard() {
-        guard !isSending else {
+        guard !isSendingSelectedChat else {
             attachmentError = "Wait for the current message to finish sending before changing attachments."
             return
         }
@@ -356,17 +362,17 @@ final class AppModel: ObservableObject {
     }
 
     func removeAttachment(_ id: PendingAttachment.ID) {
-        guard !isSending else { return }
+        guard !isSendingSelectedChat else { return }
         pendingAttachments.removeAll { $0.id == id }
     }
 
     func reorderAttachment(_ source: PendingAttachment.ID, before destination: PendingAttachment.ID) {
-        guard !isSending else { return }
+        guard !isSendingSelectedChat else { return }
         pendingAttachments = PendingAttachment.reordered(pendingAttachments, from: source, before: destination)
     }
 
     func moveAttachment(_ id: PendingAttachment.ID, by offset: Int) {
-        guard !isSending else { return }
+        guard !isSendingSelectedChat else { return }
         guard let sourceIndex = pendingAttachments.firstIndex(where: { $0.id == id }) else { return }
         let destinationIndex = min(max(0, sourceIndex + offset), pendingAttachments.count - 1)
         guard sourceIndex != destinationIndex else { return }
@@ -376,7 +382,7 @@ final class AppModel: ObservableObject {
 
     func beginReply(to message: NativeMessage) {
         guard let chat = selectedChat, chat.kind.canReply, messages.contains(where: { $0.id == message.id }),
-              !isSending else { return }
+              !isSendingSelectedChat else { return }
         replyingTo = message
         replyingChatID = chat.id
         clearMessageSelection()
@@ -390,6 +396,7 @@ final class AppModel: ObservableObject {
     }
 
     func cancelReply() {
+        guard !isSendingSelectedChat else { return }
         replyingTo = nil
         replyingChatID = nil
     }
@@ -566,9 +573,9 @@ final class AppModel: ObservableObject {
     func dismissNearestState() {
         if conversationSearchPresented {
             dismissConversationSearch()
-        } else if replyingTo != nil {
+        } else if replyingTo != nil, !isSendingSelectedChat {
             cancelReply()
-        } else if !pendingAttachments.isEmpty {
+        } else if !pendingAttachments.isEmpty, !isSendingSelectedChat {
             pendingAttachments = []
         } else if !selectedMessageIDs.isEmpty {
             clearMessageSelection()
@@ -699,6 +706,7 @@ final class AppModel: ObservableObject {
 
     private func finishSending() {
         isSending = false
+        sendingChatID = nil
         sendTask = nil
     }
 

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -7,7 +7,9 @@ typealias SendAttachmentOperation = @Sendable (PendingAttachment, String, Int64?
 typealias LoadMessageOperation = @Sendable (NativeChat.ID, Int64) async throws -> NativeMessage?
 typealias LoadMessagesOperation = @Sendable (NativeChat.ID, Int64?) async throws -> [NativeMessage]
 typealias LoadChatsOperation = @Sendable (Int64) async throws -> [NativeChat]
+typealias MarkChatReadOperation = @Sendable (NativeChat.ID) async throws -> Void
 typealias OpenAttachmentOperation = @Sendable (NativeCryptoFile, String?) async throws -> Void
+typealias WindowFocusedOperation = @MainActor @Sendable () -> Bool
 
 @MainActor
 final class AppModel: ObservableObject {
@@ -78,7 +80,9 @@ final class AppModel: ObservableObject {
     private let loadMessageOperation: LoadMessageOperation?
     private let loadMessagesOperation: LoadMessagesOperation?
     private let loadChatsOperation: LoadChatsOperation?
+    private let markChatReadOperation: MarkChatReadOperation?
     private let openAttachmentOperation: OpenAttachmentOperation?
+    private let windowFocusedOperation: WindowFocusedOperation?
     private weak var notificationManager: NativeNotificationManager?
     private var eventTask: Task<Void, Never>?
     private var conversationLoadTask: Task<Void, Never>?
@@ -95,6 +99,7 @@ final class AppModel: ObservableObject {
     private var pendingSendStatusMessages: [NativeChat.ID: String] = [:]
     private var pendingAttachmentOpenErrors: [NativeChat.ID: String] = [:]
     private var pendingReplyInvalidationChatIDs: Set<NativeChat.ID> = []
+    private var markingReadChatIDs: Set<NativeChat.ID> = []
     private var composerStates: [NativeChat.ID: ConversationComposerState] = [:]
     private var quickLookRequestKey: AttachmentOpeningKey?
     private var deletingChatID: NativeChat.ID?
@@ -116,7 +121,9 @@ final class AppModel: ObservableObject {
         loadMessageOperation: LoadMessageOperation? = nil,
         loadMessagesOperation: LoadMessagesOperation? = nil,
         loadChatsOperation: LoadChatsOperation? = nil,
-        openAttachmentOperation: OpenAttachmentOperation? = nil
+        markChatReadOperation: MarkChatReadOperation? = nil,
+        openAttachmentOperation: OpenAttachmentOperation? = nil,
+        windowFocusedOperation: WindowFocusedOperation? = nil
     ) {
         self.previewMode = previewMode
             ?? (ProcessInfo.processInfo.environment["SIMPLEX_NATIVE_UI_PREVIEW"] == "1")
@@ -127,7 +134,9 @@ final class AppModel: ObservableObject {
         self.loadMessageOperation = loadMessageOperation
         self.loadMessagesOperation = loadMessagesOperation
         self.loadChatsOperation = loadChatsOperation
+        self.markChatReadOperation = markChatReadOperation
         self.openAttachmentOperation = openAttachmentOperation
+        self.windowFocusedOperation = windowFocusedOperation
         keychainPassphraseStorageAvailable = Bundle.main.object(
             forInfoDictionaryKey: "SimpleXKeychainPassphraseStorageEnabled"
         ) as? Bool == true
@@ -270,7 +279,8 @@ final class AppModel: ObservableObject {
         }
     }
 
-    func selectChat(_ id: NativeChat.ID?) {
+    @discardableResult
+    func selectChat(_ id: NativeChat.ID?) -> Task<Void, Never>? {
         transitionToChat(id)
     }
 
@@ -1006,13 +1016,14 @@ final class AppModel: ObservableObject {
         return false
     }
 
+    @discardableResult
     private func transitionToChat(
         _ id: NativeChat.ID?,
         around messageID: Int64? = nil,
         scrollTo scrollTarget: Int64? = nil
-    ) {
+    ) -> Task<Void, Never>? {
         let changedChat = selectedChatID != id
-        guard changedChat || messageID != nil || scrollTarget != nil else { return }
+        guard changedChat || messageID != nil || scrollTarget != nil else { return nil }
 
         if changedChat {
             quickLookRequestKey = nil
@@ -1054,16 +1065,16 @@ final class AppModel: ObservableObject {
         guard let id else {
             messages = []
             isLoadingConversation = false
-            return
+            return nil
         }
         if previewMode {
             messages = NativePreviewData.messages(for: id)
             if let scrollTarget, messages.contains(where: { $0.id == scrollTarget }) {
                 targetMessageID = scrollTarget
             }
-            return
+            return nil
         }
-        scheduleConversationLoad(chatID: id, around: messageID, scrollTo: scrollTarget)
+        return scheduleConversationLoad(chatID: id, around: messageID, scrollTo: scrollTarget)
     }
 
     private func saveConversationNotices(for chatID: NativeChat.ID) {
@@ -1331,6 +1342,9 @@ final class AppModel: ObservableObject {
             }
             applyLoadedMessages(loadedMessages, to: chatID)
             conversationAnchorMessageID = messageID
+            if messageID == nil {
+                await markChatReadIfNeeded(chatID)
+            }
             return true
         } catch is CancellationError {
             return false
@@ -1363,6 +1377,40 @@ final class AppModel: ObservableObject {
         } else {
             invalidateReplyContext(in: chatID)
         }
+    }
+
+    private func markChatReadIfNeeded(_ chatID: NativeChat.ID) async {
+        guard let chat = chats.first(where: { $0.id == chatID }), chat.unreadCount > 0,
+              !markingReadChatIDs.contains(chatID), windowIsFocused else { return }
+        if previewMode, markChatReadOperation == nil { return }
+
+        markingReadChatIDs.insert(chatID)
+        defer { markingReadChatIDs.remove(chatID) }
+        do {
+            if let markChatReadOperation {
+                try await markChatReadOperation(chatID)
+            } else {
+                try await core.markChatRead(chatID: chatID)
+            }
+            guard let index = chats.firstIndex(where: { $0.id == chatID }) else { return }
+            chats[index] = chats[index].markingRead()
+            notificationManager?.removeDeliveredNotifications(chatID: chatID)
+        } catch is CancellationError {
+            return
+        } catch {
+            return
+        }
+    }
+
+    func markSelectedChatReadIfVisible() {
+        guard conversationAnchorMessageID == nil, !isLoadingConversation,
+              let chatID = selectedChatID else { return }
+        Task { await markChatReadIfNeeded(chatID) }
+    }
+
+    private var windowIsFocused: Bool {
+        if let windowFocusedOperation { return windowFocusedOperation() }
+        return NSApp.isActive && NSApp.keyWindow?.isKeyWindow == true
     }
 
     private func startEventLoop() {

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -653,8 +653,8 @@ final class AppModel: ObservableObject {
     @discardableResult
     private func navigateToMessage(_ messageID: Int64, in chatID: NativeChat.ID) -> Task<Void, Never>? {
         guard selectedChatID == chatID else { return nil }
-        conversationLoadTask?.cancel()
         if messages.contains(where: { $0.id == messageID }) {
+            cancelConversationLoadWithoutReplacement()
             prepareForQuoteNavigation()
             conversationAnchorMessageID = messageID
             targetMessageID = messageID
@@ -667,6 +667,13 @@ final class AppModel: ObservableObject {
             navigationFailureMessage: "The original quoted message is no longer available in this conversation.",
             consumeQuoteNavigationStateOnSuccess: true
         )
+    }
+
+    private func cancelConversationLoadWithoutReplacement() {
+        conversationLoadTask?.cancel()
+        conversationLoadTask = nil
+        conversationLoadRevision &+= 1
+        isLoadingConversation = false
     }
 
     func selectMessage(_ id: Int64, modifiers: NSEvent.ModifierFlags) {

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -2,8 +2,8 @@ import AppKit
 import Foundation
 
 typealias DeleteMessagesOperation = @Sendable ([Int64], NativeChat) async throws -> [NativeMessage]
-typealias SendTextOperation = @Sendable (String, Int64?, NativeChat) async throws -> Void
-typealias SendAttachmentOperation = @Sendable (PendingAttachment, String, Int64?, NativeChat) async throws -> Void
+typealias SendTextOperation = @Sendable (String, Int64?, NativeChat) async throws -> NativeSendReceipt
+typealias SendAttachmentOperation = @Sendable (PendingAttachment, String, Int64?, NativeChat) async throws -> NativeSendReceipt
 typealias LoadMessageOperation = @Sendable (NativeChat.ID, Int64) async throws -> NativeMessage?
 typealias LoadMessagesOperation = @Sendable (NativeChat.ID, Int64?) async throws -> [NativeMessage]
 typealias LoadChatsOperation = @Sendable (Int64) async throws -> [NativeChat]
@@ -343,12 +343,12 @@ final class AppModel: ObservableObject {
         let loadMessageOperation = loadMessageOperation
         sendTask = Task { [weak self] in
             var draftWasSent = false
-            var quoteWasSent = false
+            var quoteCommitResolved = false
             defer {
                 self?.finishSending(
                     in: chat.id,
                     quotedMessageID: quotedMessage?.id,
-                    quoteWasSent: quoteWasSent
+                    quoteCommitResolved: quoteCommitResolved
                 )
             }
             do {
@@ -370,15 +370,19 @@ final class AppModel: ObservableObject {
                 }
                 if attachments.isEmpty {
                     try Task.checkCancellation()
+                    let receipt: NativeSendReceipt
                     if let sendTextOperation {
-                        try await sendTextOperation(text, quotedMessage?.id, chat)
+                        receipt = try await sendTextOperation(text, quotedMessage?.id, chat)
                     } else {
-                        try await core.sendText(text, quotedItemID: quotedMessage?.id, to: chat)
+                        receipt = try await core.sendText(text, quotedItemID: quotedMessage?.id, to: chat)
                     }
                     draftWasSent = true
                     if let quotedItemID = quotedMessage?.id {
-                        quoteWasSent = true
+                        quoteCommitResolved = true
                         self?.clearReply(quotedItemID, in: chat.id)
+                        if !receipt.replyContextConfirmed {
+                            self?.reportUnconfirmedReplyContext(in: chat.id)
+                        }
                     }
                     try Task.checkCancellation()
                 } else {
@@ -389,15 +393,16 @@ final class AppModel: ObservableObject {
                     )
                     for (index, step) in sendSteps.enumerated() {
                         try Task.checkCancellation()
+                        let receipt: NativeSendReceipt
                         if let sendAttachmentOperation {
-                            try await sendAttachmentOperation(
+                            receipt = try await sendAttachmentOperation(
                                 step.attachment,
                                 step.caption,
                                 step.quotedItemID,
                                 chat
                             )
                         } else {
-                            try await core.sendAttachment(
+                            receipt = try await core.sendAttachment(
                                 step.attachment,
                                 caption: step.caption,
                                 quotedItemID: step.quotedItemID,
@@ -407,8 +412,11 @@ final class AppModel: ObservableObject {
                         if index == sendSteps.index(before: sendSteps.endIndex) { draftWasSent = true }
                         self?.removeSentAttachment(step.attachment.id, from: chat.id)
                         if let quotedItemID = step.quotedItemID {
-                            quoteWasSent = true
+                            quoteCommitResolved = true
                             self?.clearReply(quotedItemID, in: chat.id)
+                            if !receipt.replyContextConfirmed {
+                                self?.reportUnconfirmedReplyContext(in: chat.id)
+                            }
                         }
                         try Task.checkCancellation()
                     }
@@ -1051,6 +1059,16 @@ final class AppModel: ObservableObject {
         }
     }
 
+    private func reportUnconfirmedReplyContext(in chatID: NativeChat.ID) {
+        pendingReplyInvalidationChatIDs.remove(chatID)
+        let message = "Your message was sent, but SimpleX could not link it to the original message."
+        if selectedChatID == chatID {
+            replyContextError = message
+        } else {
+            pendingReplyContextErrors[chatID] = message
+        }
+    }
+
     private func restoreFailedDraft(_ text: String, in chatID: NativeChat.ID) {
         guard !text.isEmpty else { return }
         updateComposerState(for: chatID) { state in
@@ -1065,13 +1083,13 @@ final class AppModel: ObservableObject {
     private func finishSending(
         in chatID: NativeChat.ID,
         quotedMessageID: Int64?,
-        quoteWasSent: Bool
+        quoteCommitResolved: Bool
     ) {
         let replyWasInvalidated = pendingReplyInvalidationChatIDs.remove(chatID) != nil
         isSending = false
         sendingChatID = nil
         sendTask = nil
-        if replyWasInvalidated, !quoteWasSent, quotedMessageID != nil {
+        if replyWasInvalidated, !quoteCommitResolved, quotedMessageID != nil {
             invalidateReplyContext(in: chatID)
         }
         consumePendingNotificationRoutes()

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -39,6 +39,7 @@ final class AppModel: ObservableObject {
     @Published var conversationSearchText = ""
     @Published var conversationSearchPresented = false
     @Published var isLoadingConversation = false
+    @Published private(set) var isRefreshing = false
     @Published var isSending = false
     @Published private(set) var sendingChatID: NativeChat.ID?
     @Published private(set) var isDeletingMessages = false
@@ -159,6 +160,7 @@ final class AppModel: ObservableObject {
         return (hasText || !pendingAttachments.isEmpty)
             && !isSending
             && !isDeletingSelectedChat
+            && !isRefreshing
             && !isLoadingConversation
             && quoteNavigationTask == nil
             && selectedChat?.kind.canSend == true
@@ -173,7 +175,7 @@ final class AppModel: ObservableObject {
     }
 
     var canNavigateConversationHistory: Bool {
-        !isSendingSelectedChat && !isDeletingSelectedChat
+        !isSendingSelectedChat && !isDeletingSelectedChat && !isRefreshing
     }
 
     var canRefreshConversation: Bool {
@@ -193,6 +195,7 @@ final class AppModel: ObservableObject {
         let includesInFlightQuote = inFlightQuoteID.map(selectedMessageIDs.contains) ?? false
         return !isDeletingMessages
             && !isSendingSelectedChat
+            && !isRefreshing
             && !isLoadingConversation
             && quoteNavigationTask == nil
             && !selectedMessageIDs.isEmpty
@@ -262,7 +265,12 @@ final class AppModel: ObservableObject {
         guard canRefreshConversation else { return }
         guard let userID = profile?.userID else { return }
         refreshTask?.cancel()
+        isRefreshing = true
         refreshTask = Task {
+            defer {
+                isRefreshing = false
+                refreshTask = nil
+            }
             do {
                 let loadedChats = try await loadChats(userID: userID)
                 guard !Task.isCancelled else { return }

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -83,6 +83,7 @@ final class AppModel: ObservableObject {
     private var replyTargetNavigationTask: Task<Void, Never>?
     private var notificationRouteQueue = NotificationRouteQueue()
     private var pendingChatOperationErrors: [NativeChat.ID: String] = [:]
+    private var pendingQuoteNavigationErrors: [NativeChat.ID: String] = [:]
     private var pendingReplyContextErrors: [NativeChat.ID: String] = [:]
     private var pendingSendStatusMessages: [NativeChat.ID: String] = [:]
     private var pendingReplyInvalidationChatIDs: Set<NativeChat.ID> = []
@@ -979,12 +980,13 @@ final class AppModel: ObservableObject {
             quoteNavigationTask?.cancel()
             quoteNavigationTask = nil
             quoteNavigationRevision &+= 1
+            if let previousChatID = selectedChatID {
+                saveComposerState(for: previousChatID)
+                saveConversationNotices(for: previousChatID)
+            }
             quoteNavigationError = nil
             replyContextError = nil
             sendStatusMessage = nil
-            if let previousChatID = selectedChatID {
-                saveComposerState(for: previousChatID)
-            }
             selectedChatID = id
             conversationAnchorMessageID = nil
             messages = []
@@ -997,6 +999,7 @@ final class AppModel: ObservableObject {
                 phase = .failed(message)
             }
             if let id {
+                quoteNavigationError = pendingQuoteNavigationErrors.removeValue(forKey: id)
                 replyContextError = pendingReplyContextErrors.removeValue(forKey: id)
                 sendStatusMessage = pendingSendStatusMessages.removeValue(forKey: id)
             }
@@ -1017,6 +1020,18 @@ final class AppModel: ObservableObject {
             return
         }
         scheduleConversationLoad(chatID: id, around: messageID, scrollTo: scrollTarget)
+    }
+
+    private func saveConversationNotices(for chatID: NativeChat.ID) {
+        if let quoteNavigationError {
+            pendingQuoteNavigationErrors[chatID] = quoteNavigationError
+        }
+        if let replyContextError {
+            pendingReplyContextErrors[chatID] = replyContextError
+        }
+        if let sendStatusMessage {
+            pendingSendStatusMessages[chatID] = sendStatusMessage
+        }
     }
 
     private func saveComposerState(for chatID: NativeChat.ID) {

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -79,6 +79,7 @@ final class AppModel: ObservableObject {
     private(set) var sendTask: Task<Void, Never>?
     private var deleteTask: Task<Void, Never>?
     private(set) var quoteNavigationTask: Task<Void, Never>?
+    private var replyTargetNavigationTask: Task<Void, Never>?
     private var notificationRouteQueue = NotificationRouteQueue()
     private var pendingChatOperationErrors: [NativeChat.ID: String] = [:]
     private var pendingReplyContextErrors: [NativeChat.ID: String] = [:]
@@ -141,6 +142,7 @@ final class AppModel: ObservableObject {
         sendTask?.cancel()
         deleteTask?.cancel()
         quoteNavigationTask?.cancel()
+        replyTargetNavigationTask?.cancel()
     }
 
     var selectedChat: NativeChat? {
@@ -521,10 +523,16 @@ final class AppModel: ObservableObject {
     }
 
     private func cancelStaleNavigationForReply() {
+        cancelReplyTargetNavigation()
         quoteNavigationTask?.cancel()
         quoteNavigationTask = nil
         quoteNavigationRevision &+= 1
         cancelConversationLoadWithoutReplacement()
+    }
+
+    private func cancelReplyTargetNavigation() {
+        replyTargetNavigationTask?.cancel()
+        replyTargetNavigationTask = nil
     }
 
     func replyToSelectedMessage() {
@@ -535,6 +543,7 @@ final class AppModel: ObservableObject {
 
     func cancelReply() {
         guard !isSendingSelectedChat else { return }
+        cancelReplyTargetNavigation()
         replyingTo = nil
         replyingChatID = nil
     }
@@ -544,7 +553,8 @@ final class AppModel: ObservableObject {
         guard let message = replyingTo,
               let chatID = selectedChatID,
               replyingChatID == chatID else { return nil }
-        return openQuotedMessage(
+        cancelReplyTargetNavigation()
+        let task = openQuotedMessage(
             NativeQuote(
                 messageID: message.id,
                 text: message.replyPreview,
@@ -553,6 +563,8 @@ final class AppModel: ObservableObject {
             ),
             from: message.id
         )
+        replyTargetNavigationTask = task
+        return task
     }
 
     @discardableResult
@@ -924,6 +936,7 @@ final class AppModel: ObservableObject {
         guard changedChat || messageID != nil || scrollTarget != nil else { return }
 
         if changedChat {
+            cancelReplyTargetNavigation()
             quoteNavigationTask?.cancel()
             quoteNavigationTask = nil
             quoteNavigationRevision &+= 1

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -234,7 +234,7 @@ final class AppModel: ObservableObject {
                     quotedItem: quotedMessage.map {
                         NativeQuote(
                             messageID: $0.id,
-                            text: $0.text.isEmpty ? ($0.content.attachmentDescription ?? "Message") : $0.text,
+                            text: $0.replyPreview,
                             sent: $0.sent,
                             author: $0.author
                         )

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -53,6 +53,7 @@ final class AppModel: ObservableObject {
     @Published var pendingAttachments: [PendingAttachment] = []
     @Published var attachmentError: String?
     @Published var attachmentOpenError: String?
+    @Published var quickLookURL: URL?
     @Published var quoteNavigationError: String?
     @Published var replyContextError: String?
     @Published var sendStatusMessage: String?
@@ -95,6 +96,7 @@ final class AppModel: ObservableObject {
     private var pendingAttachmentOpenErrors: [NativeChat.ID: String] = [:]
     private var pendingReplyInvalidationChatIDs: Set<NativeChat.ID> = []
     private var composerStates: [NativeChat.ID: ConversationComposerState] = [:]
+    private var quickLookRequestKey: AttachmentOpeningKey?
     private var deletingChatID: NativeChat.ID?
     private var deletingMessageIDs: Set<Int64> = []
     private var selectionAnchor: Int64?
@@ -692,6 +694,11 @@ final class AppModel: ObservableObject {
         guard !openingAttachmentKeys.contains(openingKey) else { return nil }
         let loadMessageOperation = loadMessageOperation
         let openAttachmentOperation = openAttachmentOperation
+        let opensInQuickLook = openAttachmentOperation == nil && message.content.opensInQuickLook
+        if opensInQuickLook {
+            quickLookRequestKey = openingKey
+            quickLookURL = nil
+        }
         openingAttachmentKeys.insert(openingKey)
         let task = Task {
             defer { openingAttachmentKeys.remove(openingKey) }
@@ -723,13 +730,20 @@ final class AppModel: ObservableObject {
                         fileName: fileName
                     )
                     try Task.checkCancellation()
-                    guard NSWorkspace.shared.open(url) else {
+                    if opensInQuickLook {
+                        guard selectedChatID == chatID,
+                              quickLookRequestKey == openingKey else { return }
+                        quickLookRequestKey = nil
+                        quickLookURL = url
+                    } else if !NSWorkspace.shared.open(url) {
                         throw NativeChatError.unavailable("macOS could not open this attachment.")
                     }
                 }
             } catch is CancellationError {
+                if quickLookRequestKey == openingKey { quickLookRequestKey = nil }
                 return
             } catch {
+                if quickLookRequestKey == openingKey { quickLookRequestKey = nil }
                 presentAttachmentOpenFailure(error.localizedDescription, in: chatID)
             }
         }
@@ -1001,6 +1015,8 @@ final class AppModel: ObservableObject {
         guard changedChat || messageID != nil || scrollTarget != nil else { return }
 
         if changedChat {
+            quickLookRequestKey = nil
+            quickLookURL = nil
             cancelReplyTargetNavigation()
             quoteNavigationTask?.cancel()
             quoteNavigationTask = nil

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -2,6 +2,8 @@ import AppKit
 import Foundation
 
 typealias DeleteMessagesOperation = @Sendable ([Int64], NativeChat) async throws -> [NativeMessage]
+typealias SendTextOperation = @Sendable (String, Int64?, NativeChat) async throws -> Void
+typealias SendAttachmentOperation = @Sendable (PendingAttachment, String, Int64?, NativeChat) async throws -> Void
 
 @MainActor
 final class AppModel: ObservableObject {
@@ -56,11 +58,13 @@ final class AppModel: ObservableObject {
     private let previewMode: Bool
     private let passphraseStore: any DatabasePassphraseStore
     private let deleteMessagesOperation: DeleteMessagesOperation?
+    private let sendTextOperation: SendTextOperation?
+    private let sendAttachmentOperation: SendAttachmentOperation?
     private weak var notificationManager: NativeNotificationManager?
     private var eventTask: Task<Void, Never>?
     private var conversationLoadTask: Task<Void, Never>?
     private var refreshTask: Task<Void, Never>?
-    private var sendTask: Task<Void, Never>?
+    private(set) var sendTask: Task<Void, Never>?
     private var deleteTask: Task<Void, Never>?
     private var notificationRouteQueue = NotificationRouteQueue()
     private var pendingChatOperationErrors: [NativeChat.ID: String] = [:]
@@ -74,12 +78,16 @@ final class AppModel: ObservableObject {
         notificationManager: NativeNotificationManager? = nil,
         passphraseStore: any DatabasePassphraseStore = DatabasePassphraseKeychain(),
         previewMode: Bool? = nil,
-        deleteMessagesOperation: DeleteMessagesOperation? = nil
+        deleteMessagesOperation: DeleteMessagesOperation? = nil,
+        sendTextOperation: SendTextOperation? = nil,
+        sendAttachmentOperation: SendAttachmentOperation? = nil
     ) {
         self.previewMode = previewMode
             ?? (ProcessInfo.processInfo.environment["SIMPLEX_NATIVE_UI_PREVIEW"] == "1")
         self.passphraseStore = passphraseStore
         self.deleteMessagesOperation = deleteMessagesOperation
+        self.sendTextOperation = sendTextOperation
+        self.sendAttachmentOperation = sendAttachmentOperation
         keychainPassphraseStorageAvailable = Bundle.main.object(
             forInfoDictionaryKey: "SimpleXKeychainPassphraseStorageEnabled"
         ) as? Bool == true
@@ -204,7 +212,7 @@ final class AppModel: ObservableObject {
         guard (!text.isEmpty || !attachments.isEmpty), let chat = selectedChat, !isSending else { return }
         let quotedMessage = replyingChatID == chat.id ? replyingTo : nil
         if replyingTo != nil, quotedMessage == nil { cancelReply() }
-        if previewMode {
+        if previewMode, sendTextOperation == nil, sendAttachmentOperation == nil {
             if !text.isEmpty {
                 let nextID = (messages.map(\.id).max() ?? 0) + 1
                 messages.append(NativeMessage(
@@ -232,20 +240,27 @@ final class AppModel: ObservableObject {
         }
         draft = ""
         isSending = true
-        sendTask = Task {
+        let core = core
+        let sendTextOperation = sendTextOperation
+        let sendAttachmentOperation = sendAttachmentOperation
+        sendTask = Task { [weak self] in
             defer {
-                isSending = false
-                sendTask = nil
+                self?.finishSending()
             }
-            var contentWasSent = false
+            var draftWasSent = false
             do {
                 if attachments.isEmpty {
-                    try await core.sendText(text, quotedItemID: quotedMessage?.id, to: chat)
                     try Task.checkCancellation()
-                    contentWasSent = true
-                    if let quotedItemID = quotedMessage?.id {
-                        clearReply(quotedItemID, in: chat.id)
+                    if let sendTextOperation {
+                        try await sendTextOperation(text, quotedMessage?.id, chat)
+                    } else {
+                        try await core.sendText(text, quotedItemID: quotedMessage?.id, to: chat)
                     }
+                    draftWasSent = true
+                    if let quotedItemID = quotedMessage?.id {
+                        self?.clearReply(quotedItemID, in: chat.id)
+                    }
+                    try Task.checkCancellation()
                 } else {
                     let sendSteps = PendingAttachmentBatch.sendSteps(
                         attachments: attachments,
@@ -254,33 +269,43 @@ final class AppModel: ObservableObject {
                     )
                     for (index, step) in sendSteps.enumerated() {
                         try Task.checkCancellation()
-                        try await core.sendAttachment(
-                            step.attachment,
-                            caption: step.caption,
-                            quotedItemID: step.quotedItemID,
-                            to: chat
-                        )
-                        try Task.checkCancellation()
-                        if index == sendSteps.index(before: sendSteps.endIndex) { contentWasSent = true }
-                        removeSentAttachment(step.attachment.id, from: chat.id)
-                        if let quotedItemID = step.quotedItemID {
-                            clearReply(quotedItemID, in: chat.id)
+                        if let sendAttachmentOperation {
+                            try await sendAttachmentOperation(
+                                step.attachment,
+                                step.caption,
+                                step.quotedItemID,
+                                chat
+                            )
+                        } else {
+                            try await core.sendAttachment(
+                                step.attachment,
+                                caption: step.caption,
+                                quotedItemID: step.quotedItemID,
+                                to: chat
+                            )
                         }
+                        if index == sendSteps.index(before: sendSteps.endIndex) { draftWasSent = true }
+                        self?.removeSentAttachment(step.attachment.id, from: chat.id)
+                        if let quotedItemID = step.quotedItemID {
+                            self?.clearReply(quotedItemID, in: chat.id)
+                        }
+                        try Task.checkCancellation()
                     }
                 }
                 let sentMessages = try await core.loadMessages(chatID: chat.id)
                 try Task.checkCancellation()
-                if selectedChatID == chat.id { messages = sentMessages }
-                if let userID = profile?.userID {
+                if self?.selectedChatID == chat.id { self?.messages = sentMessages }
+                if let userID = self?.profile?.userID {
                     let loadedChats = try await core.loadChats(userID: userID)
                     try Task.checkCancellation()
-                    chats = loadedChats
+                    self?.chats = loadedChats
                 }
             } catch is CancellationError {
+                if !draftWasSent { self?.restoreFailedDraft(text, in: chat.id) }
                 return
             } catch {
-                if !contentWasSent { restoreFailedDraft(text, in: chat.id) }
-                phase = .failed(error.localizedDescription)
+                if !draftWasSent { self?.restoreFailedDraft(text, in: chat.id) }
+                self?.finishSendFailure(error.localizedDescription, in: chat.id)
             }
         }
     }
@@ -669,6 +694,19 @@ final class AppModel: ObservableObject {
             } else if state.draft != text {
                 state.draft = "\(text)\n\(state.draft)"
             }
+        }
+    }
+
+    private func finishSending() {
+        isSending = false
+        sendTask = nil
+    }
+
+    private func finishSendFailure(_ message: String, in chatID: NativeChat.ID) {
+        if selectedChatID == chatID {
+            phase = .failed(message)
+        } else {
+            pendingChatOperationErrors[chatID] = message
         }
     }
 

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -142,9 +142,12 @@ final class AppModel: ObservableObject {
     }
 
     var canDeleteSelectedMessages: Bool {
-        !isDeletingMessages
+        let inFlightQuoteID = isSendingSelectedChat ? replyingTo?.id : nil
+        let includesInFlightQuote = inFlightQuoteID.map(selectedMessageIDs.contains) ?? false
+        return !isDeletingMessages
             && !selectedMessageIDs.isEmpty
             && selectedMessagesInTranscriptOrder.allSatisfy(\.deletable)
+            && !includesInFlightQuote
     }
 
     var conversationSearchMatches: [NativeMessage] {

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -6,6 +6,7 @@ typealias SendTextOperation = @Sendable (String, Int64?, NativeChat) async throw
 typealias SendAttachmentOperation = @Sendable (PendingAttachment, String, Int64?, NativeChat) async throws -> Void
 typealias LoadMessageOperation = @Sendable (NativeChat.ID, Int64) async throws -> NativeMessage?
 typealias LoadMessagesOperation = @Sendable (NativeChat.ID, Int64?) async throws -> [NativeMessage]
+typealias LoadChatsOperation = @Sendable (Int64) async throws -> [NativeChat]
 typealias OpenAttachmentOperation = @Sendable (NativeCryptoFile, String?) async throws -> Void
 
 @MainActor
@@ -68,6 +69,7 @@ final class AppModel: ObservableObject {
     private let sendAttachmentOperation: SendAttachmentOperation?
     private let loadMessageOperation: LoadMessageOperation?
     private let loadMessagesOperation: LoadMessagesOperation?
+    private let loadChatsOperation: LoadChatsOperation?
     private let openAttachmentOperation: OpenAttachmentOperation?
     private weak var notificationManager: NativeNotificationManager?
     private var eventTask: Task<Void, Never>?
@@ -85,6 +87,7 @@ final class AppModel: ObservableObject {
     private var selectionAnchor: Int64?
     private var replyingChatID: NativeChat.ID?
     private var conversationLoadRevision: UInt64 = 0
+    private(set) var conversationAnchorMessageID: Int64?
     private var quoteNavigationRevision: UInt64 = 0
     private static let densityKey = "desktopChatDensity"
 
@@ -97,6 +100,7 @@ final class AppModel: ObservableObject {
         sendAttachmentOperation: SendAttachmentOperation? = nil,
         loadMessageOperation: LoadMessageOperation? = nil,
         loadMessagesOperation: LoadMessagesOperation? = nil,
+        loadChatsOperation: LoadChatsOperation? = nil,
         openAttachmentOperation: OpenAttachmentOperation? = nil
     ) {
         self.previewMode = previewMode
@@ -107,6 +111,7 @@ final class AppModel: ObservableObject {
         self.sendAttachmentOperation = sendAttachmentOperation
         self.loadMessageOperation = loadMessageOperation
         self.loadMessagesOperation = loadMessagesOperation
+        self.loadChatsOperation = loadChatsOperation
         self.openAttachmentOperation = openAttachmentOperation
         keychainPassphraseStorageAvailable = Bundle.main.object(
             forInfoDictionaryKey: "SimpleXKeychainPassphraseStorageEnabled"
@@ -236,7 +241,7 @@ final class AppModel: ObservableObject {
         refreshTask?.cancel()
         refreshTask = Task {
             do {
-                let loadedChats = try await core.loadChats(userID: userID)
+                let loadedChats = try await loadChats(userID: userID)
                 guard !Task.isCancelled else { return }
                 chats = loadedChats
                 if let chatID = selectedChatID {
@@ -358,7 +363,10 @@ final class AppModel: ObservableObject {
                 }
                 let sentMessages = try await core.loadMessages(chatID: chat.id)
                 try Task.checkCancellation()
-                if self?.selectedChatID == chat.id { self?.messages = sentMessages }
+                if self?.selectedChatID == chat.id {
+                    self?.conversationAnchorMessageID = nil
+                    self?.messages = sentMessages
+                }
                 if let userID = self?.profile?.userID {
                     let loadedChats = try await core.loadChats(userID: userID)
                     try Task.checkCancellation()
@@ -593,6 +601,7 @@ final class AppModel: ObservableObject {
         guard selectedChatID == chatID else { return nil }
         conversationLoadTask?.cancel()
         if messages.contains(where: { $0.id == messageID }) {
+            conversationAnchorMessageID = messageID
             targetMessageID = messageID
             return nil
         }
@@ -735,6 +744,7 @@ final class AppModel: ObservableObject {
         clearDeletionState()
         deletedIDs.forEach { clearReply($0, in: chatID) }
         guard selectedChatID == chatID else { return }
+        conversationAnchorMessageID = nil
         messages = loadedMessages
     }
 
@@ -742,6 +752,9 @@ final class AppModel: ObservableObject {
         clearDeletionState()
         deletedIDs.forEach { clearReply($0, in: chatID) }
         guard selectedChatID == chatID else { return }
+        if conversationAnchorMessageID.map(deletedIDs.contains) == true {
+            conversationAnchorMessageID = nil
+        }
         messages.removeAll { deletedIDs.contains($0.id) }
     }
 
@@ -828,6 +841,7 @@ final class AppModel: ObservableObject {
                 saveComposerState(for: previousChatID)
             }
             selectedChatID = id
+            conversationAnchorMessageID = nil
             messages = []
             clearMessageSelection()
             restoreComposerState(for: id)
@@ -985,7 +999,8 @@ final class AppModel: ObservableObject {
         chatID: NativeChat.ID,
         around messageID: Int64? = nil,
         showProgress: Bool = true,
-        navigationFailureMessage: String? = nil
+        navigationFailureMessage: String? = nil,
+        reportFailure: Bool = true
     ) async -> Bool {
         guard selectedChatID == chatID else { return false }
         conversationLoadRevision &+= 1
@@ -1006,6 +1021,7 @@ final class AppModel: ObservableObject {
             guard !Task.isCancelled, selectedChatID == chatID,
                   conversationLoadRevision == revision else { return false }
             applyLoadedMessages(loadedMessages, to: chatID)
+            conversationAnchorMessageID = messageID
             return true
         } catch is CancellationError {
             return false
@@ -1014,7 +1030,7 @@ final class AppModel: ObservableObject {
                   conversationLoadRevision == revision else { return false }
             if let navigationFailureMessage {
                 quoteNavigationError = navigationFailureMessage
-            } else {
+            } else if reportFailure {
                 phase = .failed(error.localizedDescription)
             }
             return false
@@ -1047,17 +1063,37 @@ final class AppModel: ObservableObject {
         }
     }
 
-    private func refreshAfterEvent() async {
+    func refreshAfterEvent() async {
         guard let userID = profile?.userID else { return }
         do {
-            chats = try await core.loadChats(userID: userID)
-            if let chatID = selectedChatID {
-                _ = await loadConversation(chatID: chatID, showProgress: false)
+            chats = try await loadChats(userID: userID)
+            if let chatID = selectedChatID, !isLoadingConversation {
+                let anchor = conversationAnchorMessageID
+                let loaded = await loadConversation(
+                    chatID: chatID,
+                    around: anchor,
+                    showProgress: false,
+                    reportFailure: anchor == nil
+                )
+                if !loaded, anchor != nil, !Task.isCancelled,
+                   selectedChatID == chatID, !isLoadingConversation {
+                    conversationAnchorMessageID = nil
+                    _ = await loadConversation(chatID: chatID, showProgress: false)
+                }
             }
             consumePendingNotificationRoutes()
+        } catch is CancellationError {
+            return
         } catch {
             phase = .failed(error.localizedDescription)
         }
+    }
+
+    private func loadChats(userID: Int64) async throws -> [NativeChat] {
+        if let loadChatsOperation {
+            return try await loadChatsOperation(userID)
+        }
+        return try await core.loadChats(userID: userID)
     }
 
     private func consumePendingNotificationRoutes() {

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -81,6 +81,7 @@ final class AppModel: ObservableObject {
     private var notificationRouteQueue = NotificationRouteQueue()
     private var pendingChatOperationErrors: [NativeChat.ID: String] = [:]
     private var pendingReplyContextErrors: [NativeChat.ID: String] = [:]
+    private var pendingReplyInvalidationChatIDs: Set<NativeChat.ID> = []
     private var composerStates: [NativeChat.ID: ConversationComposerState] = [:]
     private var deletingChatID: NativeChat.ID?
     private var deletingMessageIDs: Set<Int64> = []
@@ -311,10 +312,15 @@ final class AppModel: ObservableObject {
         let sendAttachmentOperation = sendAttachmentOperation
         let loadMessageOperation = loadMessageOperation
         sendTask = Task { [weak self] in
-            defer {
-                self?.finishSending()
-            }
             var draftWasSent = false
+            var quoteWasSent = false
+            defer {
+                self?.finishSending(
+                    in: chat.id,
+                    quotedMessageID: quotedMessage?.id,
+                    quoteWasSent: quoteWasSent
+                )
+            }
             do {
                 if let quotedMessage {
                     let refreshedReply: NativeMessage?
@@ -341,6 +347,7 @@ final class AppModel: ObservableObject {
                     }
                     draftWasSent = true
                     if let quotedItemID = quotedMessage?.id {
+                        quoteWasSent = true
                         self?.clearReply(quotedItemID, in: chat.id)
                     }
                     try Task.checkCancellation()
@@ -370,6 +377,7 @@ final class AppModel: ObservableObject {
                         if index == sendSteps.index(before: sendSteps.endIndex) { draftWasSent = true }
                         self?.removeSentAttachment(step.attachment.id, from: chat.id)
                         if let quotedItemID = step.quotedItemID {
+                            quoteWasSent = true
                             self?.clearReply(quotedItemID, in: chat.id)
                         }
                         try Task.checkCancellation()
@@ -946,6 +954,7 @@ final class AppModel: ObservableObject {
 
     private func invalidateReplyContext(in chatID: NativeChat.ID) {
         let message = "The message you were replying to is no longer available. Your draft was kept."
+        pendingReplyInvalidationChatIDs.remove(chatID)
         updateComposerState(for: chatID) { state in
             state.reply = nil
         }
@@ -967,10 +976,18 @@ final class AppModel: ObservableObject {
         }
     }
 
-    private func finishSending() {
+    private func finishSending(
+        in chatID: NativeChat.ID,
+        quotedMessageID: Int64?,
+        quoteWasSent: Bool
+    ) {
+        let replyWasInvalidated = pendingReplyInvalidationChatIDs.remove(chatID) != nil
         isSending = false
         sendingChatID = nil
         sendTask = nil
+        if replyWasInvalidated, !quoteWasSent, quotedMessageID != nil {
+            invalidateReplyContext(in: chatID)
+        }
     }
 
     private func finishSendFailure(_ message: String, in chatID: NativeChat.ID) {
@@ -1062,8 +1079,11 @@ final class AppModel: ObservableObject {
         guard replyingChatID == chatID, let currentReply = replyingTo,
               let refreshedReply = loadedMessages.first(where: { $0.id == currentReply.id }) else { return }
         if refreshedReply.replyable {
+            pendingReplyInvalidationChatIDs.remove(chatID)
             replyingTo = refreshedReply
-        } else if sendingChatID != chatID {
+        } else if sendingChatID == chatID {
+            pendingReplyInvalidationChatIDs.insert(chatID)
+        } else {
             invalidateReplyContext(in: chatID)
         }
     }

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -158,12 +158,26 @@ final class AppModel: ObservableObject {
         let hasText = !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         return (hasText || !pendingAttachments.isEmpty)
             && !isSending
-            && !isDeletingReplyTarget
+            && !isDeletingSelectedChat
+            && !isLoadingConversation
+            && quoteNavigationTask == nil
             && selectedChat?.kind.canSend == true
     }
 
     var isSendingSelectedChat: Bool {
         isSending && sendingChatID == selectedChatID
+    }
+
+    var isDeletingSelectedChat: Bool {
+        isDeletingMessages && deletingChatID == selectedChatID
+    }
+
+    var canNavigateConversationHistory: Bool {
+        !isSendingSelectedChat && !isDeletingSelectedChat
+    }
+
+    var canRefreshConversation: Bool {
+        canNavigateConversationHistory && !isLoadingConversation && quoteNavigationTask == nil
     }
 
     var isViewingConversationHistory: Bool {
@@ -178,6 +192,9 @@ final class AppModel: ObservableObject {
         let inFlightQuoteID = isSendingSelectedChat ? replyingTo?.id : nil
         let includesInFlightQuote = inFlightQuoteID.map(selectedMessageIDs.contains) ?? false
         return !isDeletingMessages
+            && !isSendingSelectedChat
+            && !isLoadingConversation
+            && quoteNavigationTask == nil
             && !selectedMessageIDs.isEmpty
             && selectedMessagesInTranscriptOrder.allSatisfy(\.deletable)
             && !includesInFlightQuote
@@ -242,6 +259,7 @@ final class AppModel: ObservableObject {
 
     func refresh() {
         guard !previewMode else { return }
+        guard canRefreshConversation else { return }
         guard let userID = profile?.userID else { return }
         refreshTask?.cancel()
         refreshTask = Task {
@@ -263,7 +281,8 @@ final class AppModel: ObservableObject {
 
     @discardableResult
     func jumpToLatest() -> Task<Void, Never>? {
-        guard let chatID = selectedChatID, isViewingConversationHistory else { return nil }
+        guard canNavigateConversationHistory,
+              let chatID = selectedChatID, isViewingConversationHistory else { return nil }
         quoteNavigationTask?.cancel()
         quoteNavigationTask = nil
         quoteNavigationRevision &+= 1
@@ -275,7 +294,7 @@ final class AppModel: ObservableObject {
         let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         let attachments = pendingAttachments
         guard (!text.isEmpty || !attachments.isEmpty), let chat = selectedChat,
-              !isSending, !isDeletingReplyTarget else { return }
+              canSendDraft else { return }
         let quotedMessage = replyingChatID == chat.id ? replyingTo : nil
         if replyingTo != nil, quotedMessage == nil { cancelReply() }
         if previewMode, sendTextOperation == nil, sendAttachmentOperation == nil {
@@ -521,7 +540,7 @@ final class AppModel: ObservableObject {
 
     @discardableResult
     func openQuotedMessage(_ quote: NativeQuote, from containingMessageID: Int64) -> Task<Void, Never>? {
-        guard let chatID = selectedChatID else { return nil }
+        guard canNavigateConversationHistory, let chatID = selectedChatID else { return nil }
         quoteNavigationTask?.cancel()
         quoteNavigationTask = nil
         quoteNavigationRevision &+= 1
@@ -806,11 +825,6 @@ final class AppModel: ObservableObject {
         } else {
             pendingChatOperationErrors[chatID] = message
         }
-    }
-
-    private var isDeletingReplyTarget: Bool {
-        guard let replyingTo else { return false }
-        return deletionIncludesMessage(replyingTo.id, in: replyingChatID)
     }
 
     private func deletionIncludesMessage(_ messageID: Int64, in chatID: NativeChat.ID?) -> Bool {

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -835,7 +835,7 @@ final class AppModel: ObservableObject {
 
     func copySelectedMessages() {
         guard !selectedMessageIDs.isEmpty else { return }
-        let text = selectedMessagesInTranscriptOrder.map(\.text).joined(separator: "\n\n")
+        let text = MessageSelection.clipboardText(for: selectedMessagesInTranscriptOrder)
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)
     }

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 @MainActor
@@ -18,9 +19,30 @@ final class AppModel: ObservableObject {
     @Published var searchText = ""
     @Published var isLoadingConversation = false
     @Published var isSending = false
+    @Published var selectedMessageIDs: Set<Int64> = []
+    @Published var transcriptFocused = false
+    @Published var pendingAttachments: [PendingAttachment] = []
+    @Published var attachmentError: String?
+    @Published var showingDeleteConfirmation = false
+    @Published var targetMessageID: Int64?
+    @Published var density: DesktopChatDensity {
+        didSet { UserDefaults.standard.set(density.rawValue, forKey: Self.densityKey) }
+    }
 
     private let core = SimpleXCore()
+    private weak var notificationManager: NativeNotificationManager?
     private var eventTask: Task<Void, Never>?
+    private var notificationRouteQueue = NotificationRouteQueue()
+    private var selectionAnchor: Int64?
+    private static let densityKey = "desktopChatDensity"
+
+    init(notificationManager: NativeNotificationManager? = nil) {
+        density = DesktopChatDensity(
+            rawValue: UserDefaults.standard.string(forKey: Self.densityKey) ?? ""
+        ) ?? .compact
+        self.notificationManager = notificationManager
+        notificationManager?.model = self
+    }
 
     deinit {
         eventTask?.cancel()
@@ -38,6 +60,19 @@ final class AppModel: ObservableObject {
         }
     }
 
+    var canSendDraft: Bool {
+        let hasText = !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        return (hasText || !pendingAttachments.isEmpty) && !isSending && selectedChat?.kind.canSend == true
+    }
+
+    var selectedMessagesInTranscriptOrder: [NativeMessage] {
+        messages.filter { selectedMessageIDs.contains($0.id) }
+    }
+
+    var canDeleteSelectedMessages: Bool {
+        !selectedMessageIDs.isEmpty && selectedMessagesInTranscriptOrder.allSatisfy(\.deletable)
+    }
+
     func unlock(passphrase: String) {
         guard phase != .opening else { return }
         phase = .opening
@@ -50,6 +85,8 @@ final class AppModel: ObservableObject {
                 if selectedChatID == nil { selectedChatID = chats.first?.id }
                 await loadSelectedConversation()
                 startEventLoop()
+                notificationManager?.chatSetupReady()
+                consumePendingNotificationRoutes()
             } catch {
                 phase = .locked(message: error.localizedDescription)
             }
@@ -57,7 +94,12 @@ final class AppModel: ObservableObject {
     }
 
     func selectChat(_ id: NativeChat.ID?) {
+        guard selectedChatID != id else { return }
         selectedChatID = id
+        clearMessageSelection()
+        pendingAttachments = []
+        targetMessageID = nil
+        if let id { notificationManager?.removeDeliveredNotifications(chatID: id) }
         Task { await loadSelectedConversation() }
     }
 
@@ -75,12 +117,21 @@ final class AppModel: ObservableObject {
 
     func sendDraft() {
         let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty, let chat = selectedChat, !isSending else { return }
+        let attachments = pendingAttachments
+        guard (!text.isEmpty || !attachments.isEmpty), let chat = selectedChat, !isSending else { return }
         draft = ""
         isSending = true
         Task {
             do {
-                try await core.sendText(text, to: chat)
+                if attachments.isEmpty {
+                    try await core.sendText(text, to: chat)
+                } else {
+                    for (index, attachment) in attachments.enumerated() {
+                        let caption = index == attachments.index(before: attachments.endIndex) ? text : ""
+                        try await core.sendAttachment(attachment, caption: caption, to: chat)
+                        pendingAttachments.removeAll { $0.id == attachment.id }
+                    }
+                }
                 messages = try await core.loadMessages(chatID: chat.id)
                 if let userID = profile?.userID { chats = try await core.loadChats(userID: userID) }
             } catch {
@@ -91,14 +142,146 @@ final class AppModel: ObservableObject {
         }
     }
 
-    private func loadSelectedConversation() async {
+    func chooseAttachments() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowedContentTypes = [.data]
+        panel.prompt = "Attach"
+        panel.message = "Choose images, videos, or documents to send."
+        guard panel.runModal() == .OK else { return }
+        stageAttachments(panel.urls)
+    }
+
+    func stageAttachments(_ urls: [URL]) {
+        var failures: [String] = []
+        for url in urls {
+            do {
+                let attachment = try PendingAttachment.stage(url: url)
+                if !pendingAttachments.contains(where: { $0.url == attachment.url }) {
+                    pendingAttachments.append(attachment)
+                }
+            } catch {
+                failures.append(error.localizedDescription)
+            }
+        }
+        if !failures.isEmpty { attachmentError = failures.joined(separator: "\n") }
+    }
+
+    func stageFilesFromPasteboard() {
+        let urls = NSPasteboard.general.readObjects(forClasses: [NSURL.self]) as? [URL] ?? []
+        if urls.isEmpty {
+            attachmentError = "The clipboard does not contain any files."
+        } else {
+            stageAttachments(urls)
+        }
+    }
+
+    func removeAttachment(_ id: PendingAttachment.ID) {
+        pendingAttachments.removeAll { $0.id == id }
+    }
+
+    func reorderAttachment(_ source: PendingAttachment.ID, before destination: PendingAttachment.ID) {
+        pendingAttachments = PendingAttachment.reordered(pendingAttachments, from: source, before: destination)
+    }
+
+    func selectMessage(_ id: Int64, modifiers: NSEvent.ModifierFlags) {
+        let result = MessageSelection.updated(
+            current: selectedMessageIDs,
+            anchor: selectionAnchor,
+            clicked: id,
+            orderedIDs: messages.map(\.id),
+            command: modifiers.contains(.command),
+            shift: modifiers.contains(.shift)
+        )
+        selectedMessageIDs = result.selection
+        selectionAnchor = result.anchor
+    }
+
+    func selectAllMessages() {
+        guard transcriptFocused else { return }
+        selectedMessageIDs = Set(messages.map(\.id))
+        selectionAnchor = messages.last?.id
+    }
+
+    func moveMessageSelection(by offset: Int) {
+        guard transcriptFocused, !messages.isEmpty else { return }
+        let currentID = selectedMessagesInTranscriptOrder.last?.id
+        let currentIndex = currentID.flatMap { id in messages.firstIndex(where: { $0.id == id }) }
+        let proposed = (currentIndex ?? (offset > 0 ? -1 : messages.count)) + offset
+        let targetIndex = min(max(0, proposed), messages.count - 1)
+        selectedMessageIDs = [messages[targetIndex].id]
+        selectionAnchor = messages[targetIndex].id
+    }
+
+    func copySelectedMessages() {
+        guard transcriptFocused, !selectedMessageIDs.isEmpty else { return }
+        let text = selectedMessagesInTranscriptOrder.map(\.text).joined(separator: "\n\n")
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+    }
+
+    func requestDeleteSelectedMessages() {
+        guard transcriptFocused, canDeleteSelectedMessages else { return }
+        showingDeleteConfirmation = true
+    }
+
+    func deleteSelectedMessages() {
+        guard let chat = selectedChat, canDeleteSelectedMessages else { return }
+        let identifiers = selectedMessagesInTranscriptOrder.map(\.id)
+        showingDeleteConfirmation = false
+        Task {
+            do {
+                try await core.deleteMessages(identifiers, from: chat)
+                clearMessageSelection()
+                messages = try await core.loadMessages(chatID: chat.id)
+            } catch {
+                phase = .failed(error.localizedDescription)
+            }
+        }
+    }
+
+    func clearMessageSelection() {
+        selectedMessageIDs = []
+        selectionAnchor = nil
+    }
+
+    func dismissNearestState() {
+        if !pendingAttachments.isEmpty {
+            pendingAttachments = []
+        } else if !selectedMessageIDs.isEmpty {
+            clearMessageSelection()
+        }
+    }
+
+    func openNotificationRoute(_ route: NotificationRoute) {
+        guard case .ready = phase,
+              route.userID == nil || route.userID == profile?.userID,
+              route.remoteHostID == nil else {
+            notificationRouteQueue.enqueue(route)
+            return
+        }
+        guard chats.contains(where: { $0.id == route.chatID }) else {
+            notificationRouteQueue.enqueue(route)
+            return
+        }
+        selectedChatID = route.chatID
+        clearMessageSelection()
+        targetMessageID = route.messageID
+        notificationManager?.removeDeliveredNotifications(chatID: route.chatID)
+        Task { await loadSelectedConversation(around: route.messageID) }
+    }
+
+    private func loadSelectedConversation(around messageID: Int64? = nil) async {
         guard let chat = selectedChat else {
             messages = []
             return
         }
         isLoadingConversation = true
         do {
-            messages = try await core.loadMessages(chatID: chat.id)
+            messages = try await core.loadMessages(chatID: chat.id, around: messageID)
+            selectedMessageIDs.formIntersection(messages.map(\.id))
         } catch {
             phase = .failed(error.localizedDescription)
         }
@@ -110,8 +293,9 @@ final class AppModel: ObservableObject {
         eventTask = Task { [weak self] in
             while !Task.isCancelled {
                 guard let self else { return }
-                guard await core.waitForEvent() else { continue }
+                guard let event = await core.receiveEvent() else { continue }
                 await refreshAfterEvent()
+                notificationManager?.handleCoreEvent(event)
             }
         }
     }
@@ -123,8 +307,14 @@ final class AppModel: ObservableObject {
             if selectedChatID != nil {
                 await loadSelectedConversation()
             }
+            consumePendingNotificationRoutes()
         } catch {
             phase = .failed(error.localizedDescription)
         }
+    }
+
+    private func consumePendingNotificationRoutes() {
+        let routes = notificationRouteQueue.consumeIfReady(true)
+        for route in routes { openNotificationRoute(route) }
     }
 }

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -9,6 +9,7 @@ typealias LoadMessagesOperation = @Sendable (NativeChat.ID, Int64?) async throws
 typealias LoadChatsOperation = @Sendable (Int64) async throws -> [NativeChat]
 typealias MarkChatReadOperation = @Sendable (NativeChat.ID) async throws -> Void
 typealias OpenAttachmentOperation = @Sendable (NativeCryptoFile, String?) async throws -> Void
+typealias PrepareAttachmentOperation = @Sendable (NativeCryptoFile, String?) async throws -> URL
 typealias WindowFocusedOperation = @MainActor @Sendable () -> Bool
 
 @MainActor
@@ -60,6 +61,7 @@ final class AppModel: ObservableObject {
     @Published var replyContextError: String?
     @Published var sendStatusMessage: String?
     @Published private var openingAttachmentKeys: Set<AttachmentOpeningKey> = []
+    @Published private var inlineAudioURLs: [AttachmentOpeningKey: URL] = [:]
     @Published var replyingTo: NativeMessage?
     @Published var composerFocusRequest = 0
     @Published var showingDeleteConfirmation = false
@@ -82,6 +84,7 @@ final class AppModel: ObservableObject {
     private let loadChatsOperation: LoadChatsOperation?
     private let markChatReadOperation: MarkChatReadOperation?
     private let openAttachmentOperation: OpenAttachmentOperation?
+    private let prepareAttachmentOperation: PrepareAttachmentOperation?
     private let windowFocusedOperation: WindowFocusedOperation?
     private weak var notificationManager: NativeNotificationManager?
     private var eventTask: Task<Void, Never>?
@@ -123,6 +126,7 @@ final class AppModel: ObservableObject {
         loadChatsOperation: LoadChatsOperation? = nil,
         markChatReadOperation: MarkChatReadOperation? = nil,
         openAttachmentOperation: OpenAttachmentOperation? = nil,
+        prepareAttachmentOperation: PrepareAttachmentOperation? = nil,
         windowFocusedOperation: WindowFocusedOperation? = nil
     ) {
         self.previewMode = previewMode
@@ -136,6 +140,7 @@ final class AppModel: ObservableObject {
         self.loadChatsOperation = loadChatsOperation
         self.markChatReadOperation = markChatReadOperation
         self.openAttachmentOperation = openAttachmentOperation
+        self.prepareAttachmentOperation = prepareAttachmentOperation
         self.windowFocusedOperation = windowFocusedOperation
         keychainPassphraseStorageAvailable = Bundle.main.object(
             forInfoDictionaryKey: "SimpleXKeychainPassphraseStorageEnabled"
@@ -713,25 +718,12 @@ final class AppModel: ObservableObject {
         let task = Task {
             defer { openingAttachmentKeys.remove(openingKey) }
             do {
-                var source = initialSource
-                if source.cryptoArgs == nil {
-                    let refreshedMessage: NativeMessage?
-                    if let loadMessageOperation {
-                        refreshedMessage = try await loadMessageOperation(chatID, message.id)
-                    } else {
-                        refreshedMessage = try await core.loadMessage(chatID: chatID, itemID: message.id)
-                    }
-                    try Task.checkCancellation()
-                    if let refreshedMessage, let refreshedSource = refreshedMessage.fileSource {
-                        source = refreshedSource
-                        if selectedChatID == chatID,
-                           let index = messages.firstIndex(where: { $0.id == message.id }) {
-                            messages[index] = refreshedMessage
-                        }
-                    }
-                }
-
-                let fileName = message.content.fileName ?? message.content.attachmentDescription
+                let (source, fileName) = try await resolveAttachment(
+                    initialSource: initialSource,
+                    message: message,
+                    chatID: chatID,
+                    loadMessageOperation: loadMessageOperation
+                )
                 if let openAttachmentOperation {
                     try await openAttachmentOperation(source, fileName)
                 } else {
@@ -758,6 +750,75 @@ final class AppModel: ObservableObject {
             }
         }
         return task
+    }
+
+    @discardableResult
+    func prepareInlineAudio(_ message: NativeMessage) -> Task<Void, Never>? {
+        guard message.content.inlineAudioFileName != nil,
+              let initialSource = message.fileSource,
+              let chatID = selectedChatID else { return nil }
+        let openingKey = AttachmentOpeningKey(chatID: chatID, messageID: message.id)
+        guard inlineAudioURLs[openingKey] == nil,
+              !openingAttachmentKeys.contains(openingKey) else { return nil }
+
+        let loadMessageOperation = loadMessageOperation
+        let prepareAttachmentOperation = prepareAttachmentOperation
+        openingAttachmentKeys.insert(openingKey)
+        let task = Task {
+            defer { openingAttachmentKeys.remove(openingKey) }
+            do {
+                let (source, fileName) = try await resolveAttachment(
+                    initialSource: initialSource,
+                    message: message,
+                    chatID: chatID,
+                    loadMessageOperation: loadMessageOperation
+                )
+                let url: URL
+                if let prepareAttachmentOperation {
+                    url = try await prepareAttachmentOperation(source, fileName)
+                } else {
+                    url = try await core.openableURL(for: source, fileName: fileName)
+                }
+                try Task.checkCancellation()
+                inlineAudioURLs[openingKey] = url
+            } catch is CancellationError {
+                return
+            } catch {
+                presentAttachmentOpenFailure(error.localizedDescription, in: chatID)
+            }
+        }
+        return task
+    }
+
+    func inlineAudioURL(_ messageID: Int64) -> URL? {
+        guard let chatID = selectedChatID else { return nil }
+        return inlineAudioURLs[AttachmentOpeningKey(chatID: chatID, messageID: messageID)]
+    }
+
+    private func resolveAttachment(
+        initialSource: NativeCryptoFile,
+        message: NativeMessage,
+        chatID: NativeChat.ID,
+        loadMessageOperation: LoadMessageOperation?
+    ) async throws -> (source: NativeCryptoFile, fileName: String?) {
+        var source = initialSource
+        if source.cryptoArgs == nil {
+            let refreshedMessage: NativeMessage?
+            if let loadMessageOperation {
+                refreshedMessage = try await loadMessageOperation(chatID, message.id)
+            } else {
+                refreshedMessage = try await core.loadMessage(chatID: chatID, itemID: message.id)
+            }
+            try Task.checkCancellation()
+            if let refreshedMessage, let refreshedSource = refreshedMessage.fileSource {
+                source = refreshedSource
+                if selectedChatID == chatID,
+                   let index = messages.firstIndex(where: { $0.id == message.id }) {
+                    messages[index] = refreshedMessage
+                }
+            }
+        }
+        return (source, message.content.fileName ?? message.content.attachmentDescription)
     }
 
     func isOpeningAttachment(_ messageID: Int64) -> Bool {

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -10,6 +10,16 @@ final class AppModel: ObservableObject {
         case failed(String)
     }
 
+    private struct ConversationComposerState {
+        var draft = ""
+        var attachments: [PendingAttachment] = []
+        var reply: NativeMessage?
+
+        var isEmpty: Bool {
+            draft.isEmpty && attachments.isEmpty && reply == nil
+        }
+    }
+
     @Published var phase: Phase = .locked(message: nil)
     @Published var profile: NativeProfile?
     @Published var chats: [NativeChat] = []
@@ -48,6 +58,7 @@ final class AppModel: ObservableObject {
     private var refreshTask: Task<Void, Never>?
     private var sendTask: Task<Void, Never>?
     private var notificationRouteQueue = NotificationRouteQueue()
+    private var composerStates: [NativeChat.ID: ConversationComposerState] = [:]
     private var selectionAnchor: Int64?
     private var replyingChatID: NativeChat.ID?
     private var conversationLoadRevision: UInt64 = 0
@@ -221,23 +232,28 @@ final class AppModel: ObservableObject {
                     try await core.sendText(text, quotedItemID: quotedMessage?.id, to: chat)
                     try Task.checkCancellation()
                     contentWasSent = true
-                    if selectedChatID == chat.id, replyingTo?.id == quotedMessage?.id { cancelReply() }
+                    if let quotedItemID = quotedMessage?.id {
+                        clearReply(quotedItemID, in: chat.id)
+                    }
                 } else {
-                    for (index, attachment) in attachments.enumerated() {
+                    let sendSteps = PendingAttachmentBatch.sendSteps(
+                        attachments: attachments,
+                        caption: text,
+                        quotedItemID: quotedMessage?.id
+                    )
+                    for (index, step) in sendSteps.enumerated() {
                         try Task.checkCancellation()
-                        let caption = index == attachments.index(before: attachments.endIndex) ? text : ""
-                        let quotedItemID = index == attachments.startIndex ? quotedMessage?.id : nil
                         try await core.sendAttachment(
-                            attachment,
-                            caption: caption,
-                            quotedItemID: quotedItemID,
+                            step.attachment,
+                            caption: step.caption,
+                            quotedItemID: step.quotedItemID,
                             to: chat
                         )
                         try Task.checkCancellation()
-                        if index == attachments.index(before: attachments.endIndex) { contentWasSent = true }
-                        if selectedChatID == chat.id {
-                            pendingAttachments.removeAll { $0.id == attachment.id }
-                            if quotedItemID != nil, replyingTo?.id == quotedItemID { cancelReply() }
+                        if index == sendSteps.index(before: sendSteps.endIndex) { contentWasSent = true }
+                        removeSentAttachment(step.attachment.id, from: chat.id)
+                        if let quotedItemID = step.quotedItemID {
+                            clearReply(quotedItemID, in: chat.id)
                         }
                     }
                 }
@@ -252,15 +268,14 @@ final class AppModel: ObservableObject {
             } catch is CancellationError {
                 return
             } catch {
-                if selectedChatID == chat.id {
-                    if !contentWasSent { draft = text }
-                    phase = .failed(error.localizedDescription)
-                }
+                if !contentWasSent { restoreFailedDraft(text, in: chat.id) }
+                phase = .failed(error.localizedDescription)
             }
         }
     }
 
     func chooseAttachments() {
+        guard !isSending else { return }
         let panel = NSOpenPanel()
         panel.allowsMultipleSelection = true
         panel.canChooseDirectories = false
@@ -273,6 +288,10 @@ final class AppModel: ObservableObject {
     }
 
     func stageAttachments(_ urls: [URL]) {
+        guard !isSending else {
+            attachmentError = "Wait for the current message to finish sending before changing attachments."
+            return
+        }
         var failures: [String] = []
         for url in urls {
             do {
@@ -288,6 +307,10 @@ final class AppModel: ObservableObject {
     }
 
     func stageFilesFromPasteboard() {
+        guard !isSending else {
+            attachmentError = "Wait for the current message to finish sending before changing attachments."
+            return
+        }
         let urls = NSPasteboard.general.readObjects(forClasses: [NSURL.self]) as? [URL] ?? []
         if urls.isEmpty {
             attachmentError = "The clipboard does not contain any files."
@@ -297,14 +320,17 @@ final class AppModel: ObservableObject {
     }
 
     func removeAttachment(_ id: PendingAttachment.ID) {
+        guard !isSending else { return }
         pendingAttachments.removeAll { $0.id == id }
     }
 
     func reorderAttachment(_ source: PendingAttachment.ID, before destination: PendingAttachment.ID) {
+        guard !isSending else { return }
         pendingAttachments = PendingAttachment.reordered(pendingAttachments, from: source, before: destination)
     }
 
     func moveAttachment(_ id: PendingAttachment.ID, by offset: Int) {
+        guard !isSending else { return }
         guard let sourceIndex = pendingAttachments.firstIndex(where: { $0.id == id }) else { return }
         let destinationIndex = min(max(0, sourceIndex + offset), pendingAttachments.count - 1)
         guard sourceIndex != destinationIndex else { return }
@@ -496,10 +522,12 @@ final class AppModel: ObservableObject {
         guard changedChat || messageID != nil || scrollTarget != nil else { return }
 
         if changedChat {
+            if let previousChatID = selectedChatID {
+                saveComposerState(for: previousChatID)
+            }
             selectedChatID = id
             clearMessageSelection()
-            pendingAttachments = []
-            cancelReply()
+            restoreComposerState(for: id)
             targetMessageID = nil
             conversationSearchText = ""
             conversationSearchPresented = false
@@ -520,6 +548,74 @@ final class AppModel: ObservableObject {
             return
         }
         scheduleConversationLoad(chatID: id, around: messageID, scrollTo: scrollTarget)
+    }
+
+    private func saveComposerState(for chatID: NativeChat.ID) {
+        storeComposerState(
+            ConversationComposerState(draft: draft, attachments: pendingAttachments, reply: replyingTo),
+            for: chatID
+        )
+    }
+
+    private func restoreComposerState(for chatID: NativeChat.ID?) {
+        let state = chatID.flatMap { composerStates[$0] } ?? ConversationComposerState()
+        draft = state.draft
+        pendingAttachments = state.attachments
+        replyingTo = state.reply
+        replyingChatID = state.reply == nil ? nil : chatID
+    }
+
+    private func storeComposerState(_ state: ConversationComposerState, for chatID: NativeChat.ID) {
+        if state.isEmpty {
+            composerStates.removeValue(forKey: chatID)
+        } else {
+            composerStates[chatID] = state
+        }
+    }
+
+    private func updateComposerState(
+        for chatID: NativeChat.ID,
+        _ update: (inout ConversationComposerState) -> Void
+    ) {
+        if selectedChatID == chatID {
+            var state = ConversationComposerState(
+                draft: draft,
+                attachments: pendingAttachments,
+                reply: replyingTo
+            )
+            update(&state)
+            draft = state.draft
+            pendingAttachments = state.attachments
+            replyingTo = state.reply
+            replyingChatID = state.reply == nil ? nil : chatID
+        } else {
+            var state = composerStates[chatID] ?? ConversationComposerState()
+            update(&state)
+            storeComposerState(state, for: chatID)
+        }
+    }
+
+    private func removeSentAttachment(_ attachmentID: PendingAttachment.ID, from chatID: NativeChat.ID) {
+        updateComposerState(for: chatID) { state in
+            state.attachments.removeAll { $0.id == attachmentID }
+        }
+    }
+
+    private func clearReply(_ messageID: Int64, in chatID: NativeChat.ID) {
+        updateComposerState(for: chatID) { state in
+            if state.reply?.id == messageID { state.reply = nil }
+        }
+    }
+
+    private func restoreFailedDraft(_ text: String, in chatID: NativeChat.ID) {
+        guard !text.isEmpty else { return }
+        updateComposerState(for: chatID) { state in
+            if state.draft.isEmpty {
+                state.draft = text
+            } else if state.draft != text {
+                state.draft = "\(text)\n\(state.draft)"
+            }
+        }
     }
 
     private func scheduleConversationLoad(

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -80,6 +80,8 @@ final class AppModel: ObservableObject {
     private var pendingChatOperationErrors: [NativeChat.ID: String] = [:]
     private var pendingReplyContextErrors: [NativeChat.ID: String] = [:]
     private var composerStates: [NativeChat.ID: ConversationComposerState] = [:]
+    private var deletingChatID: NativeChat.ID?
+    private var deletingMessageIDs: Set<Int64> = []
     private var selectionAnchor: Int64?
     private var replyingChatID: NativeChat.ID?
     private var conversationLoadRevision: UInt64 = 0
@@ -148,7 +150,10 @@ final class AppModel: ObservableObject {
 
     var canSendDraft: Bool {
         let hasText = !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        return (hasText || !pendingAttachments.isEmpty) && !isSending && selectedChat?.kind.canSend == true
+        return (hasText || !pendingAttachments.isEmpty)
+            && !isSending
+            && !isDeletingReplyTarget
+            && selectedChat?.kind.canSend == true
     }
 
     var isSendingSelectedChat: Bool {
@@ -169,10 +174,12 @@ final class AppModel: ObservableObject {
     }
 
     var canReplyToSelectedMessage: Bool {
-        selectedMessagesInTranscriptOrder.count == 1
-            && selectedMessagesInTranscriptOrder.first?.replyable == true
+        guard selectedMessagesInTranscriptOrder.count == 1,
+              let message = selectedMessagesInTranscriptOrder.first else { return false }
+        return message.replyable
             && selectedChat?.kind.canReply == true
             && !isSendingSelectedChat
+            && !deletionIncludesMessage(message.id, in: selectedChatID)
     }
 
     var canDismissNearestState: Bool {
@@ -250,7 +257,8 @@ final class AppModel: ObservableObject {
     func sendDraft() {
         let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         let attachments = pendingAttachments
-        guard (!text.isEmpty || !attachments.isEmpty), let chat = selectedChat, !isSending else { return }
+        guard (!text.isEmpty || !attachments.isEmpty), let chat = selectedChat,
+              !isSending, !isDeletingReplyTarget else { return }
         let quotedMessage = replyingChatID == chat.id ? replyingTo : nil
         if replyingTo != nil, quotedMessage == nil { cancelReply() }
         if previewMode, sendTextOperation == nil, sendAttachmentOperation == nil {
@@ -437,7 +445,8 @@ final class AppModel: ObservableObject {
         guard let chat = selectedChat, chat.kind.canReply,
               let currentMessage = messages.first(where: { $0.id == message.id }),
               currentMessage.replyable,
-              !isSendingSelectedChat else { return }
+              !isSendingSelectedChat,
+              !deletionIncludesMessage(currentMessage.id, in: chat.id) else { return }
         replyingTo = currentMessage
         replyingChatID = chat.id
         clearMessageSelection()
@@ -650,61 +659,101 @@ final class AppModel: ObservableObject {
     func deleteSelectedMessages() -> Task<Void, Never>? {
         guard let chat = selectedChat, canDeleteSelectedMessages else { return nil }
         let identifiers = selectedMessagesInTranscriptOrder.map(\.id)
-        if let replyingTo, identifiers.contains(replyingTo.id) { cancelReply() }
         showingDeleteConfirmation = false
         if previewMode, deleteMessagesOperation == nil {
             messages.removeAll { identifiers.contains($0.id) }
+            identifiers.forEach { clearReply($0, in: chat.id) }
             clearMessageSelection()
             return nil
         }
 
+        deletingChatID = chat.id
+        deletingMessageIDs = Set(identifiers)
         isDeletingMessages = true
         clearMessageSelection()
         let operation = deleteMessagesOperation
         let core = core
         let task = Task { [weak self] in
+            var deletionCommitted = false
             do {
                 let loadedMessages: [NativeMessage]
                 if let operation {
                     loadedMessages = try await operation(identifiers, chat)
+                    deletionCommitted = true
                 } else {
                     try await core.deleteMessages(identifiers, from: chat)
+                    deletionCommitted = true
                     try Task.checkCancellation()
                     loadedMessages = try await core.loadMessages(chatID: chat.id)
                 }
                 try Task.checkCancellation()
                 guard let self else { return }
-                self.finishMessageDeletion(loadedMessages, in: chat.id)
+                self.finishMessageDeletion(loadedMessages, deletedIDs: identifiers, in: chat.id)
             } catch is CancellationError {
-                self?.finishMessageDeletionCancellation()
+                if deletionCommitted {
+                    self?.finishCommittedMessageDeletion(deletedIDs: identifiers, in: chat.id)
+                } else {
+                    self?.finishMessageDeletionCancellation()
+                }
             } catch {
-                self?.finishMessageDeletionFailure(error.localizedDescription, in: chat.id)
+                if deletionCommitted {
+                    self?.finishCommittedMessageDeletion(deletedIDs: identifiers, in: chat.id)
+                } else {
+                    self?.finishMessageDeletionFailure(error.localizedDescription, in: chat.id)
+                }
             }
         }
         deleteTask = task
         return task
     }
 
-    private func finishMessageDeletion(_ loadedMessages: [NativeMessage], in chatID: NativeChat.ID) {
-        isDeletingMessages = false
-        deleteTask = nil
+    private func finishMessageDeletion(
+        _ loadedMessages: [NativeMessage],
+        deletedIDs: [Int64],
+        in chatID: NativeChat.ID
+    ) {
+        clearDeletionState()
+        deletedIDs.forEach { clearReply($0, in: chatID) }
         guard selectedChatID == chatID else { return }
         messages = loadedMessages
     }
 
+    private func finishCommittedMessageDeletion(deletedIDs: [Int64], in chatID: NativeChat.ID) {
+        clearDeletionState()
+        deletedIDs.forEach { clearReply($0, in: chatID) }
+        guard selectedChatID == chatID else { return }
+        messages.removeAll { deletedIDs.contains($0.id) }
+    }
+
     private func finishMessageDeletionCancellation() {
-        isDeletingMessages = false
-        deleteTask = nil
+        clearDeletionState()
     }
 
     private func finishMessageDeletionFailure(_ message: String, in chatID: NativeChat.ID) {
-        isDeletingMessages = false
-        deleteTask = nil
+        clearDeletionState()
         if selectedChatID == chatID {
             phase = .failed(message)
         } else {
             pendingChatOperationErrors[chatID] = message
         }
+    }
+
+    private var isDeletingReplyTarget: Bool {
+        guard let replyingTo else { return false }
+        return deletionIncludesMessage(replyingTo.id, in: replyingChatID)
+    }
+
+    private func deletionIncludesMessage(_ messageID: Int64, in chatID: NativeChat.ID?) -> Bool {
+        isDeletingMessages
+            && deletingChatID == chatID
+            && deletingMessageIDs.contains(messageID)
+    }
+
+    private func clearDeletionState() {
+        deletingChatID = nil
+        deletingMessageIDs = []
+        isDeletingMessages = false
+        deleteTask = nil
     }
 
     func clearMessageSelection() {

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -427,6 +427,9 @@ final class AppModel: ObservableObject {
             } catch is CancellationError {
                 if !draftWasSent { self?.restoreFailedDraft(text, in: chat.id) }
                 return
+            } catch NativeChatError.replyTargetUnavailable {
+                if !draftWasSent { self?.restoreFailedDraft(text, in: chat.id) }
+                self?.invalidateReplyContext(in: chat.id)
             } catch {
                 if !draftWasSent { self?.restoreFailedDraft(text, in: chat.id) }
                 self?.finishSendFailure(error.localizedDescription, in: chat.id)

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -379,6 +379,11 @@ final class AppModel: ObservableObject {
                         receipt = try await core.sendText(text, quotedItemID: quotedMessage?.id, to: chat)
                     }
                     draftWasSent = true
+                    self?.applyCommittedMessages(
+                        receipt.committedMessages,
+                        in: chat.id,
+                        announcement: "Message sent"
+                    )
                     if let quotedItemID = quotedMessage?.id {
                         quoteCommitResolved = true
                         self?.clearReply(quotedItemID, in: chat.id)
@@ -412,6 +417,11 @@ final class AppModel: ObservableObject {
                             )
                         }
                         if index == sendSteps.index(before: sendSteps.endIndex) { draftWasSent = true }
+                        self?.applyCommittedMessages(
+                            receipt.committedMessages,
+                            in: chat.id,
+                            announcement: "Attachment \(index + 1) of \(sendSteps.count) sent"
+                        )
                         self?.removeSentAttachment(step.attachment.id, from: chat.id)
                         if let quotedItemID = step.quotedItemID {
                             quoteCommitResolved = true
@@ -1053,6 +1063,33 @@ final class AppModel: ObservableObject {
     private func removeSentAttachment(_ attachmentID: PendingAttachment.ID, from chatID: NativeChat.ID) {
         updateComposerState(for: chatID) { state in
             state.attachments.removeAll { $0.id == attachmentID }
+        }
+    }
+
+    private func applyCommittedMessages(
+        _ committedMessages: [NativeMessage],
+        in chatID: NativeChat.ID,
+        announcement: String
+    ) {
+        guard selectedChatID == chatID, !committedMessages.isEmpty else { return }
+        for message in committedMessages {
+            if let index = messages.firstIndex(where: { $0.id == message.id }) {
+                messages[index] = message
+            } else {
+                messages.append(message)
+            }
+        }
+        targetMessageID = committedMessages.last?.id
+        if let application = NSApp {
+            let userInfo: [NSAccessibility.NotificationUserInfoKey: Any] = [
+                .announcement: announcement,
+                .priority: NSNumber(value: NSAccessibilityPriorityLevel.medium.rawValue),
+            ]
+            NSAccessibility.post(
+                element: application,
+                notification: .announcementRequested,
+                userInfo: userInfo
+            )
         }
     }
 

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -450,14 +450,14 @@ final class AppModel: ObservableObject {
     }
 
     func copySelectedMessages() {
-        guard transcriptFocused, !selectedMessageIDs.isEmpty else { return }
+        guard !selectedMessageIDs.isEmpty else { return }
         let text = selectedMessagesInTranscriptOrder.map(\.text).joined(separator: "\n\n")
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)
     }
 
     func requestDeleteSelectedMessages() {
-        guard transcriptFocused, canDeleteSelectedMessages else { return }
+        guard canDeleteSelectedMessages else { return }
         showingDeleteConfirmation = true
     }
 

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -176,10 +176,7 @@ final class AppModel: ObservableObject {
     var canReplyToSelectedMessage: Bool {
         guard selectedMessagesInTranscriptOrder.count == 1,
               let message = selectedMessagesInTranscriptOrder.first else { return false }
-        return message.replyable
-            && selectedChat?.kind.canReply == true
-            && !isSendingSelectedChat
-            && !deletionIncludesMessage(message.id, in: selectedChatID)
+        return canReply(to: message)
     }
 
     var canDismissNearestState: Bool {
@@ -442,15 +439,22 @@ final class AppModel: ObservableObject {
     }
 
     func beginReply(to message: NativeMessage) {
-        guard let chat = selectedChat, chat.kind.canReply,
+        guard let chat = selectedChat, canReply(to: message),
               let currentMessage = messages.first(where: { $0.id == message.id }),
-              currentMessage.replyable,
-              !isSendingSelectedChat,
-              !deletionIncludesMessage(currentMessage.id, in: chat.id) else { return }
+              currentMessage.replyable else { return }
         replyingTo = currentMessage
         replyingChatID = chat.id
         clearMessageSelection()
         composerFocusRequest &+= 1
+    }
+
+    func canReply(to message: NativeMessage) -> Bool {
+        guard let chat = selectedChat,
+              chat.kind.canReply,
+              !isSendingSelectedChat,
+              let currentMessage = messages.first(where: { $0.id == message.id }) else { return false }
+        return currentMessage.replyable
+            && !deletionIncludesMessage(currentMessage.id, in: chat.id)
     }
 
     func replyToSelectedMessage() {
@@ -463,6 +467,22 @@ final class AppModel: ObservableObject {
         guard !isSendingSelectedChat else { return }
         replyingTo = nil
         replyingChatID = nil
+    }
+
+    @discardableResult
+    func openReplyTarget() -> Task<Void, Never>? {
+        guard let message = replyingTo,
+              let chatID = selectedChatID,
+              replyingChatID == chatID else { return nil }
+        return openQuotedMessage(
+            NativeQuote(
+                messageID: message.id,
+                text: message.replyPreview,
+                sent: message.sent,
+                author: message.author
+            ),
+            from: message.id
+        )
     }
 
     @discardableResult
@@ -808,6 +828,7 @@ final class AppModel: ObservableObject {
                 saveComposerState(for: previousChatID)
             }
             selectedChatID = id
+            messages = []
             clearMessageSelection()
             restoreComposerState(for: id)
             targetMessageID = nil

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -5,6 +5,7 @@ typealias DeleteMessagesOperation = @Sendable ([Int64], NativeChat) async throws
 typealias SendTextOperation = @Sendable (String, Int64?, NativeChat) async throws -> Void
 typealias SendAttachmentOperation = @Sendable (PendingAttachment, String, Int64?, NativeChat) async throws -> Void
 typealias LoadMessageOperation = @Sendable (NativeChat.ID, Int64) async throws -> NativeMessage?
+typealias LoadMessagesOperation = @Sendable (NativeChat.ID, Int64?) async throws -> [NativeMessage]
 typealias OpenAttachmentOperation = @Sendable (NativeCryptoFile, String?) async throws -> Void
 
 @MainActor
@@ -66,6 +67,7 @@ final class AppModel: ObservableObject {
     private let sendTextOperation: SendTextOperation?
     private let sendAttachmentOperation: SendAttachmentOperation?
     private let loadMessageOperation: LoadMessageOperation?
+    private let loadMessagesOperation: LoadMessagesOperation?
     private let openAttachmentOperation: OpenAttachmentOperation?
     private weak var notificationManager: NativeNotificationManager?
     private var eventTask: Task<Void, Never>?
@@ -92,6 +94,7 @@ final class AppModel: ObservableObject {
         sendTextOperation: SendTextOperation? = nil,
         sendAttachmentOperation: SendAttachmentOperation? = nil,
         loadMessageOperation: LoadMessageOperation? = nil,
+        loadMessagesOperation: LoadMessagesOperation? = nil,
         openAttachmentOperation: OpenAttachmentOperation? = nil
     ) {
         self.previewMode = previewMode
@@ -101,6 +104,7 @@ final class AppModel: ObservableObject {
         self.sendTextOperation = sendTextOperation
         self.sendAttachmentOperation = sendAttachmentOperation
         self.loadMessageOperation = loadMessageOperation
+        self.loadMessagesOperation = loadMessagesOperation
         self.openAttachmentOperation = openAttachmentOperation
         keychainPassphraseStorageAvailable = Bundle.main.object(
             forInfoDictionaryKey: "SimpleXKeychainPassphraseStorageEnabled"
@@ -456,8 +460,7 @@ final class AppModel: ObservableObject {
     func openQuotedMessage(_ quote: NativeQuote, from containingMessageID: Int64) -> Task<Void, Never>? {
         guard let chatID = selectedChatID else { return nil }
         if let messageID = quote.messageID {
-            navigateToMessage(messageID, in: chatID)
-            return nil
+            return navigateToMessage(messageID, in: chatID)
         }
 
         quoteNavigationTask?.cancel()
@@ -490,7 +493,9 @@ final class AppModel: ObservableObject {
                 if let index = messages.firstIndex(where: { $0.id == containingMessageID }) {
                     messages[index] = refreshedMessage
                 }
-                navigateToMessage(quotedMessageID, in: chatID)
+                if let navigation = navigateToMessage(quotedMessageID, in: chatID) {
+                    await navigation.value
+                }
             } catch is CancellationError {
                 return
             } catch {
@@ -552,14 +557,20 @@ final class AppModel: ObservableObject {
         return task
     }
 
-    private func navigateToMessage(_ messageID: Int64, in chatID: NativeChat.ID) {
-        guard selectedChatID == chatID else { return }
+    @discardableResult
+    private func navigateToMessage(_ messageID: Int64, in chatID: NativeChat.ID) -> Task<Void, Never>? {
+        guard selectedChatID == chatID else { return nil }
         if messages.contains(where: { $0.id == messageID }) {
             targetMessageID = messageID
-            return
+            return nil
         }
         conversationLoadTask?.cancel()
-        scheduleConversationLoad(chatID: chatID, around: messageID, scrollTo: messageID)
+        return scheduleConversationLoad(
+            chatID: chatID,
+            around: messageID,
+            scrollTo: messageID,
+            navigationFailureMessage: "The original quoted message is no longer available in this conversation."
+        )
     }
 
     func selectMessage(_ id: Int64, modifiers: NSEvent.ModifierFlags) {
@@ -870,26 +881,39 @@ final class AppModel: ObservableObject {
         }
     }
 
+    @discardableResult
     private func scheduleConversationLoad(
         chatID: NativeChat.ID,
         around messageID: Int64? = nil,
-        scrollTo scrollTarget: Int64? = nil
-    ) {
+        scrollTo scrollTarget: Int64? = nil,
+        navigationFailureMessage: String? = nil
+    ) -> Task<Void, Never> {
         conversationLoadTask?.cancel()
-        conversationLoadTask = Task {
-            let loaded = await loadConversation(chatID: chatID, around: messageID)
+        let task = Task {
+            let loaded = await loadConversation(
+                chatID: chatID,
+                around: messageID,
+                navigationFailureMessage: navigationFailureMessage
+            )
             guard loaded, !Task.isCancelled, selectedChatID == chatID else { return }
-            if let scrollTarget, messages.contains(where: { $0.id == scrollTarget }) {
-                targetMessageID = scrollTarget
+            if let scrollTarget {
+                if messages.contains(where: { $0.id == scrollTarget }) {
+                    targetMessageID = scrollTarget
+                } else if let navigationFailureMessage {
+                    quoteNavigationError = navigationFailureMessage
+                }
             }
         }
+        conversationLoadTask = task
+        return task
     }
 
     @discardableResult
     private func loadConversation(
         chatID: NativeChat.ID,
         around messageID: Int64? = nil,
-        showProgress: Bool = true
+        showProgress: Bool = true,
+        navigationFailureMessage: String? = nil
     ) async -> Bool {
         guard selectedChatID == chatID else { return false }
         conversationLoadRevision &+= 1
@@ -901,7 +925,12 @@ final class AppModel: ObservableObject {
             }
         }
         do {
-            let loadedMessages = try await core.loadMessages(chatID: chatID, around: messageID)
+            let loadedMessages: [NativeMessage]
+            if let loadMessagesOperation {
+                loadedMessages = try await loadMessagesOperation(chatID, messageID)
+            } else {
+                loadedMessages = try await core.loadMessages(chatID: chatID, around: messageID)
+            }
             guard !Task.isCancelled, selectedChatID == chatID,
                   conversationLoadRevision == revision else { return false }
             applyLoadedMessages(loadedMessages, to: chatID)
@@ -909,7 +938,13 @@ final class AppModel: ObservableObject {
         } catch is CancellationError {
             return false
         } catch {
-            phase = .failed(error.localizedDescription)
+            guard !Task.isCancelled, selectedChatID == chatID,
+                  conversationLoadRevision == revision else { return false }
+            if let navigationFailureMessage {
+                quoteNavigationError = navigationFailureMessage
+            } else {
+                phase = .failed(error.localizedDescription)
+            }
             return false
         }
     }

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -46,6 +46,7 @@ final class AppModel: ObservableObject {
     @Published var attachmentError: String?
     @Published var attachmentOpenError: String?
     @Published var quoteNavigationError: String?
+    @Published var replyContextError: String?
     @Published var openingAttachmentIDs: Set<Int64> = []
     @Published var replyingTo: NativeMessage?
     @Published var composerFocusRequest = 0
@@ -160,6 +161,13 @@ final class AppModel: ObservableObject {
             && !selectedMessageIDs.isEmpty
             && selectedMessagesInTranscriptOrder.allSatisfy(\.deletable)
             && !includesInFlightQuote
+    }
+
+    var canReplyToSelectedMessage: Bool {
+        selectedMessagesInTranscriptOrder.count == 1
+            && selectedMessagesInTranscriptOrder.first?.replyable == true
+            && selectedChat?.kind.canReply == true
+            && !isSendingSelectedChat
     }
 
     var conversationSearchMatches: [NativeMessage] {
@@ -396,7 +404,8 @@ final class AppModel: ObservableObject {
     }
 
     func beginReply(to message: NativeMessage) {
-        guard let chat = selectedChat, chat.kind.canReply, messages.contains(where: { $0.id == message.id }),
+        guard let chat = selectedChat, chat.kind.canReply, message.replyable,
+              messages.contains(where: { $0.id == message.id }),
               !isSendingSelectedChat else { return }
         replyingTo = message
         replyingChatID = chat.id
@@ -702,6 +711,7 @@ final class AppModel: ObservableObject {
             quoteNavigationTask = nil
             quoteNavigationRevision &+= 1
             quoteNavigationError = nil
+            replyContextError = nil
             if let previousChatID = selectedChatID {
                 saveComposerState(for: previousChatID)
             }
@@ -849,14 +859,29 @@ final class AppModel: ObservableObject {
             let loadedMessages = try await core.loadMessages(chatID: chatID, around: messageID)
             guard !Task.isCancelled, selectedChatID == chatID,
                   conversationLoadRevision == revision else { return false }
-            messages = loadedMessages
-            selectedMessageIDs.formIntersection(messages.map(\.id))
+            applyLoadedMessages(loadedMessages, to: chatID)
             return true
         } catch is CancellationError {
             return false
         } catch {
             phase = .failed(error.localizedDescription)
             return false
+        }
+    }
+
+    func applyLoadedMessages(_ loadedMessages: [NativeMessage], to chatID: NativeChat.ID) {
+        guard selectedChatID == chatID else { return }
+        messages = loadedMessages
+        selectedMessageIDs.formIntersection(messages.map(\.id))
+
+        guard replyingChatID == chatID, let currentReply = replyingTo,
+              let refreshedReply = loadedMessages.first(where: { $0.id == currentReply.id }) else { return }
+        if refreshedReply.replyable {
+            replyingTo = refreshedReply
+        } else if sendingChatID != chatID {
+            replyingTo = nil
+            replyingChatID = nil
+            replyContextError = "The message you were replying to is no longer available. Your draft was kept."
         }
     }
 

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -341,6 +341,8 @@ final class AppModel: ObservableObject {
         let sendTextOperation = sendTextOperation
         let sendAttachmentOperation = sendAttachmentOperation
         let loadMessageOperation = loadMessageOperation
+        let loadMessagesOperation = loadMessagesOperation
+        let loadChatsOperation = loadChatsOperation
         sendTask = Task { [weak self] in
             var draftWasSent = false
             var quoteCommitResolved = false
@@ -421,14 +423,24 @@ final class AppModel: ObservableObject {
                         try Task.checkCancellation()
                     }
                 }
-                let sentMessages = try await core.loadMessages(chatID: chat.id)
+                let sentMessages: [NativeMessage]
+                if let loadMessagesOperation {
+                    sentMessages = try await loadMessagesOperation(chat.id, nil)
+                } else {
+                    sentMessages = try await core.loadMessages(chatID: chat.id)
+                }
                 try Task.checkCancellation()
                 if self?.selectedChatID == chat.id {
                     self?.conversationAnchorMessageID = nil
                     self?.messages = sentMessages
                 }
                 if let userID = self?.profile?.userID {
-                    let loadedChats = try await core.loadChats(userID: userID)
+                    let loadedChats: [NativeChat]
+                    if let loadChatsOperation {
+                        loadedChats = try await loadChatsOperation(userID)
+                    } else {
+                        loadedChats = try await core.loadChats(userID: userID)
+                    }
                     try Task.checkCancellation()
                     self?.chats = loadedChats
                 }
@@ -439,8 +451,12 @@ final class AppModel: ObservableObject {
                 if !draftWasSent { self?.restoreFailedDraft(text, in: chat.id) }
                 self?.invalidateReplyContext(in: chat.id)
             } catch {
-                if !draftWasSent { self?.restoreFailedDraft(text, in: chat.id) }
-                self?.finishSendFailure(error.localizedDescription, in: chat.id)
+                if draftWasSent {
+                    self?.finishPostSendRefreshFailure(error.localizedDescription, in: chat.id)
+                } else {
+                    self?.restoreFailedDraft(text, in: chat.id)
+                    self?.finishSendFailure(error.localizedDescription, in: chat.id)
+                }
             }
         }
     }
@@ -1101,6 +1117,11 @@ final class AppModel: ObservableObject {
         } else {
             pendingChatOperationErrors[chatID] = message
         }
+    }
+
+    private func finishPostSendRefreshFailure(_ detail: String, in chatID: NativeChat.ID) {
+        let message = "Your message was sent, but the conversation could not refresh. Use Refresh to load it. \(detail)"
+        finishSendFailure(message, in: chatID)
     }
 
     @discardableResult

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -609,14 +609,14 @@ final class AppModel: ObservableObject {
               let chatID = selectedChatID,
               replyingChatID == chatID else { return nil }
         cancelReplyTargetNavigation()
-        let task = openQuotedMessage(
-            NativeQuote(
-                messageID: message.id,
-                text: message.replyPreview,
-                sent: message.sent,
-                author: message.author
-            ),
-            from: message.id
+        quoteNavigationTask?.cancel()
+        quoteNavigationTask = nil
+        quoteNavigationRevision &+= 1
+        quoteNavigationError = nil
+        let task = navigateToMessage(
+            message.id,
+            in: chatID,
+            invalidateReplyIfMissing: true
         )
         replyTargetNavigationTask = task
         return task
@@ -743,7 +743,11 @@ final class AppModel: ObservableObject {
     }
 
     @discardableResult
-    private func navigateToMessage(_ messageID: Int64, in chatID: NativeChat.ID) -> Task<Void, Never>? {
+    private func navigateToMessage(
+        _ messageID: Int64,
+        in chatID: NativeChat.ID,
+        invalidateReplyIfMissing: Bool = false
+    ) -> Task<Void, Never>? {
         guard selectedChatID == chatID else { return nil }
         if messages.contains(where: { $0.id == messageID }) {
             cancelConversationLoadWithoutReplacement()
@@ -757,7 +761,8 @@ final class AppModel: ObservableObject {
             around: messageID,
             scrollTo: messageID,
             navigationFailureMessage: "The original quoted message is no longer available in this conversation.",
-            consumeQuoteNavigationStateOnSuccess: true
+            consumeQuoteNavigationStateOnSuccess: true,
+            invalidateReplyIfMissing: invalidateReplyIfMissing
         )
     }
 
@@ -1242,14 +1247,16 @@ final class AppModel: ObservableObject {
         scrollTo scrollTarget: Int64? = nil,
         navigationFailureMessage: String? = nil,
         consumeQuoteNavigationStateOnSuccess: Bool = false,
-        scrollToLatest: Bool = false
+        scrollToLatest: Bool = false,
+        invalidateReplyIfMissing: Bool = false
     ) -> Task<Void, Never> {
         conversationLoadTask?.cancel()
         let task = Task {
             let loaded = await loadConversation(
                 chatID: chatID,
                 around: messageID,
-                navigationFailureMessage: navigationFailureMessage
+                navigationFailureMessage: navigationFailureMessage,
+                invalidateReplyIfMissing: invalidateReplyIfMissing
             )
             guard loaded, !Task.isCancelled, selectedChatID == chatID else { return }
             if scrollToLatest, let latestMessageID = messages.last?.id {
@@ -1275,7 +1282,8 @@ final class AppModel: ObservableObject {
         around messageID: Int64? = nil,
         showProgress: Bool = true,
         navigationFailureMessage: String? = nil,
-        reportFailure: Bool = true
+        reportFailure: Bool = true,
+        invalidateReplyIfMissing: Bool = false
     ) async -> Bool {
         guard selectedChatID == chatID else { return false }
         conversationLoadRevision &+= 1
@@ -1297,7 +1305,11 @@ final class AppModel: ObservableObject {
                   conversationLoadRevision == revision else { return false }
             if let navigationFailureMessage, let messageID,
                !loadedMessages.contains(where: { $0.id == messageID }) {
-                quoteNavigationError = navigationFailureMessage
+                if invalidateReplyIfMissing {
+                    invalidateReplyContext(in: chatID)
+                } else {
+                    quoteNavigationError = navigationFailureMessage
+                }
                 return false
             }
             applyLoadedMessages(loadedMessages, to: chatID)
@@ -1309,7 +1321,9 @@ final class AppModel: ObservableObject {
             guard !Task.isCancelled, selectedChatID == chatID,
                   conversationLoadRevision == revision else { return false }
             if let navigationFailureMessage {
-                quoteNavigationError = navigationFailureMessage
+                quoteNavigationError = invalidateReplyIfMissing
+                    ? error.localizedDescription
+                    : navigationFailureMessage
             } else if reportFailure {
                 presentChatOperationFailure(error.localizedDescription, in: chatID)
             }

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -500,6 +500,7 @@ final class AppModel: ObservableObject {
         guard let chat = selectedChat, canReply(to: message),
               let currentMessage = messages.first(where: { $0.id == message.id }),
               currentMessage.replyable else { return }
+        cancelStaleNavigationForReply()
         replyingTo = currentMessage
         replyingChatID = chat.id
         if conversationSearchPresented {
@@ -513,10 +514,17 @@ final class AppModel: ObservableObject {
     func canReply(to message: NativeMessage) -> Bool {
         guard let chat = selectedChat,
               chat.kind.canReply,
-              !isSendingSelectedChat,
+              canNavigateConversationHistory,
               let currentMessage = messages.first(where: { $0.id == message.id }) else { return false }
         return currentMessage.replyable
             && !deletionIncludesMessage(currentMessage.id, in: chat.id)
+    }
+
+    private func cancelStaleNavigationForReply() {
+        quoteNavigationTask?.cancel()
+        quoteNavigationTask = nil
+        quoteNavigationRevision &+= 1
+        cancelConversationLoadWithoutReplacement()
     }
 
     func replyToSelectedMessage() {

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -538,11 +538,15 @@ final class AppModel: ObservableObject {
     }
 
     @discardableResult
-    private func loadConversation(chatID: NativeChat.ID, around messageID: Int64? = nil) async -> Bool {
+    private func loadConversation(
+        chatID: NativeChat.ID,
+        around messageID: Int64? = nil,
+        showProgress: Bool = true
+    ) async -> Bool {
         guard selectedChatID == chatID else { return false }
         conversationLoadRevision &+= 1
         let revision = conversationLoadRevision
-        isLoadingConversation = true
+        isLoadingConversation = showProgress
         defer {
             if selectedChatID == chatID, conversationLoadRevision == revision {
                 isLoadingConversation = false
@@ -580,7 +584,7 @@ final class AppModel: ObservableObject {
         do {
             chats = try await core.loadChats(userID: userID)
             if let chatID = selectedChatID {
-                _ = await loadConversation(chatID: chatID)
+                _ = await loadConversation(chatID: chatID, showProgress: false)
             }
             consumePendingNotificationRoutes()
         } catch {

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -581,10 +581,13 @@ final class AppModel: ObservableObject {
         replyTargetNavigationTask = nil
     }
 
-    func replyToSelectedMessage() {
+    @discardableResult
+    func replyToSelectedMessage() -> Bool {
         guard selectedMessagesInTranscriptOrder.count == 1,
-              let message = selectedMessagesInTranscriptOrder.first else { return }
+              let message = selectedMessagesInTranscriptOrder.first,
+              canReply(to: message) else { return false }
         beginReply(to: message)
+        return replyingTo?.id == message.id
     }
 
     func cancelReply() {

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -28,6 +28,11 @@ final class AppModel: ObservableObject {
         }
     }
 
+    private struct AttachmentOpeningKey: Hashable {
+        let chatID: NativeChat.ID
+        let messageID: Int64
+    }
+
     @Published var phase: Phase = .locked(message: nil)
     @Published var profile: NativeProfile?
     @Published var chats: [NativeChat] = []
@@ -51,7 +56,7 @@ final class AppModel: ObservableObject {
     @Published var quoteNavigationError: String?
     @Published var replyContextError: String?
     @Published var sendStatusMessage: String?
-    @Published var openingAttachmentIDs: Set<Int64> = []
+    @Published private var openingAttachmentKeys: Set<AttachmentOpeningKey> = []
     @Published var replyingTo: NativeMessage?
     @Published var composerFocusRequest = 0
     @Published var showingDeleteConfirmation = false
@@ -87,6 +92,7 @@ final class AppModel: ObservableObject {
     private var pendingQuoteNavigationErrors: [NativeChat.ID: String] = [:]
     private var pendingReplyContextErrors: [NativeChat.ID: String] = [:]
     private var pendingSendStatusMessages: [NativeChat.ID: String] = [:]
+    private var pendingAttachmentOpenErrors: [NativeChat.ID: String] = [:]
     private var pendingReplyInvalidationChatIDs: Set<NativeChat.ID> = []
     private var composerStates: [NativeChat.ID: ConversationComposerState] = [:]
     private var deletingChatID: NativeChat.ID?
@@ -680,16 +686,17 @@ final class AppModel: ObservableObject {
     @discardableResult
     func openAttachment(_ message: NativeMessage) -> Task<Void, Never>? {
         guard let initialSource = message.fileSource,
-              !openingAttachmentIDs.contains(message.id) else { return nil }
-        let chatID = selectedChatID
+              let chatID = selectedChatID else { return nil }
+        let openingKey = AttachmentOpeningKey(chatID: chatID, messageID: message.id)
+        guard !openingAttachmentKeys.contains(openingKey) else { return nil }
         let loadMessageOperation = loadMessageOperation
         let openAttachmentOperation = openAttachmentOperation
-        openingAttachmentIDs.insert(message.id)
+        openingAttachmentKeys.insert(openingKey)
         let task = Task {
-            defer { openingAttachmentIDs.remove(message.id) }
+            defer { openingAttachmentKeys.remove(openingKey) }
             do {
                 var source = initialSource
-                if source.cryptoArgs == nil, let chatID {
+                if source.cryptoArgs == nil {
                     let refreshedMessage: NativeMessage?
                     if let loadMessageOperation {
                         refreshedMessage = try await loadMessageOperation(chatID, message.id)
@@ -722,10 +729,17 @@ final class AppModel: ObservableObject {
             } catch is CancellationError {
                 return
             } catch {
-                attachmentOpenError = error.localizedDescription
+                presentAttachmentOpenFailure(error.localizedDescription, in: chatID)
             }
         }
         return task
+    }
+
+    func isOpeningAttachment(_ messageID: Int64) -> Bool {
+        guard let chatID = selectedChatID else { return false }
+        return openingAttachmentKeys.contains(
+            AttachmentOpeningKey(chatID: chatID, messageID: messageID)
+        )
     }
 
     @discardableResult
@@ -993,6 +1007,7 @@ final class AppModel: ObservableObject {
             quoteNavigationError = nil
             replyContextError = nil
             sendStatusMessage = nil
+            attachmentOpenError = nil
             selectedChatID = id
             conversationAnchorMessageID = nil
             messages = []
@@ -1008,6 +1023,7 @@ final class AppModel: ObservableObject {
                 quoteNavigationError = pendingQuoteNavigationErrors.removeValue(forKey: id)
                 replyContextError = pendingReplyContextErrors.removeValue(forKey: id)
                 sendStatusMessage = pendingSendStatusMessages.removeValue(forKey: id)
+                attachmentOpenError = pendingAttachmentOpenErrors.removeValue(forKey: id)
             }
         }
         if let id { notificationManager?.removeDeliveredNotifications(chatID: id) }
@@ -1037,6 +1053,9 @@ final class AppModel: ObservableObject {
         }
         if let sendStatusMessage {
             pendingSendStatusMessages[chatID] = sendStatusMessage
+        }
+        if let attachmentOpenError {
+            pendingAttachmentOpenErrors[chatID] = attachmentOpenError
         }
     }
 
@@ -1205,6 +1224,14 @@ final class AppModel: ObservableObject {
             sendStatusMessage = message
         } else {
             pendingSendStatusMessages[chatID] = message
+        }
+    }
+
+    private func presentAttachmentOpenFailure(_ message: String, in chatID: NativeChat.ID) {
+        if selectedChatID == chatID {
+            attachmentOpenError = message
+        } else {
+            pendingAttachmentOpenErrors[chatID] = message
         }
     }
 

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -171,6 +171,14 @@ final class AppModel: ObservableObject {
             && !isSendingSelectedChat
     }
 
+    var canDismissNearestState: Bool {
+        conversationSearchPresented
+            || sidebarSearchPresented
+            || (replyingTo != nil && !isSendingSelectedChat)
+            || (!pendingAttachments.isEmpty && !isSendingSelectedChat)
+            || !selectedMessageIDs.isEmpty
+    }
+
     var conversationSearchMatches: [NativeMessage] {
         ConversationSearch.matches(messages, query: conversationSearchText)
     }
@@ -694,6 +702,9 @@ final class AppModel: ObservableObject {
     func dismissNearestState() {
         if conversationSearchPresented {
             dismissConversationSearch()
+        } else if sidebarSearchPresented {
+            sidebarSearchPresented = false
+            searchText = ""
         } else if replyingTo != nil, !isSendingSelectedChat {
             cancelReply()
         } else if !pendingAttachments.isEmpty, !isSendingSelectedChat {

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -1157,7 +1157,7 @@ final class AppModel: ObservableObject {
         guard let userID = profile?.userID else { return }
         do {
             chats = try await loadChats(userID: userID)
-            if let chatID = selectedChatID, !isLoadingConversation {
+            if let chatID = selectedChatID, canRefreshConversation {
                 let anchor = conversationAnchorMessageID
                 let loaded = await loadConversation(
                     chatID: chatID,
@@ -1166,7 +1166,9 @@ final class AppModel: ObservableObject {
                     reportFailure: anchor == nil
                 )
                 if !loaded, anchor != nil, !Task.isCancelled,
-                   selectedChatID == chatID, !isLoadingConversation {
+                   selectedChatID == chatID,
+                   conversationAnchorMessageID == anchor,
+                   !isLoadingConversation {
                     conversationAnchorMessageID = nil
                     _ = await loadConversation(chatID: chatID, showProgress: false)
                 }

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -87,7 +87,7 @@ final class AppModel: ObservableObject {
     private var selectionAnchor: Int64?
     private var replyingChatID: NativeChat.ID?
     private var conversationLoadRevision: UInt64 = 0
-    private(set) var conversationAnchorMessageID: Int64?
+    @Published private(set) var conversationAnchorMessageID: Int64?
     private var quoteNavigationRevision: UInt64 = 0
     private static let densityKey = "desktopChatDensity"
 
@@ -163,6 +163,10 @@ final class AppModel: ObservableObject {
 
     var isSendingSelectedChat: Bool {
         isSending && sendingChatID == selectedChatID
+    }
+
+    var isViewingConversationHistory: Bool {
+        conversationAnchorMessageID != nil
     }
 
     var selectedMessagesInTranscriptOrder: [NativeMessage] {
@@ -254,6 +258,16 @@ final class AppModel: ObservableObject {
                 phase = .failed(error.localizedDescription)
             }
         }
+    }
+
+    @discardableResult
+    func jumpToLatest() -> Task<Void, Never>? {
+        guard let chatID = selectedChatID, isViewingConversationHistory else { return nil }
+        quoteNavigationTask?.cancel()
+        quoteNavigationTask = nil
+        quoteNavigationRevision &+= 1
+        quoteNavigationError = nil
+        return scheduleConversationLoad(chatID: chatID, scrollToLatest: true)
     }
 
     func sendDraft() {
@@ -972,7 +986,8 @@ final class AppModel: ObservableObject {
         chatID: NativeChat.ID,
         around messageID: Int64? = nil,
         scrollTo scrollTarget: Int64? = nil,
-        navigationFailureMessage: String? = nil
+        navigationFailureMessage: String? = nil,
+        scrollToLatest: Bool = false
     ) -> Task<Void, Never> {
         conversationLoadTask?.cancel()
         let task = Task {
@@ -982,7 +997,9 @@ final class AppModel: ObservableObject {
                 navigationFailureMessage: navigationFailureMessage
             )
             guard loaded, !Task.isCancelled, selectedChatID == chatID else { return }
-            if let scrollTarget {
+            if scrollToLatest, let latestMessageID = messages.last?.id {
+                targetMessageID = latestMessageID
+            } else if let scrollTarget {
                 if messages.contains(where: { $0.id == scrollTarget }) {
                     targetMessageID = scrollTarget
                 } else if let navigationFailureMessage {

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -1,0 +1,130 @@
+import Foundation
+
+@MainActor
+final class AppModel: ObservableObject {
+    enum Phase: Equatable {
+        case locked(message: String?)
+        case opening
+        case ready
+        case failed(String)
+    }
+
+    @Published var phase: Phase = .locked(message: nil)
+    @Published var profile: NativeProfile?
+    @Published var chats: [NativeChat] = []
+    @Published var selectedChatID: NativeChat.ID?
+    @Published var messages: [NativeMessage] = []
+    @Published var draft = ""
+    @Published var searchText = ""
+    @Published var isLoadingConversation = false
+    @Published var isSending = false
+
+    private let core = SimpleXCore()
+    private var eventTask: Task<Void, Never>?
+
+    deinit {
+        eventTask?.cancel()
+    }
+
+    var selectedChat: NativeChat? {
+        chats.first { $0.id == selectedChatID }
+    }
+
+    var filteredChats: [NativeChat] {
+        guard !searchText.isEmpty else { return chats }
+        return chats.filter {
+            $0.displayName.localizedCaseInsensitiveContains(searchText)
+                || $0.preview.localizedCaseInsensitiveContains(searchText)
+        }
+    }
+
+    func unlock(passphrase: String) {
+        guard phase != .opening else { return }
+        phase = .opening
+        Task {
+            do {
+                let (profile, chats) = try await core.open(passphrase: passphrase)
+                self.profile = profile
+                self.chats = chats
+                self.phase = .ready
+                if selectedChatID == nil { selectedChatID = chats.first?.id }
+                await loadSelectedConversation()
+                startEventLoop()
+            } catch {
+                phase = .locked(message: error.localizedDescription)
+            }
+        }
+    }
+
+    func selectChat(_ id: NativeChat.ID?) {
+        selectedChatID = id
+        Task { await loadSelectedConversation() }
+    }
+
+    func refresh() {
+        guard let userID = profile?.userID else { return }
+        Task {
+            do {
+                chats = try await core.loadChats(userID: userID)
+                await loadSelectedConversation()
+            } catch {
+                phase = .failed(error.localizedDescription)
+            }
+        }
+    }
+
+    func sendDraft() {
+        let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty, let chat = selectedChat, !isSending else { return }
+        draft = ""
+        isSending = true
+        Task {
+            do {
+                try await core.sendText(text, to: chat)
+                messages = try await core.loadMessages(chatID: chat.id)
+                if let userID = profile?.userID { chats = try await core.loadChats(userID: userID) }
+            } catch {
+                draft = text
+                phase = .failed(error.localizedDescription)
+            }
+            isSending = false
+        }
+    }
+
+    private func loadSelectedConversation() async {
+        guard let chat = selectedChat else {
+            messages = []
+            return
+        }
+        isLoadingConversation = true
+        do {
+            messages = try await core.loadMessages(chatID: chat.id)
+        } catch {
+            phase = .failed(error.localizedDescription)
+        }
+        isLoadingConversation = false
+    }
+
+    private func startEventLoop() {
+        eventTask?.cancel()
+        eventTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                guard await core.waitForEvent() else { continue }
+                await refreshAfterEvent()
+            }
+        }
+    }
+
+    private func refreshAfterEvent() async {
+        guard let userID = profile?.userID else { return }
+        do {
+            chats = try await core.loadChats(userID: userID)
+            if selectedChatID != nil {
+                await loadSelectedConversation()
+            }
+        } catch {
+            phase = .failed(error.localizedDescription)
+        }
+    }
+}

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -76,6 +76,7 @@ final class AppModel: ObservableObject {
     private(set) var quoteNavigationTask: Task<Void, Never>?
     private var notificationRouteQueue = NotificationRouteQueue()
     private var pendingChatOperationErrors: [NativeChat.ID: String] = [:]
+    private var pendingReplyContextErrors: [NativeChat.ID: String] = [:]
     private var composerStates: [NativeChat.ID: ConversationComposerState] = [:]
     private var selectionAnchor: Int64?
     private var replyingChatID: NativeChat.ID?
@@ -272,12 +273,29 @@ final class AppModel: ObservableObject {
         let core = core
         let sendTextOperation = sendTextOperation
         let sendAttachmentOperation = sendAttachmentOperation
+        let loadMessageOperation = loadMessageOperation
         sendTask = Task { [weak self] in
             defer {
                 self?.finishSending()
             }
             var draftWasSent = false
             do {
+                if let quotedMessage {
+                    let refreshedReply: NativeMessage?
+                    if let loadMessageOperation {
+                        refreshedReply = try await loadMessageOperation(chat.id, quotedMessage.id)
+                    } else if self?.previewMode == true {
+                        refreshedReply = quotedMessage
+                    } else {
+                        refreshedReply = try await core.loadMessage(chatID: chat.id, itemID: quotedMessage.id)
+                    }
+                    try Task.checkCancellation()
+                    guard refreshedReply?.replyable == true else {
+                        self?.restoreFailedDraft(text, in: chat.id)
+                        self?.invalidateReplyContext(in: chat.id)
+                        return
+                    }
+                }
                 if attachments.isEmpty {
                     try Task.checkCancellation()
                     if let sendTextOperation {
@@ -404,10 +422,11 @@ final class AppModel: ObservableObject {
     }
 
     func beginReply(to message: NativeMessage) {
-        guard let chat = selectedChat, chat.kind.canReply, message.replyable,
-              messages.contains(where: { $0.id == message.id }),
+        guard let chat = selectedChat, chat.kind.canReply,
+              let currentMessage = messages.first(where: { $0.id == message.id }),
+              currentMessage.replyable,
               !isSendingSelectedChat else { return }
-        replyingTo = message
+        replyingTo = currentMessage
         replyingChatID = chat.id
         clearMessageSelection()
         composerFocusRequest &+= 1
@@ -724,6 +743,9 @@ final class AppModel: ObservableObject {
             if let id, let message = pendingChatOperationErrors.removeValue(forKey: id) {
                 phase = .failed(message)
             }
+            if let id {
+                replyContextError = pendingReplyContextErrors.removeValue(forKey: id)
+            }
         }
         if let id { notificationManager?.removeDeliveredNotifications(chatID: id) }
 
@@ -797,6 +819,18 @@ final class AppModel: ObservableObject {
     private func clearReply(_ messageID: Int64, in chatID: NativeChat.ID) {
         updateComposerState(for: chatID) { state in
             if state.reply?.id == messageID { state.reply = nil }
+        }
+    }
+
+    private func invalidateReplyContext(in chatID: NativeChat.ID) {
+        let message = "The message you were replying to is no longer available. Your draft was kept."
+        updateComposerState(for: chatID) { state in
+            state.reply = nil
+        }
+        if selectedChatID == chatID {
+            replyContextError = message
+        } else {
+            pendingReplyContextErrors[chatID] = message
         }
     }
 
@@ -879,9 +913,7 @@ final class AppModel: ObservableObject {
         if refreshedReply.replyable {
             replyingTo = refreshedReply
         } else if sendingChatID != chatID {
-            replyingTo = nil
-            replyingChatID = nil
-            replyContextError = "The message you were replying to is no longer available. Your draft was kept."
+            invalidateReplyContext(in: chatID)
         }
     }
 

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -270,6 +270,7 @@ final class AppModel: ObservableObject {
             defer {
                 isRefreshing = false
                 refreshTask = nil
+                consumePendingNotificationRoutes()
             }
             do {
                 let loadedChats = try await loadChats(userID: userID)
@@ -813,6 +814,7 @@ final class AppModel: ObservableObject {
         in chatID: NativeChat.ID
     ) {
         clearDeletionState()
+        defer { consumePendingNotificationRoutes() }
         deletedIDs.forEach { clearReply($0, in: chatID) }
         guard selectedChatID == chatID else { return }
         conversationAnchorMessageID = nil
@@ -821,6 +823,7 @@ final class AppModel: ObservableObject {
 
     private func finishCommittedMessageDeletion(deletedIDs: [Int64], in chatID: NativeChat.ID) {
         clearDeletionState()
+        defer { consumePendingNotificationRoutes() }
         deletedIDs.forEach { clearReply($0, in: chatID) }
         guard selectedChatID == chatID else { return }
         if conversationAnchorMessageID.map(deletedIDs.contains) == true {
@@ -831,6 +834,7 @@ final class AppModel: ObservableObject {
 
     private func finishMessageDeletionCancellation() {
         clearDeletionState()
+        consumePendingNotificationRoutes()
     }
 
     private func finishMessageDeletionFailure(_ message: String, in chatID: NativeChat.ID) {
@@ -840,6 +844,7 @@ final class AppModel: ObservableObject {
         } else {
             pendingChatOperationErrors[chatID] = message
         }
+        consumePendingNotificationRoutes()
     }
 
     private func deletionIncludesMessage(_ messageID: Int64, in chatID: NativeChat.ID?) -> Bool {
@@ -876,7 +881,7 @@ final class AppModel: ObservableObject {
     }
 
     func openNotificationRoute(_ route: NotificationRoute) {
-        guard case .ready = phase,
+        guard canOpenNotificationRoutes,
               route.userID == nil || route.userID == profile?.userID,
               route.remoteHostID == nil else {
             notificationRouteQueue.enqueue(route)
@@ -886,7 +891,20 @@ final class AppModel: ObservableObject {
             notificationRouteQueue.enqueue(route)
             return
         }
+        if isRefreshing || (
+            route.chatID == selectedChatID
+                && (isSendingSelectedChat || isDeletingSelectedChat)
+        ) {
+            notificationRouteQueue.enqueue(route)
+            return
+        }
         transitionToChat(route.chatID, around: route.messageID, scrollTo: route.messageID)
+    }
+
+    private var canOpenNotificationRoutes: Bool {
+        if case .ready = phase { return true }
+        if case .failed = phase { return true }
+        return false
     }
 
     private func transitionToChat(
@@ -1032,6 +1050,7 @@ final class AppModel: ObservableObject {
         if replyWasInvalidated, !quoteWasSent, quotedMessageID != nil {
             invalidateReplyContext(in: chatID)
         }
+        consumePendingNotificationRoutes()
     }
 
     private func finishSendFailure(_ message: String, in chatID: NativeChat.ID) {

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -83,6 +83,7 @@ final class AppModel: ObservableObject {
     private var replyTargetNavigationTask: Task<Void, Never>?
     private var notificationRouteQueue = NotificationRouteQueue()
     private var pendingChatOperationErrors: [NativeChat.ID: String] = [:]
+    private var presentedChatOperationErrorChatID: NativeChat.ID?
     private var pendingQuoteNavigationErrors: [NativeChat.ID: String] = [:]
     private var pendingReplyContextErrors: [NativeChat.ID: String] = [:]
     private var pendingSendStatusMessages: [NativeChat.ID: String] = [:]
@@ -269,6 +270,7 @@ final class AppModel: ObservableObject {
         guard !previewMode else { return }
         guard canRefreshConversation else { return }
         guard let userID = profile?.userID else { return }
+        let refreshChatID = selectedChatID
         refreshTask?.cancel()
         isRefreshing = true
         refreshTask = Task {
@@ -288,7 +290,11 @@ final class AppModel: ObservableObject {
             } catch is CancellationError {
                 return
             } catch {
-                phase = .failed(error.localizedDescription)
+                if let refreshChatID {
+                    presentChatOperationFailure(error.localizedDescription, in: refreshChatID)
+                } else {
+                    presentGlobalFailure(error.localizedDescription)
+                }
             }
         }
     }
@@ -899,11 +905,7 @@ final class AppModel: ObservableObject {
 
     private func finishMessageDeletionFailure(_ message: String, in chatID: NativeChat.ID) {
         clearDeletionState()
-        if selectedChatID == chatID {
-            phase = .failed(message)
-        } else {
-            pendingChatOperationErrors[chatID] = message
-        }
+        presentChatOperationFailure(message, in: chatID)
         consumePendingNotificationRoutes()
     }
 
@@ -983,6 +985,7 @@ final class AppModel: ObservableObject {
             if let previousChatID = selectedChatID {
                 saveComposerState(for: previousChatID)
                 saveConversationNotices(for: previousChatID)
+                savePresentedChatOperationFailure(for: previousChatID)
             }
             quoteNavigationError = nil
             replyContextError = nil
@@ -996,7 +999,7 @@ final class AppModel: ObservableObject {
             conversationSearchText = ""
             conversationSearchPresented = false
             if let id, let message = pendingChatOperationErrors.removeValue(forKey: id) {
-                phase = .failed(message)
+                presentChatOperationFailure(message, in: id)
             }
             if let id {
                 quoteNavigationError = pendingQuoteNavigationErrors.removeValue(forKey: id)
@@ -1032,6 +1035,14 @@ final class AppModel: ObservableObject {
         if let sendStatusMessage {
             pendingSendStatusMessages[chatID] = sendStatusMessage
         }
+    }
+
+    private func savePresentedChatOperationFailure(for chatID: NativeChat.ID) {
+        guard presentedChatOperationErrorChatID == chatID else { return }
+        defer { presentedChatOperationErrorChatID = nil }
+        guard case let .failed(message) = phase else { return }
+        pendingChatOperationErrors[chatID] = message
+        phase = .ready
     }
 
     private func saveComposerState(for chatID: NativeChat.ID) {
@@ -1168,11 +1179,21 @@ final class AppModel: ObservableObject {
     }
 
     private func finishSendFailure(_ message: String, in chatID: NativeChat.ID) {
+        presentChatOperationFailure(message, in: chatID)
+    }
+
+    private func presentChatOperationFailure(_ message: String, in chatID: NativeChat.ID) {
         if selectedChatID == chatID {
+            presentedChatOperationErrorChatID = chatID
             phase = .failed(message)
         } else {
             pendingChatOperationErrors[chatID] = message
         }
+    }
+
+    private func presentGlobalFailure(_ message: String) {
+        presentedChatOperationErrorChatID = nil
+        phase = .failed(message)
     }
 
     private func finishPostSendRefreshFailure(_ detail: String, in chatID: NativeChat.ID) {
@@ -1260,7 +1281,7 @@ final class AppModel: ObservableObject {
             if let navigationFailureMessage {
                 quoteNavigationError = navigationFailureMessage
             } else if reportFailure {
-                phase = .failed(error.localizedDescription)
+                presentChatOperationFailure(error.localizedDescription, in: chatID)
             }
             return false
         }
@@ -1319,7 +1340,7 @@ final class AppModel: ObservableObject {
         } catch is CancellationError {
             return
         } catch {
-            phase = .failed(error.localizedDescription)
+            presentGlobalFailure(error.localizedDescription)
         }
     }
 

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -50,6 +50,7 @@ final class AppModel: ObservableObject {
     @Published var attachmentOpenError: String?
     @Published var quoteNavigationError: String?
     @Published var replyContextError: String?
+    @Published var sendStatusMessage: String?
     @Published var openingAttachmentIDs: Set<Int64> = []
     @Published var replyingTo: NativeMessage?
     @Published var composerFocusRequest = 0
@@ -83,6 +84,7 @@ final class AppModel: ObservableObject {
     private var notificationRouteQueue = NotificationRouteQueue()
     private var pendingChatOperationErrors: [NativeChat.ID: String] = [:]
     private var pendingReplyContextErrors: [NativeChat.ID: String] = [:]
+    private var pendingSendStatusMessages: [NativeChat.ID: String] = [:]
     private var pendingReplyInvalidationChatIDs: Set<NativeChat.ID> = []
     private var composerStates: [NativeChat.ID: ConversationComposerState] = [:]
     private var deletingChatID: NativeChat.ID?
@@ -979,6 +981,7 @@ final class AppModel: ObservableObject {
             quoteNavigationRevision &+= 1
             quoteNavigationError = nil
             replyContextError = nil
+            sendStatusMessage = nil
             if let previousChatID = selectedChatID {
                 saveComposerState(for: previousChatID)
             }
@@ -995,6 +998,7 @@ final class AppModel: ObservableObject {
             }
             if let id {
                 replyContextError = pendingReplyContextErrors.removeValue(forKey: id)
+                sendStatusMessage = pendingSendStatusMessages.removeValue(forKey: id)
             }
         }
         if let id { notificationManager?.removeDeliveredNotifications(chatID: id) }
@@ -1158,7 +1162,11 @@ final class AppModel: ObservableObject {
 
     private func finishPostSendRefreshFailure(_ detail: String, in chatID: NativeChat.ID) {
         let message = "Your message was sent, but the conversation could not refresh. Use Refresh to load it. \(detail)"
-        finishSendFailure(message, in: chatID)
+        if selectedChatID == chatID {
+            sendStatusMessage = message
+        } else {
+            pendingSendStatusMessages[chatID] = message
+        }
     }
 
     @discardableResult

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -527,6 +527,7 @@ final class AppModel: ObservableObject {
         quoteNavigationRevision &+= 1
         quoteNavigationError = nil
         if let messageID = quote.messageID {
+            prepareForQuoteNavigation()
             return navigateToMessage(messageID, in: chatID)
         }
 
@@ -555,6 +556,7 @@ final class AppModel: ObservableObject {
                     quoteNavigationError = "The original quoted message is no longer available in this conversation."
                     return
                 }
+                prepareForQuoteNavigation()
                 if let index = messages.firstIndex(where: { $0.id == containingMessageID }) {
                     messages[index] = refreshedMessage
                 }
@@ -570,6 +572,14 @@ final class AppModel: ObservableObject {
         }
         quoteNavigationTask = task
         return task
+    }
+
+    private func prepareForQuoteNavigation() {
+        if conversationSearchPresented {
+            dismissConversationSearch()
+        } else {
+            clearMessageSelection()
+        }
     }
 
     @discardableResult

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -459,12 +459,14 @@ final class AppModel: ObservableObject {
     @discardableResult
     func openQuotedMessage(_ quote: NativeQuote, from containingMessageID: Int64) -> Task<Void, Never>? {
         guard let chatID = selectedChatID else { return nil }
+        quoteNavigationTask?.cancel()
+        quoteNavigationTask = nil
+        quoteNavigationRevision &+= 1
+        quoteNavigationError = nil
         if let messageID = quote.messageID {
             return navigateToMessage(messageID, in: chatID)
         }
 
-        quoteNavigationTask?.cancel()
-        quoteNavigationRevision &+= 1
         let revision = quoteNavigationRevision
         let operation = loadMessageOperation
         let task = Task {
@@ -560,11 +562,11 @@ final class AppModel: ObservableObject {
     @discardableResult
     private func navigateToMessage(_ messageID: Int64, in chatID: NativeChat.ID) -> Task<Void, Never>? {
         guard selectedChatID == chatID else { return nil }
+        conversationLoadTask?.cancel()
         if messages.contains(where: { $0.id == messageID }) {
             targetMessageID = messageID
             return nil
         }
-        conversationLoadTask?.cancel()
         return scheduleConversationLoad(
             chatID: chatID,
             around: messageID,

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -1,6 +1,8 @@
 import AppKit
 import Foundation
 
+typealias DeleteMessagesOperation = @Sendable ([Int64], NativeChat) async throws -> [NativeMessage]
+
 @MainActor
 final class AppModel: ObservableObject {
     enum Phase: Equatable {
@@ -32,6 +34,7 @@ final class AppModel: ObservableObject {
     @Published var conversationSearchPresented = false
     @Published var isLoadingConversation = false
     @Published var isSending = false
+    @Published private(set) var isDeletingMessages = false
     @Published var selectedMessageIDs: Set<Int64> = []
     @Published var transcriptFocused = false
     @Published var pendingAttachments: [PendingAttachment] = []
@@ -52,12 +55,15 @@ final class AppModel: ObservableObject {
     private let core = SimpleXCore()
     private let previewMode: Bool
     private let passphraseStore: any DatabasePassphraseStore
+    private let deleteMessagesOperation: DeleteMessagesOperation?
     private weak var notificationManager: NativeNotificationManager?
     private var eventTask: Task<Void, Never>?
     private var conversationLoadTask: Task<Void, Never>?
     private var refreshTask: Task<Void, Never>?
     private var sendTask: Task<Void, Never>?
+    private var deleteTask: Task<Void, Never>?
     private var notificationRouteQueue = NotificationRouteQueue()
+    private var pendingChatOperationErrors: [NativeChat.ID: String] = [:]
     private var composerStates: [NativeChat.ID: ConversationComposerState] = [:]
     private var selectionAnchor: Int64?
     private var replyingChatID: NativeChat.ID?
@@ -67,11 +73,13 @@ final class AppModel: ObservableObject {
     init(
         notificationManager: NativeNotificationManager? = nil,
         passphraseStore: any DatabasePassphraseStore = DatabasePassphraseKeychain(),
-        previewMode: Bool? = nil
+        previewMode: Bool? = nil,
+        deleteMessagesOperation: DeleteMessagesOperation? = nil
     ) {
         self.previewMode = previewMode
             ?? (ProcessInfo.processInfo.environment["SIMPLEX_NATIVE_UI_PREVIEW"] == "1")
         self.passphraseStore = passphraseStore
+        self.deleteMessagesOperation = deleteMessagesOperation
         keychainPassphraseStorageAvailable = Bundle.main.object(
             forInfoDictionaryKey: "SimpleXKeychainPassphraseStorageEnabled"
         ) as? Bool == true
@@ -96,6 +104,7 @@ final class AppModel: ObservableObject {
         conversationLoadTask?.cancel()
         refreshTask?.cancel()
         sendTask?.cancel()
+        deleteTask?.cancel()
     }
 
     var selectedChat: NativeChat? {
@@ -120,7 +129,9 @@ final class AppModel: ObservableObject {
     }
 
     var canDeleteSelectedMessages: Bool {
-        !selectedMessageIDs.isEmpty && selectedMessagesInTranscriptOrder.allSatisfy(\.deletable)
+        !isDeletingMessages
+            && !selectedMessageIDs.isEmpty
+            && selectedMessagesInTranscriptOrder.allSatisfy(\.deletable)
     }
 
     var conversationSearchMatches: [NativeMessage] {
@@ -461,24 +472,64 @@ final class AppModel: ObservableObject {
         showingDeleteConfirmation = true
     }
 
-    func deleteSelectedMessages() {
-        guard let chat = selectedChat, canDeleteSelectedMessages else { return }
+    @discardableResult
+    func deleteSelectedMessages() -> Task<Void, Never>? {
+        guard let chat = selectedChat, canDeleteSelectedMessages else { return nil }
         let identifiers = selectedMessagesInTranscriptOrder.map(\.id)
         if let replyingTo, identifiers.contains(replyingTo.id) { cancelReply() }
         showingDeleteConfirmation = false
-        if previewMode {
+        if previewMode, deleteMessagesOperation == nil {
             messages.removeAll { identifiers.contains($0.id) }
             clearMessageSelection()
-            return
+            return nil
         }
-        Task {
+
+        isDeletingMessages = true
+        clearMessageSelection()
+        let operation = deleteMessagesOperation
+        let core = core
+        let task = Task { [weak self] in
             do {
-                try await core.deleteMessages(identifiers, from: chat)
-                clearMessageSelection()
-                messages = try await core.loadMessages(chatID: chat.id)
+                let loadedMessages: [NativeMessage]
+                if let operation {
+                    loadedMessages = try await operation(identifiers, chat)
+                } else {
+                    try await core.deleteMessages(identifiers, from: chat)
+                    try Task.checkCancellation()
+                    loadedMessages = try await core.loadMessages(chatID: chat.id)
+                }
+                try Task.checkCancellation()
+                guard let self else { return }
+                self.finishMessageDeletion(loadedMessages, in: chat.id)
+            } catch is CancellationError {
+                self?.finishMessageDeletionCancellation()
             } catch {
-                phase = .failed(error.localizedDescription)
+                self?.finishMessageDeletionFailure(error.localizedDescription, in: chat.id)
             }
+        }
+        deleteTask = task
+        return task
+    }
+
+    private func finishMessageDeletion(_ loadedMessages: [NativeMessage], in chatID: NativeChat.ID) {
+        isDeletingMessages = false
+        deleteTask = nil
+        guard selectedChatID == chatID else { return }
+        messages = loadedMessages
+    }
+
+    private func finishMessageDeletionCancellation() {
+        isDeletingMessages = false
+        deleteTask = nil
+    }
+
+    private func finishMessageDeletionFailure(_ message: String, in chatID: NativeChat.ID) {
+        isDeletingMessages = false
+        deleteTask = nil
+        if selectedChatID == chatID {
+            phase = .failed(message)
+        } else {
+            pendingChatOperationErrors[chatID] = message
         }
     }
 
@@ -531,6 +582,9 @@ final class AppModel: ObservableObject {
             targetMessageID = nil
             conversationSearchText = ""
             conversationSearchPresented = false
+            if let id, let message = pendingChatOperationErrors.removeValue(forKey: id) {
+                phase = .failed(message)
+            }
         }
         if let id { notificationManager?.removeDeliveredNotifications(chatID: id) }
 

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -527,7 +527,6 @@ final class AppModel: ObservableObject {
         quoteNavigationRevision &+= 1
         quoteNavigationError = nil
         if let messageID = quote.messageID {
-            prepareForQuoteNavigation()
             return navigateToMessage(messageID, in: chatID)
         }
 
@@ -556,7 +555,6 @@ final class AppModel: ObservableObject {
                     quoteNavigationError = "The original quoted message is no longer available in this conversation."
                     return
                 }
-                prepareForQuoteNavigation()
                 if let index = messages.firstIndex(where: { $0.id == containingMessageID }) {
                     messages[index] = refreshedMessage
                 }
@@ -638,6 +636,7 @@ final class AppModel: ObservableObject {
         guard selectedChatID == chatID else { return nil }
         conversationLoadTask?.cancel()
         if messages.contains(where: { $0.id == messageID }) {
+            prepareForQuoteNavigation()
             conversationAnchorMessageID = messageID
             targetMessageID = messageID
             return nil
@@ -646,7 +645,8 @@ final class AppModel: ObservableObject {
             chatID: chatID,
             around: messageID,
             scrollTo: messageID,
-            navigationFailureMessage: "The original quoted message is no longer available in this conversation."
+            navigationFailureMessage: "The original quoted message is no longer available in this conversation.",
+            consumeQuoteNavigationStateOnSuccess: true
         )
     }
 
@@ -1019,6 +1019,7 @@ final class AppModel: ObservableObject {
         around messageID: Int64? = nil,
         scrollTo scrollTarget: Int64? = nil,
         navigationFailureMessage: String? = nil,
+        consumeQuoteNavigationStateOnSuccess: Bool = false,
         scrollToLatest: Bool = false
     ) -> Task<Void, Never> {
         conversationLoadTask?.cancel()
@@ -1033,6 +1034,9 @@ final class AppModel: ObservableObject {
                 targetMessageID = latestMessageID
             } else if let scrollTarget {
                 if messages.contains(where: { $0.id == scrollTarget }) {
+                    if consumeQuoteNavigationStateOnSuccess {
+                        prepareForQuoteNavigation()
+                    }
                     targetMessageID = scrollTarget
                 } else if let navigationFailureMessage {
                     quoteNavigationError = navigationFailureMessage
@@ -1069,6 +1073,11 @@ final class AppModel: ObservableObject {
             }
             guard !Task.isCancelled, selectedChatID == chatID,
                   conversationLoadRevision == revision else { return false }
+            if let navigationFailureMessage, let messageID,
+               !loadedMessages.contains(where: { $0.id == messageID }) {
+                quoteNavigationError = navigationFailureMessage
+                return false
+            }
             applyLoadedMessages(loadedMessages, to: chatID)
             conversationAnchorMessageID = messageID
             return true

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -26,6 +26,10 @@ final class AppModel: ObservableObject {
     @Published var transcriptFocused = false
     @Published var pendingAttachments: [PendingAttachment] = []
     @Published var attachmentError: String?
+    @Published var attachmentOpenError: String?
+    @Published var openingAttachmentIDs: Set<Int64> = []
+    @Published var replyingTo: NativeMessage?
+    @Published var composerFocusRequest = 0
     @Published var showingDeleteConfirmation = false
     @Published var targetMessageID: Int64?
     @Published var hasStoredPassphrase = false
@@ -40,6 +44,7 @@ final class AppModel: ObservableObject {
     private let passphraseStore: any DatabasePassphraseStore
     private weak var notificationManager: NativeNotificationManager?
     private var eventTask: Task<Void, Never>?
+    private var conversationLoadTask: Task<Void, Never>?
     private var notificationRouteQueue = NotificationRouteQueue()
     private var selectionAnchor: Int64?
     private static let densityKey = "desktopChatDensity"
@@ -71,6 +76,7 @@ final class AppModel: ObservableObject {
 
     deinit {
         eventTask?.cancel()
+        conversationLoadTask?.cancel()
     }
 
     var selectedChat: NativeChat? {
@@ -142,6 +148,7 @@ final class AppModel: ObservableObject {
         selectedChatID = id
         clearMessageSelection()
         pendingAttachments = []
+        replyingTo = nil
         targetMessageID = nil
         conversationSearchText = ""
         conversationSearchPresented = false
@@ -150,7 +157,8 @@ final class AppModel: ObservableObject {
             messages = id.map(NativePreviewData.messages) ?? []
             return
         }
-        Task { await loadSelectedConversation() }
+        conversationLoadTask?.cancel()
+        conversationLoadTask = Task { await loadSelectedConversation() }
     }
 
     func refresh() {
@@ -169,6 +177,7 @@ final class AppModel: ObservableObject {
     func sendDraft() {
         let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         let attachments = pendingAttachments
+        let quotedMessage = replyingTo
         guard (!text.isEmpty || !attachments.isEmpty), let chat = selectedChat, !isSending else { return }
         if previewMode {
             if !text.isEmpty {
@@ -180,31 +189,56 @@ final class AppModel: ObservableObject {
                     sent: true,
                     author: nil,
                     deletable: true,
-                    content: .text
+                    content: .text,
+                    quotedItem: quotedMessage.map {
+                        NativeQuote(
+                            messageID: $0.id,
+                            text: $0.text.isEmpty ? ($0.content.attachmentDescription ?? "Message") : $0.text,
+                            sent: $0.sent,
+                            author: $0.author
+                        )
+                    }
                 ))
             }
             draft = ""
             pendingAttachments = []
+            replyingTo = nil
             return
         }
         draft = ""
         isSending = true
         Task {
+            var contentWasSent = false
             do {
                 if attachments.isEmpty {
-                    try await core.sendText(text, to: chat)
+                    try await core.sendText(text, quotedItemID: quotedMessage?.id, to: chat)
+                    contentWasSent = true
+                    if selectedChatID == chat.id, replyingTo?.id == quotedMessage?.id { replyingTo = nil }
                 } else {
                     for (index, attachment) in attachments.enumerated() {
                         let caption = index == attachments.index(before: attachments.endIndex) ? text : ""
-                        try await core.sendAttachment(attachment, caption: caption, to: chat)
-                        pendingAttachments.removeAll { $0.id == attachment.id }
+                        let quotedItemID = index == attachments.startIndex ? quotedMessage?.id : nil
+                        try await core.sendAttachment(
+                            attachment,
+                            caption: caption,
+                            quotedItemID: quotedItemID,
+                            to: chat
+                        )
+                        if index == attachments.index(before: attachments.endIndex) { contentWasSent = true }
+                        if selectedChatID == chat.id {
+                            pendingAttachments.removeAll { $0.id == attachment.id }
+                            if quotedItemID != nil, replyingTo?.id == quotedItemID { replyingTo = nil }
+                        }
                     }
                 }
-                messages = try await core.loadMessages(chatID: chat.id)
+                let sentMessages = try await core.loadMessages(chatID: chat.id)
+                if selectedChatID == chat.id { messages = sentMessages }
                 if let userID = profile?.userID { chats = try await core.loadChats(userID: userID) }
             } catch {
-                draft = text
-                phase = .failed(error.localizedDescription)
+                if selectedChatID == chat.id {
+                    if !contentWasSent { draft = text }
+                    phase = .failed(error.localizedDescription)
+                }
             }
             isSending = false
         }
@@ -260,6 +294,58 @@ final class AppModel: ObservableObject {
         guard sourceIndex != destinationIndex else { return }
         let attachment = pendingAttachments.remove(at: sourceIndex)
         pendingAttachments.insert(attachment, at: destinationIndex)
+    }
+
+    func beginReply(to message: NativeMessage) {
+        guard selectedChat?.kind.canReply == true, !isSending else { return }
+        replyingTo = message
+        clearMessageSelection()
+        composerFocusRequest &+= 1
+    }
+
+    func replyToSelectedMessage() {
+        guard selectedMessagesInTranscriptOrder.count == 1,
+              let message = selectedMessagesInTranscriptOrder.first else { return }
+        beginReply(to: message)
+    }
+
+    func cancelReply() {
+        replyingTo = nil
+    }
+
+    func openQuotedMessage(_ messageID: Int64) {
+        if messages.contains(where: { $0.id == messageID }) {
+            targetMessageID = messageID
+            return
+        }
+        conversationLoadTask?.cancel()
+        conversationLoadTask = Task {
+            await loadSelectedConversation(around: messageID)
+            guard !Task.isCancelled, messages.contains(where: { $0.id == messageID }) else { return }
+            targetMessageID = messageID
+        }
+    }
+
+    func openAttachment(_ message: NativeMessage) {
+        guard let source = message.fileSource,
+              !openingAttachmentIDs.contains(message.id) else { return }
+        openingAttachmentIDs.insert(message.id)
+        Task {
+            defer { openingAttachmentIDs.remove(message.id) }
+            do {
+                let url = try await core.openableURL(
+                    for: source,
+                    fileName: message.content.attachmentDescription
+                )
+                guard NSWorkspace.shared.open(url) else {
+                    throw NativeChatError.unavailable("macOS could not open this attachment.")
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                attachmentOpenError = error.localizedDescription
+            }
+        }
     }
 
     func selectMessage(_ id: Int64, modifiers: NSEvent.ModifierFlags) {
@@ -336,6 +422,7 @@ final class AppModel: ObservableObject {
     func deleteSelectedMessages() {
         guard let chat = selectedChat, canDeleteSelectedMessages else { return }
         let identifiers = selectedMessagesInTranscriptOrder.map(\.id)
+        if let replyingTo, identifiers.contains(replyingTo.id) { self.replyingTo = nil }
         showingDeleteConfirmation = false
         if previewMode {
             messages.removeAll { identifiers.contains($0.id) }
@@ -361,6 +448,8 @@ final class AppModel: ObservableObject {
     func dismissNearestState() {
         if conversationSearchPresented {
             dismissConversationSearch()
+        } else if replyingTo != nil {
+            cancelReply()
         } else if !pendingAttachments.isEmpty {
             pendingAttachments = []
         } else if !selectedMessageIDs.isEmpty {
@@ -391,14 +480,21 @@ final class AppModel: ObservableObject {
             messages = []
             return
         }
+        let chatID = chat.id
         isLoadingConversation = true
+        defer {
+            if selectedChatID == chatID { isLoadingConversation = false }
+        }
         do {
-            messages = try await core.loadMessages(chatID: chat.id, around: messageID)
+            let loadedMessages = try await core.loadMessages(chatID: chatID, around: messageID)
+            guard !Task.isCancelled, selectedChatID == chatID else { return }
+            messages = loadedMessages
             selectedMessageIDs.formIntersection(messages.map(\.id))
+        } catch is CancellationError {
+            return
         } catch {
             phase = .failed(error.localizedDescription)
         }
-        isLoadingConversation = false
     }
 
     private func startEventLoop() {

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -17,6 +17,9 @@ final class AppModel: ObservableObject {
     @Published var messages: [NativeMessage] = []
     @Published var draft = ""
     @Published var searchText = ""
+    @Published var sidebarSearchPresented = false
+    @Published var conversationSearchText = ""
+    @Published var conversationSearchPresented = false
     @Published var isLoadingConversation = false
     @Published var isSending = false
     @Published var selectedMessageIDs: Set<Int64> = []
@@ -25,23 +28,45 @@ final class AppModel: ObservableObject {
     @Published var attachmentError: String?
     @Published var showingDeleteConfirmation = false
     @Published var targetMessageID: Int64?
+    @Published var hasStoredPassphrase = false
+    @Published var keychainStatusMessage: String?
+    @Published private(set) var keychainPassphraseStorageAvailable: Bool
     @Published var density: DesktopChatDensity {
         didSet { UserDefaults.standard.set(density.rawValue, forKey: Self.densityKey) }
     }
 
     private let core = SimpleXCore()
+    private let previewMode: Bool
+    private let passphraseStore: any DatabasePassphraseStore
     private weak var notificationManager: NativeNotificationManager?
     private var eventTask: Task<Void, Never>?
     private var notificationRouteQueue = NotificationRouteQueue()
     private var selectionAnchor: Int64?
     private static let densityKey = "desktopChatDensity"
 
-    init(notificationManager: NativeNotificationManager? = nil) {
+    init(
+        notificationManager: NativeNotificationManager? = nil,
+        passphraseStore: any DatabasePassphraseStore = DatabasePassphraseKeychain()
+    ) {
+        previewMode = ProcessInfo.processInfo.environment["SIMPLEX_NATIVE_UI_PREVIEW"] == "1"
+        self.passphraseStore = passphraseStore
+        keychainPassphraseStorageAvailable = Bundle.main.object(
+            forInfoDictionaryKey: "SimpleXKeychainPassphraseStorageEnabled"
+        ) as? Bool == true
         density = DesktopChatDensity(
             rawValue: UserDefaults.standard.string(forKey: Self.densityKey) ?? ""
         ) ?? .compact
         self.notificationManager = notificationManager
         notificationManager?.model = self
+        if previewMode {
+            phase = .ready
+            profile = NativePreviewData.profile
+            chats = NativePreviewData.chats
+            selectedChatID = NativePreviewData.chats.first?.id
+            messages = selectedChatID.map(NativePreviewData.messages) ?? []
+        } else if keychainPassphraseStorageAvailable {
+            Task { await attemptAutomaticUnlock() }
+        }
     }
 
     deinit {
@@ -73,22 +98,41 @@ final class AppModel: ObservableObject {
         !selectedMessageIDs.isEmpty && selectedMessagesInTranscriptOrder.allSatisfy(\.deletable)
     }
 
-    func unlock(passphrase: String) {
+    var conversationSearchMatches: [NativeMessage] {
+        ConversationSearch.matches(messages, query: conversationSearchText)
+    }
+
+    var conversationSearchResultDescription: String {
+        let matches = conversationSearchMatches
+        let selectedID = selectedMessagesInTranscriptOrder.last?.id
+        return ConversationSearch.resultDescription(
+            matches: matches,
+            selectedID: selectedID,
+            queryIsEmpty: conversationSearchText.isEmpty
+        )
+    }
+
+    func unlock(passphrase: String, rememberPassphrase: Bool = true) {
         guard phase != .opening else { return }
         phase = .opening
         Task {
+            await openProfile(
+                passphrase: passphrase,
+                rememberPassphrase: rememberPassphrase && keychainPassphraseStorageAvailable,
+                automatic: false
+            )
+        }
+    }
+
+    func forgetSavedPassphrase() {
+        guard keychainPassphraseStorageAvailable else { return }
+        Task {
             do {
-                let (profile, chats) = try await core.open(passphrase: passphrase)
-                self.profile = profile
-                self.chats = chats
-                self.phase = .ready
-                if selectedChatID == nil { selectedChatID = chats.first?.id }
-                await loadSelectedConversation()
-                startEventLoop()
-                notificationManager?.chatSetupReady()
-                consumePendingNotificationRoutes()
+                try await passphraseStore.delete()
+                hasStoredPassphrase = false
+                keychainStatusMessage = "The saved passphrase was removed from Mac Keychain."
             } catch {
-                phase = .locked(message: error.localizedDescription)
+                keychainStatusMessage = error.localizedDescription
             }
         }
     }
@@ -99,11 +143,18 @@ final class AppModel: ObservableObject {
         clearMessageSelection()
         pendingAttachments = []
         targetMessageID = nil
+        conversationSearchText = ""
+        conversationSearchPresented = false
         if let id { notificationManager?.removeDeliveredNotifications(chatID: id) }
+        if previewMode {
+            messages = id.map(NativePreviewData.messages) ?? []
+            return
+        }
         Task { await loadSelectedConversation() }
     }
 
     func refresh() {
+        guard !previewMode else { return }
         guard let userID = profile?.userID else { return }
         Task {
             do {
@@ -119,6 +170,23 @@ final class AppModel: ObservableObject {
         let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         let attachments = pendingAttachments
         guard (!text.isEmpty || !attachments.isEmpty), let chat = selectedChat, !isSending else { return }
+        if previewMode {
+            if !text.isEmpty {
+                let nextID = (messages.map(\.id).max() ?? 0) + 1
+                messages.append(NativeMessage(
+                    id: nextID,
+                    text: text,
+                    timestamp: Date(),
+                    sent: true,
+                    author: nil,
+                    deletable: true,
+                    content: .text
+                ))
+            }
+            draft = ""
+            pendingAttachments = []
+            return
+        }
         draft = ""
         isSending = true
         Task {
@@ -186,6 +254,14 @@ final class AppModel: ObservableObject {
         pendingAttachments = PendingAttachment.reordered(pendingAttachments, from: source, before: destination)
     }
 
+    func moveAttachment(_ id: PendingAttachment.ID, by offset: Int) {
+        guard let sourceIndex = pendingAttachments.firstIndex(where: { $0.id == id }) else { return }
+        let destinationIndex = min(max(0, sourceIndex + offset), pendingAttachments.count - 1)
+        guard sourceIndex != destinationIndex else { return }
+        let attachment = pendingAttachments.remove(at: sourceIndex)
+        pendingAttachments.insert(attachment, at: destinationIndex)
+    }
+
     func selectMessage(_ id: Int64, modifiers: NSEvent.ModifierFlags) {
         let result = MessageSelection.updated(
             current: selectedMessageIDs,
@@ -215,6 +291,36 @@ final class AppModel: ObservableObject {
         selectionAnchor = messages[targetIndex].id
     }
 
+    func beginConversationSearch() {
+        guard selectedChat != nil else { return }
+        conversationSearchPresented = true
+    }
+
+    func updateConversationSearchSelection() {
+        guard let first = conversationSearchMatches.first else {
+            clearMessageSelection()
+            return
+        }
+        selectedMessageIDs = [first.id]
+        selectionAnchor = first.id
+        targetMessageID = first.id
+    }
+
+    func moveConversationSearchResult(by offset: Int) {
+        let matches = conversationSearchMatches
+        let selectedID = selectedMessagesInTranscriptOrder.last?.id
+        guard let nextID = ConversationSearch.nextID(in: matches, currentID: selectedID, offset: offset) else { return }
+        selectedMessageIDs = [nextID]
+        selectionAnchor = nextID
+        targetMessageID = nextID
+    }
+
+    func dismissConversationSearch() {
+        conversationSearchPresented = false
+        conversationSearchText = ""
+        clearMessageSelection()
+    }
+
     func copySelectedMessages() {
         guard transcriptFocused, !selectedMessageIDs.isEmpty else { return }
         let text = selectedMessagesInTranscriptOrder.map(\.text).joined(separator: "\n\n")
@@ -231,6 +337,11 @@ final class AppModel: ObservableObject {
         guard let chat = selectedChat, canDeleteSelectedMessages else { return }
         let identifiers = selectedMessagesInTranscriptOrder.map(\.id)
         showingDeleteConfirmation = false
+        if previewMode {
+            messages.removeAll { identifiers.contains($0.id) }
+            clearMessageSelection()
+            return
+        }
         Task {
             do {
                 try await core.deleteMessages(identifiers, from: chat)
@@ -248,7 +359,9 @@ final class AppModel: ObservableObject {
     }
 
     func dismissNearestState() {
-        if !pendingAttachments.isEmpty {
+        if conversationSearchPresented {
+            dismissConversationSearch()
+        } else if !pendingAttachments.isEmpty {
             pendingAttachments = []
         } else if !selectedMessageIDs.isEmpty {
             clearMessageSelection()
@@ -316,5 +429,65 @@ final class AppModel: ObservableObject {
     private func consumePendingNotificationRoutes() {
         let routes = notificationRouteQueue.consumeIfReady(true)
         for route in routes { openNotificationRoute(route) }
+    }
+
+    private func attemptAutomaticUnlock() async {
+        phase = .opening
+        do {
+            guard let passphrase = try await passphraseStore.load() else {
+                phase = .locked(message: nil)
+                return
+            }
+            hasStoredPassphrase = true
+            await openProfile(passphrase: passphrase, rememberPassphrase: true, automatic: true)
+        } catch {
+            keychainStatusMessage = error.localizedDescription
+            phase = .locked(message: "Couldn’t read the saved passphrase. Enter it to continue.")
+        }
+    }
+
+    private func openProfile(passphrase: String, rememberPassphrase: Bool, automatic: Bool) async {
+        do {
+            let (profile, chats) = try await core.open(passphrase: passphrase)
+
+            if rememberPassphrase {
+                do {
+                    try await passphraseStore.save(passphrase)
+                    hasStoredPassphrase = true
+                    keychainStatusMessage = nil
+                } catch {
+                    hasStoredPassphrase = false
+                    keychainStatusMessage = "The profile opened, but its passphrase wasn’t saved: \(error.localizedDescription)"
+                }
+            } else if !automatic {
+                do {
+                    try await passphraseStore.delete()
+                    hasStoredPassphrase = false
+                } catch {
+                    keychainStatusMessage = error.localizedDescription
+                }
+            }
+
+            self.profile = profile
+            self.chats = chats
+            phase = .ready
+            if selectedChatID == nil { selectedChatID = chats.first?.id }
+            await loadSelectedConversation()
+            startEventLoop()
+            notificationManager?.chatSetupReady()
+            consumePendingNotificationRoutes()
+        } catch {
+            if automatic, error.localizedDescription == "That database passphrase is not correct." {
+                do {
+                    try await passphraseStore.delete()
+                    hasStoredPassphrase = false
+                } catch {
+                    keychainStatusMessage = error.localizedDescription
+                }
+                phase = .locked(message: "The saved passphrase no longer opens this profile. Enter the current passphrase.")
+            } else {
+                phase = .locked(message: error.localizedDescription)
+            }
+        }
     }
 }

--- a/apps/macos-native/Sources/SimpleXNative/AppModel.swift
+++ b/apps/macos-native/Sources/SimpleXNative/AppModel.swift
@@ -597,12 +597,13 @@ final class AppModel: ObservableObject {
                     }
                 }
 
+                let fileName = message.content.fileName ?? message.content.attachmentDescription
                 if let openAttachmentOperation {
-                    try await openAttachmentOperation(source, message.content.attachmentDescription)
+                    try await openAttachmentOperation(source, fileName)
                 } else {
                     let url = try await core.openableURL(
                         for: source,
-                        fileName: message.content.attachmentDescription
+                        fileName: fileName
                     )
                     try Task.checkCancellation()
                     guard NSWorkspace.shared.open(url) else {

--- a/apps/macos-native/Sources/SimpleXNative/Core/SimpleXCore.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Core/SimpleXCore.swift
@@ -258,19 +258,24 @@ actor SimpleXCore {
     }
 
     private func sendComposedMessage(_ message: [String: Any], to chat: NativeChat) throws {
+        try ensureCommandSucceeded(send(Self.sendCommand(message: message, to: chat)))
+    }
+
+    nonisolated static func sendCommand(message: [String: Any], to chat: NativeChat) throws -> String {
+        if message["quotedItemId"] != nil, !chat.kind.canReply {
+            throw NativeChatError.unavailable("Replies are not supported in this conversation.")
+        }
         let content = [message]
         let data = try JSONSerialization.data(withJSONObject: content)
         guard let json = String(data: data, encoding: .utf8) else {
             throw NativeChatError.invalidResponse("The message could not be encoded.")
         }
-        let command: String
         if chat.kind == .local {
-            command = "/_create *\(chat.apiID) json \(json)"
+            return "/_create *\(chat.apiID) json \(json)"
         } else {
             let asGroup = chat.sendAsGroup ? "(as_group=on)" : ""
-            command = "/_send \(chat.kind.rawValue)\(chat.apiID)\(asGroup) live=off ttl=default sign=off json \(json)"
+            return "/_send \(chat.kind.rawValue)\(chat.apiID)\(asGroup) live=off ttl=default sign=off json \(json)"
         }
-        try ensureCommandSucceeded(send(command))
     }
 
     private func loadIfNeeded() throws {

--- a/apps/macos-native/Sources/SimpleXNative/Core/SimpleXCore.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Core/SimpleXCore.swift
@@ -72,6 +72,10 @@ actor SimpleXCore {
         return messages.first(where: { $0.id == itemID })
     }
 
+    func markChatRead(chatID: String) throws {
+        try ensureCommandSucceeded(send(Self.markChatReadCommand(chatID: chatID)))
+    }
+
     nonisolated static func chatPageCommand(
         chatID: String,
         around messageID: Int64?,
@@ -79,6 +83,10 @@ actor SimpleXCore {
     ) -> String {
         let pagination = messageID.map { "around=\($0) count=\(count)" } ?? "count=\(count)"
         return "/_get chat \(chatID) \(pagination)"
+    }
+
+    nonisolated static func markChatReadCommand(chatID: String) -> String {
+        "/_read chat \(chatID)"
     }
 
     func sendText(_ text: String, quotedItemID: Int64?, to chat: NativeChat) throws -> NativeSendReceipt {

--- a/apps/macos-native/Sources/SimpleXNative/Core/SimpleXCore.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Core/SimpleXCore.swift
@@ -1,0 +1,142 @@
+import CoreBridge
+import Foundation
+
+actor SimpleXCore {
+    private var controller: UnsafeMutableRawPointer?
+    private var loaded = false
+
+    deinit {
+        if let controller {
+            if let result = sx_core_close_store(controller) {
+                sx_core_free(result)
+            }
+        }
+    }
+
+    func open(passphrase: String) throws -> (NativeProfile, [NativeChat]) {
+        try loadIfNeeded()
+        let migration = try migrate(passphrase: passphrase)
+        guard NativeChatParser.migrationSucceeded(migration) else {
+            throw NativeChatError.core(NativeChatParser.migrationError(from: migration))
+        }
+        guard controller != nil else {
+            throw NativeChatError.unavailable("The SimpleX core opened the database without returning a controller.")
+        }
+
+        try configureFilePaths()
+        _ = try send("/_start main=on snd_files=on")
+        let profile = try NativeChatParser.profile(from: send("/u"))
+        let chats = try NativeChatParser.chats(from: send("/_get chats \(profile.userID) pcc=on"))
+        return (profile, chats)
+    }
+
+    func loadChats(userID: Int64) throws -> [NativeChat] {
+        try NativeChatParser.chats(from: send("/_get chats \(userID) pcc=on"))
+    }
+
+    func loadMessages(chatID: String) throws -> [NativeMessage] {
+        try NativeChatParser.messages(from: send("/_get chat \(chatID) count=75"))
+    }
+
+    func sendText(_ text: String, to chat: NativeChat) throws {
+        guard chat.kind.canSend else {
+            throw NativeChatError.unavailable("This conversation cannot accept messages yet.")
+        }
+        let content: [[String: Any]] = [[
+            "msgContent": ["type": "text", "text": text],
+            "mentions": [:],
+        ]]
+        let data = try JSONSerialization.data(withJSONObject: content)
+        guard let json = String(data: data, encoding: .utf8) else {
+            throw NativeChatError.invalidResponse("The message could not be encoded.")
+        }
+        let command: String
+        if chat.kind == .local {
+            command = "/_create *\(chat.apiID) json \(json)"
+        } else {
+            let asGroup = chat.sendAsGroup ? "(as_group=on)" : ""
+            command = "/_send \(chat.kind.rawValue)\(chat.apiID)\(asGroup) live=off ttl=default sign=off json \(json)"
+        }
+        _ = try send(command)
+    }
+
+    func waitForEvent(timeoutMicroseconds: Int32 = 500_000) -> Bool {
+        guard let controller,
+              let pointer = sx_core_recv_msg_wait(controller, timeoutMicroseconds) else {
+            return false
+        }
+        defer { sx_core_free(pointer) }
+        guard let response = String(validatingUTF8: pointer) else { return false }
+        return !response.isEmpty
+    }
+
+    private func loadIfNeeded() throws {
+        guard !loaded else { return }
+        let environment = ProcessInfo.processInfo.environment["SIMPLEX_CORE_LIB_DIR"]
+        let libraryDirectory = environment ?? Bundle.main.privateFrameworksURL?.path
+        guard let libraryDirectory else {
+            throw NativeChatError.unavailable("The SimpleX core libraries were not found in the app bundle.")
+        }
+        var error = [CChar](repeating: 0, count: 4096)
+        guard sx_core_load(libraryDirectory, &error, error.count) else {
+            throw NativeChatError.unavailable(String(cString: error))
+        }
+        guard sx_core_initialize(&error, error.count) else {
+            throw NativeChatError.unavailable(String(cString: error))
+        }
+        loaded = true
+    }
+
+    private func migrate(passphrase: String) throws -> Data {
+        let prefix = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".local/share/simplex/simplex_v1").path
+        let result = prefix.withCString { path in
+            passphrase.withCString { key in
+                "yesUp".withCString { confirmation in
+                    sx_core_migrate_init(path, key, confirmation, &controller)
+                }
+            }
+        }
+        return try data(from: result)
+    }
+
+    private func configureFilePaths() throws {
+        let dataDirectory = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".local/share/simplex", isDirectory: true)
+        let files = dataDirectory.appendingPathComponent("simplex_v1_files", isDirectory: true)
+        let temporary = dataDirectory.appendingPathComponent("tmp", isDirectory: true)
+        let assets = dataDirectory.appendingPathComponent("simplex_v1_assets", isDirectory: true)
+        try FileManager.default.createDirectory(at: files, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: temporary, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: assets, withIntermediateDirectories: true)
+        let paths = [
+            "appFilesFolder": files.path,
+            "appTempFolder": temporary.path,
+            "appAssetsFolder": assets.path,
+        ]
+        let encoded = try JSONSerialization.data(withJSONObject: paths)
+        guard let json = String(data: encoded, encoding: .utf8) else {
+            throw NativeChatError.invalidResponse("The app file paths could not be encoded.")
+        }
+        _ = try send("/set file paths \(json)")
+    }
+
+    private func send(_ command: String) throws -> Data {
+        guard let controller else {
+            throw NativeChatError.unavailable("The SimpleX database is not open.")
+        }
+        let result = command.withCString { sx_core_send_cmd(controller, $0, 0) }
+        return try data(from: result)
+    }
+
+    private func data(from pointer: UnsafePointer<CChar>?) throws -> Data {
+        guard let pointer else {
+            throw NativeChatError.unavailable("The SimpleX core returned no data.")
+        }
+        defer { sx_core_free(pointer) }
+        guard let string = String(validatingUTF8: pointer), let data = string.data(using: .utf8) else {
+            throw NativeChatError.invalidResponse("The SimpleX core returned invalid UTF-8.")
+        }
+        return data
+    }
+}

--- a/apps/macos-native/Sources/SimpleXNative/Core/SimpleXCore.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Core/SimpleXCore.swift
@@ -260,7 +260,7 @@ actor SimpleXCore {
     private func sendComposedMessage(_ message: [String: Any], to chat: NativeChat) throws {
         let response = try send(Self.sendCommand(message: message, to: chat))
         if message["quotedItemId"] != nil,
-           NativeChatParser.commandErrorIsInvalidQuote(response) {
+           NativeChatParser.commandErrorMakesReplyTargetUnavailable(response) {
             throw NativeChatError.replyTargetUnavailable
         }
         try NativeChatParser.validateCommandResponse(

--- a/apps/macos-native/Sources/SimpleXNative/Core/SimpleXCore.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Core/SimpleXCore.swift
@@ -44,8 +44,29 @@ actor SimpleXCore {
     }
 
     func loadMessages(chatID: String, around messageID: Int64? = nil) throws -> [NativeMessage] {
-        let pagination = messageID.map { "around=\($0) count=75" } ?? "count=75"
-        return try NativeChatParser.messages(from: send("/_get chat \(chatID) \(pagination)"))
+        try NativeChatParser.messages(from: send(Self.chatPageCommand(
+            chatID: chatID,
+            around: messageID,
+            count: 75
+        )))
+    }
+
+    func loadMessage(chatID: String, itemID: Int64) throws -> NativeMessage? {
+        let messages = try NativeChatParser.messages(from: send(Self.chatPageCommand(
+            chatID: chatID,
+            around: itemID,
+            count: 0
+        )))
+        return messages.first(where: { $0.id == itemID }) ?? messages.first
+    }
+
+    nonisolated static func chatPageCommand(
+        chatID: String,
+        around messageID: Int64?,
+        count: Int
+    ) -> String {
+        let pagination = messageID.map { "around=\($0) count=\(count)" } ?? "count=\(count)"
+        return "/_get chat \(chatID) \(pagination)"
     }
 
     func sendText(_ text: String, quotedItemID: Int64?, to chat: NativeChat) throws {
@@ -106,12 +127,15 @@ actor SimpleXCore {
         guard FileManager.default.fileExists(atPath: sourceURL.path) else {
             throw NativeChatError.unavailable("The attachment is no longer stored on this Mac.")
         }
-        guard let cryptoArgs = source.cryptoArgs else { return sourceURL }
+        guard let cryptoArgs = source.cryptoArgs else {
+            try Self.validateImageHeader(at: sourceURL, fileName: fileName)
+            return sourceURL
+        }
 
         try loadIfNeeded()
         let directory = decryptedFilesDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        let safeName = URL(fileURLWithPath: fileName ?? source.filePath).lastPathComponent
+        let safeName = Self.openedFileName(preferredName: fileName, sourcePath: source.filePath)
         let destination = directory.appendingPathComponent(safeName.isEmpty ? "Attachment" : safeName)
         let result = sourceURL.path.withCString { fromPath in
             cryptoArgs.fileKey.withCString { key in
@@ -136,7 +160,59 @@ actor SimpleXCore {
             try? FileManager.default.removeItem(at: directory)
             throw NativeChatError.unavailable("SimpleX decrypted the attachment without creating a readable file.")
         }
+        do {
+            try Self.validateImageHeader(at: destination, fileName: fileName)
+        } catch {
+            try? FileManager.default.removeItem(at: directory)
+            throw error
+        }
         return destination
+    }
+
+    nonisolated static func imageHeaderIsReadable(_ data: Data, fileName: String?) -> Bool {
+        let fileExtension = URL(fileURLWithPath: fileName ?? "").pathExtension.lowercased()
+        switch fileExtension {
+        case "jpg", "jpeg":
+            return data.starts(with: [0xff, 0xd8, 0xff])
+        case "png":
+            return data.starts(with: [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+        case "gif":
+            return data.starts(with: Data("GIF87a".utf8)) || data.starts(with: Data("GIF89a".utf8))
+        case "tif", "tiff":
+            return data.starts(with: [0x49, 0x49, 0x2a, 0x00])
+                || data.starts(with: [0x4d, 0x4d, 0x00, 0x2a])
+        case "bmp":
+            return data.starts(with: Data("BM".utf8))
+        case "webp":
+            return data.count >= 12
+                && data.prefix(4) == Data("RIFF".utf8)
+                && data.dropFirst(8).prefix(4) == Data("WEBP".utf8)
+        case "heic", "heif", "avif":
+            return data.count >= 12 && data.dropFirst(4).prefix(4) == Data("ftyp".utf8)
+        default:
+            return true
+        }
+    }
+
+    nonisolated static func openedFileName(preferredName: String?, sourcePath: String) -> String {
+        let preferred = URL(fileURLWithPath: preferredName ?? "").lastPathComponent
+        let source = URL(fileURLWithPath: sourcePath).lastPathComponent
+        if preferred.isEmpty { return source }
+        if URL(fileURLWithPath: preferred).pathExtension.isEmpty,
+           !URL(fileURLWithPath: source).pathExtension.isEmpty {
+            return source
+        }
+        return preferred
+    }
+
+    private nonisolated static func validateImageHeader(at url: URL, fileName: String?) throws {
+        let header = try Data(contentsOf: url, options: .mappedIfSafe).prefix(16)
+        let resolvedName = openedFileName(preferredName: fileName, sourcePath: url.path)
+        guard imageHeaderIsReadable(Data(header), fileName: resolvedName) else {
+            throw NativeChatError.unavailable(
+                "SimpleX could not decode this image. Its stored copy may still be encrypted or incomplete."
+            )
+        }
     }
 
     nonisolated static func composedMessage(

--- a/apps/macos-native/Sources/SimpleXNative/Core/SimpleXCore.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Core/SimpleXCore.swift
@@ -81,11 +81,11 @@ actor SimpleXCore {
         return "/_get chat \(chatID) \(pagination)"
     }
 
-    func sendText(_ text: String, quotedItemID: Int64?, to chat: NativeChat) throws {
+    func sendText(_ text: String, quotedItemID: Int64?, to chat: NativeChat) throws -> NativeSendReceipt {
         guard chat.kind.canSend else {
             throw NativeChatError.unavailable("This conversation cannot accept messages yet.")
         }
-        try sendComposedMessage(
+        return try sendComposedMessage(
             Self.composedMessage(
                 messageContent: ["type": "text", "text": text],
                 quotedItemID: quotedItemID
@@ -99,7 +99,7 @@ actor SimpleXCore {
         caption: String,
         quotedItemID: Int64?,
         to chat: NativeChat
-    ) throws {
+    ) throws -> NativeSendReceipt {
         guard chat.kind.canSend else {
             throw NativeChatError.unavailable("This conversation cannot accept attachments yet.")
         }
@@ -121,7 +121,7 @@ actor SimpleXCore {
         case .document:
             messageContent = ["type": "file", "text": caption]
         }
-        try sendComposedMessage(
+        return try sendComposedMessage(
             Self.composedMessage(
                 messageContent: messageContent,
                 fileSource: [
@@ -257,16 +257,15 @@ actor SimpleXCore {
         return response.data(using: .utf8)
     }
 
-    private func sendComposedMessage(_ message: [String: Any], to chat: NativeChat) throws {
+    private func sendComposedMessage(_ message: [String: Any], to chat: NativeChat) throws -> NativeSendReceipt {
         let response = try send(Self.sendCommand(message: message, to: chat))
         if message["quotedItemId"] != nil,
            NativeChatParser.commandErrorMakesReplyTargetUnavailable(response) {
             throw NativeChatError.replyTargetUnavailable
         }
-        try NativeChatParser.validateCommandResponse(
+        return try NativeChatParser.validateSendResponse(
             response,
-            expectedType: "newChatItems",
-            requireChatItems: true
+            quotedItemID: message["quotedItemId"] as? Int64
         )
     }
 

--- a/apps/macos-native/Sources/SimpleXNative/Core/SimpleXCore.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Core/SimpleXCore.swift
@@ -24,7 +24,7 @@ actor SimpleXCore {
         }
 
         try configureFilePaths()
-        _ = try send("/_start main=on snd_files=on")
+        try ensureCommandSucceeded(send("/_start main=on snd_files=on"))
         let profile = try NativeChatParser.profile(from: send("/u"))
         let chats = try NativeChatParser.chats(from: send("/_get chats \(profile.userID) pcc=on"))
         return (profile, chats)
@@ -34,18 +34,71 @@ actor SimpleXCore {
         try NativeChatParser.chats(from: send("/_get chats \(userID) pcc=on"))
     }
 
-    func loadMessages(chatID: String) throws -> [NativeMessage] {
-        try NativeChatParser.messages(from: send("/_get chat \(chatID) count=75"))
+    func loadMessages(chatID: String, around messageID: Int64? = nil) throws -> [NativeMessage] {
+        let pagination = messageID.map { "around=\($0) count=75" } ?? "count=75"
+        return try NativeChatParser.messages(from: send("/_get chat \(chatID) \(pagination)"))
     }
 
     func sendText(_ text: String, to chat: NativeChat) throws {
         guard chat.kind.canSend else {
             throw NativeChatError.unavailable("This conversation cannot accept messages yet.")
         }
-        let content: [[String: Any]] = [[
+        try sendComposedMessage([
             "msgContent": ["type": "text", "text": text],
             "mentions": [:],
-        ]]
+        ], to: chat)
+    }
+
+    func sendAttachment(_ attachment: PendingAttachment, caption: String, to chat: NativeChat) throws {
+        guard chat.kind.canSend else {
+            throw NativeChatError.unavailable("This conversation cannot accept attachments yet.")
+        }
+        let messageContent: [String: Any]
+        switch attachment.kind {
+        case .image:
+            messageContent = [
+                "type": "image",
+                "text": caption,
+                "image": attachment.previewImage ?? "",
+            ]
+        case .video:
+            messageContent = [
+                "type": "video",
+                "text": caption,
+                "image": "",
+                "duration": 0,
+            ]
+        case .document:
+            messageContent = ["type": "file", "text": caption]
+        }
+        try sendComposedMessage([
+            "fileSource": [
+                "filePath": attachment.url.path,
+                "cryptoArgs": NSNull(),
+            ],
+            "msgContent": messageContent,
+            "mentions": [:],
+        ], to: chat)
+    }
+
+    func deleteMessages(_ messageIDs: [Int64], from chat: NativeChat) throws {
+        guard !messageIDs.isEmpty else { return }
+        let identifiers = messageIDs.map(String.init).joined(separator: ",")
+        try ensureCommandSucceeded(send("/_delete item \(chat.kind.rawValue)\(chat.apiID) \(identifiers) internal"))
+    }
+
+    func receiveEvent(timeoutMicroseconds: Int32 = 500_000) -> Data? {
+        guard let controller,
+              let pointer = sx_core_recv_msg_wait(controller, timeoutMicroseconds) else {
+            return nil
+        }
+        defer { sx_core_free(pointer) }
+        guard let response = String(validatingUTF8: pointer), !response.isEmpty else { return nil }
+        return response.data(using: .utf8)
+    }
+
+    private func sendComposedMessage(_ message: [String: Any], to chat: NativeChat) throws {
+        let content = [message]
         let data = try JSONSerialization.data(withJSONObject: content)
         guard let json = String(data: data, encoding: .utf8) else {
             throw NativeChatError.invalidResponse("The message could not be encoded.")
@@ -57,17 +110,7 @@ actor SimpleXCore {
             let asGroup = chat.sendAsGroup ? "(as_group=on)" : ""
             command = "/_send \(chat.kind.rawValue)\(chat.apiID)\(asGroup) live=off ttl=default sign=off json \(json)"
         }
-        _ = try send(command)
-    }
-
-    func waitForEvent(timeoutMicroseconds: Int32 = 500_000) -> Bool {
-        guard let controller,
-              let pointer = sx_core_recv_msg_wait(controller, timeoutMicroseconds) else {
-            return false
-        }
-        defer { sx_core_free(pointer) }
-        guard let response = String(validatingUTF8: pointer) else { return false }
-        return !response.isEmpty
+        try ensureCommandSucceeded(send(command))
     }
 
     private func loadIfNeeded() throws {
@@ -118,7 +161,7 @@ actor SimpleXCore {
         guard let json = String(data: encoded, encoding: .utf8) else {
             throw NativeChatError.invalidResponse("The app file paths could not be encoded.")
         }
-        _ = try send("/set file paths \(json)")
+        try ensureCommandSucceeded(send("/set file paths \(json)"))
     }
 
     private func send(_ command: String) throws -> Data {
@@ -127,6 +170,12 @@ actor SimpleXCore {
         }
         let result = command.withCString { sx_core_send_cmd(controller, $0, 0) }
         return try data(from: result)
+    }
+
+    private func ensureCommandSucceeded(_ response: Data) throws {
+        if let message = NativeChatParser.commandError(from: response) {
+            throw NativeChatError.core(message)
+        }
     }
 
     private func data(from pointer: UnsafePointer<CChar>?) throws -> Data {

--- a/apps/macos-native/Sources/SimpleXNative/Core/SimpleXCore.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Core/SimpleXCore.swift
@@ -4,6 +4,14 @@ import Foundation
 actor SimpleXCore {
     private var controller: UnsafeMutableRawPointer?
     private var loaded = false
+    private let decryptedFilesDirectory: URL
+
+    init() {
+        decryptedFilesDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("chat.simplex.native", isDirectory: true)
+            .appendingPathComponent("OpenedAttachments", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    }
 
     deinit {
         if let controller {
@@ -11,6 +19,7 @@ actor SimpleXCore {
                 sx_core_free(result)
             }
         }
+        try? FileManager.default.removeItem(at: decryptedFilesDirectory)
     }
 
     func open(passphrase: String) throws -> (NativeProfile, [NativeChat]) {
@@ -39,17 +48,25 @@ actor SimpleXCore {
         return try NativeChatParser.messages(from: send("/_get chat \(chatID) \(pagination)"))
     }
 
-    func sendText(_ text: String, to chat: NativeChat) throws {
+    func sendText(_ text: String, quotedItemID: Int64?, to chat: NativeChat) throws {
         guard chat.kind.canSend else {
             throw NativeChatError.unavailable("This conversation cannot accept messages yet.")
         }
-        try sendComposedMessage([
-            "msgContent": ["type": "text", "text": text],
-            "mentions": [:],
-        ], to: chat)
+        try sendComposedMessage(
+            Self.composedMessage(
+                messageContent: ["type": "text", "text": text],
+                quotedItemID: quotedItemID
+            ),
+            to: chat
+        )
     }
 
-    func sendAttachment(_ attachment: PendingAttachment, caption: String, to chat: NativeChat) throws {
+    func sendAttachment(
+        _ attachment: PendingAttachment,
+        caption: String,
+        quotedItemID: Int64?,
+        to chat: NativeChat
+    ) throws {
         guard chat.kind.canSend else {
             throw NativeChatError.unavailable("This conversation cannot accept attachments yet.")
         }
@@ -71,14 +88,69 @@ actor SimpleXCore {
         case .document:
             messageContent = ["type": "file", "text": caption]
         }
-        try sendComposedMessage([
-            "fileSource": [
-                "filePath": attachment.url.path,
-                "cryptoArgs": NSNull(),
-            ],
+        try sendComposedMessage(
+            Self.composedMessage(
+                messageContent: messageContent,
+                fileSource: [
+                    "filePath": attachment.url.path,
+                    "cryptoArgs": NSNull(),
+                ],
+                quotedItemID: quotedItemID
+            ),
+            to: chat
+        )
+    }
+
+    func openableURL(for source: NativeCryptoFile, fileName: String?) throws -> URL {
+        let sourceURL = source.sourceURL
+        guard FileManager.default.fileExists(atPath: sourceURL.path) else {
+            throw NativeChatError.unavailable("The attachment is no longer stored on this Mac.")
+        }
+        guard let cryptoArgs = source.cryptoArgs else { return sourceURL }
+
+        try loadIfNeeded()
+        let directory = decryptedFilesDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let safeName = URL(fileURLWithPath: fileName ?? source.filePath).lastPathComponent
+        let destination = directory.appendingPathComponent(safeName.isEmpty ? "Attachment" : safeName)
+        let result = sourceURL.path.withCString { fromPath in
+            cryptoArgs.fileKey.withCString { key in
+                cryptoArgs.fileNonce.withCString { nonce in
+                    destination.path.withCString { toPath in
+                        sx_core_decrypt_file(fromPath, key, nonce, toPath)
+                    }
+                }
+            }
+        }
+        guard let result else {
+            try? FileManager.default.removeItem(at: directory)
+            throw NativeChatError.unavailable("SimpleX could not decrypt the attachment.")
+        }
+        defer { sx_core_free(result) }
+        let error = String(cString: result)
+        guard error.isEmpty else {
+            try? FileManager.default.removeItem(at: directory)
+            throw NativeChatError.core(error)
+        }
+        guard FileManager.default.fileExists(atPath: destination.path) else {
+            try? FileManager.default.removeItem(at: directory)
+            throw NativeChatError.unavailable("SimpleX decrypted the attachment without creating a readable file.")
+        }
+        return destination
+    }
+
+    nonisolated static func composedMessage(
+        messageContent: [String: Any],
+        fileSource: [String: Any]? = nil,
+        quotedItemID: Int64?
+    ) -> [String: Any] {
+        var message: [String: Any] = [
             "msgContent": messageContent,
-            "mentions": [:],
-        ], to: chat)
+            "mentions": [String: Int64](),
+        ]
+        if let fileSource { message["fileSource"] = fileSource }
+        if let quotedItemID { message["quotedItemId"] = quotedItemID }
+        return message
     }
 
     func deleteMessages(_ messageIDs: [Int64], from chat: NativeChat) throws {

--- a/apps/macos-native/Sources/SimpleXNative/Core/SimpleXCore.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Core/SimpleXCore.swift
@@ -258,7 +258,16 @@ actor SimpleXCore {
     }
 
     private func sendComposedMessage(_ message: [String: Any], to chat: NativeChat) throws {
-        try ensureCommandSucceeded(send(Self.sendCommand(message: message, to: chat)))
+        let response = try send(Self.sendCommand(message: message, to: chat))
+        if message["quotedItemId"] != nil,
+           NativeChatParser.commandErrorIsInvalidQuote(response) {
+            throw NativeChatError.replyTargetUnavailable
+        }
+        try NativeChatParser.validateCommandResponse(
+            response,
+            expectedType: "newChatItems",
+            requireChatItems: true
+        )
     }
 
     nonisolated static func sendCommand(message: [String: Any], to chat: NativeChat) throws -> String {
@@ -342,9 +351,7 @@ actor SimpleXCore {
     }
 
     private func ensureCommandSucceeded(_ response: Data) throws {
-        if let message = NativeChatParser.commandError(from: response) {
-            throw NativeChatError.core(message)
-        }
+        try NativeChatParser.validateCommandResponse(response)
     }
 
     private func data(from pointer: UnsafePointer<CChar>?) throws -> Data {

--- a/apps/macos-native/Sources/SimpleXNative/Core/SimpleXCore.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Core/SimpleXCore.swift
@@ -1,8 +1,25 @@
 import CoreBridge
 import Foundation
 
+private final class SimpleXControllerHandle: @unchecked Sendable {
+    // Safety: the handle is privately owned by SimpleXCore, never escapes that actor,
+    // and closes its immutable native pointer exactly once during teardown.
+    // TODO: remove the unchecked conformance when imported C pointers support Sendable ownership.
+    let pointer: UnsafeMutableRawPointer
+
+    init(_ pointer: UnsafeMutableRawPointer) {
+        self.pointer = pointer
+    }
+
+    deinit {
+        if let result = sx_core_close_store(pointer) {
+            sx_core_free(result)
+        }
+    }
+}
+
 actor SimpleXCore {
-    private var controller: UnsafeMutableRawPointer?
+    private var controller: SimpleXControllerHandle?
     private var loaded = false
     private let decryptedFilesDirectory: URL
 
@@ -14,11 +31,6 @@ actor SimpleXCore {
     }
 
     deinit {
-        if let controller {
-            if let result = sx_core_close_store(controller) {
-                sx_core_free(result)
-            }
-        }
         try? FileManager.default.removeItem(at: decryptedFilesDirectory)
     }
 
@@ -57,7 +69,7 @@ actor SimpleXCore {
             around: itemID,
             count: 0
         )))
-        return messages.first(where: { $0.id == itemID }) ?? messages.first
+        return messages.first(where: { $0.id == itemID })
     }
 
     nonisolated static func chatPageCommand(
@@ -237,7 +249,7 @@ actor SimpleXCore {
 
     func receiveEvent(timeoutMicroseconds: Int32 = 500_000) -> Data? {
         guard let controller,
-              let pointer = sx_core_recv_msg_wait(controller, timeoutMicroseconds) else {
+              let pointer = sx_core_recv_msg_wait(controller.pointer, timeoutMicroseconds) else {
             return nil
         }
         defer { sx_core_free(pointer) }
@@ -281,12 +293,16 @@ actor SimpleXCore {
     private func migrate(passphrase: String) throws -> Data {
         let prefix = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".local/share/simplex/simplex_v1").path
+        var rawController: UnsafeMutableRawPointer?
         let result = prefix.withCString { path in
             passphrase.withCString { key in
                 "yesUp".withCString { confirmation in
-                    sx_core_migrate_init(path, key, confirmation, &controller)
+                    sx_core_migrate_init(path, key, confirmation, &rawController)
                 }
             }
+        }
+        if let rawController {
+            controller = SimpleXControllerHandle(rawController)
         }
         return try data(from: result)
     }
@@ -316,7 +332,7 @@ actor SimpleXCore {
         guard let controller else {
             throw NativeChatError.unavailable("The SimpleX database is not open.")
         }
-        let result = command.withCString { sx_core_send_cmd(controller, $0, 0) }
+        let result = command.withCString { sx_core_send_cmd(controller.pointer, $0, 0) }
         return try data(from: result)
     }
 

--- a/apps/macos-native/Sources/SimpleXNative/MainWindowCommands.swift
+++ b/apps/macos-native/Sources/SimpleXNative/MainWindowCommands.swift
@@ -1,0 +1,18 @@
+import AppKit
+import SwiftUI
+
+struct MainWindowCommands: Commands {
+    static let windowID = "main"
+
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some Commands {
+        CommandGroup(replacing: .newItem) {
+            Button("New Window") {
+                openWindow(id: Self.windowID)
+                NSApp.activate(ignoringOtherApps: true)
+            }
+            .keyboardShortcut("n")
+        }
+    }
+}

--- a/apps/macos-native/Sources/SimpleXNative/Models/DesktopModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/DesktopModels.swift
@@ -131,6 +131,28 @@ struct PendingAttachment: Identifiable, Hashable, Sendable {
     }
 }
 
+struct PendingAttachmentSendStep: Equatable, Sendable {
+    let attachment: PendingAttachment
+    let caption: String
+    let quotedItemID: Int64?
+}
+
+enum PendingAttachmentBatch {
+    static func sendSteps(
+        attachments: [PendingAttachment],
+        caption: String,
+        quotedItemID: Int64?
+    ) -> [PendingAttachmentSendStep] {
+        attachments.enumerated().map { index, attachment in
+            PendingAttachmentSendStep(
+                attachment: attachment,
+                caption: index == attachments.index(before: attachments.endIndex) ? caption : "",
+                quotedItemID: index == attachments.startIndex ? quotedItemID : nil
+            )
+        }
+    }
+}
+
 enum AttachmentValidationError: LocalizedError, Equatable {
     case notAReadableFile(String)
     case tooLarge(String)

--- a/apps/macos-native/Sources/SimpleXNative/Models/DesktopModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/DesktopModels.swift
@@ -1,0 +1,402 @@
+import AppKit
+import Foundation
+import UniformTypeIdentifiers
+
+enum DesktopChatDensity: String, CaseIterable, Identifiable, Sendable {
+    case compact
+    case comfortable
+    case spacious
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .compact: "Compact"
+        case .comfortable: "Comfortable"
+        case .spacious: "Spacious"
+        }
+    }
+
+    var tokens: DesktopDensityTokens {
+        switch self {
+        case .compact:
+            DesktopDensityTokens(chatRowPadding: 4, avatarSize: 40, messagePadding: 8, transcriptGap: 8, composerPadding: 8)
+        case .comfortable:
+            DesktopDensityTokens(chatRowPadding: 8, avatarSize: 44, messagePadding: 12, transcriptGap: 12, composerPadding: 12)
+        case .spacious:
+            DesktopDensityTokens(chatRowPadding: 12, avatarSize: 48, messagePadding: 16, transcriptGap: 16, composerPadding: 16)
+        }
+    }
+}
+
+struct DesktopDensityTokens: Equatable, Sendable {
+    let chatRowPadding: CGFloat
+    let avatarSize: CGFloat
+    let messagePadding: CGFloat
+    let transcriptGap: CGFloat
+    let composerPadding: CGFloat
+}
+
+enum PendingAttachmentKind: String, Sendable {
+    case image
+    case video
+    case document
+
+    var symbolName: String {
+        switch self {
+        case .image: "photo"
+        case .video: "film"
+        case .document: "doc"
+        }
+    }
+}
+
+struct PendingAttachment: Identifiable, Hashable, Sendable {
+    static let maximumByteCount: Int64 = 5 * 1_024 * 1_024 * 1_024
+
+    let id: UUID
+    let url: URL
+    let fileName: String
+    let kind: PendingAttachmentKind
+    let byteCount: Int64
+    let previewImage: String?
+
+    static func stage(url: URL) throws -> PendingAttachment {
+        let resolvedURL = url.resolvingSymlinksInPath()
+        let values = try resolvedURL.resourceValues(forKeys: [
+            .contentTypeKey,
+            .fileSizeKey,
+            .isRegularFileKey,
+            .isReadableKey,
+            .nameKey,
+        ])
+        guard values.isRegularFile == true, values.isReadable != false else {
+            throw AttachmentValidationError.notAReadableFile(resolvedURL.lastPathComponent)
+        }
+        let byteCount = Int64(values.fileSize ?? 0)
+        guard byteCount <= maximumByteCount else {
+            throw AttachmentValidationError.tooLarge(resolvedURL.lastPathComponent)
+        }
+        let contentType = values.contentType
+        let kind: PendingAttachmentKind
+        if contentType?.conforms(to: .image) == true {
+            kind = .image
+        } else if contentType?.conforms(to: .movie) == true || contentType?.conforms(to: .video) == true {
+            kind = .video
+        } else {
+            kind = .document
+        }
+        return PendingAttachment(
+            id: UUID(),
+            url: resolvedURL,
+            fileName: values.name ?? resolvedURL.lastPathComponent,
+            kind: kind,
+            byteCount: byteCount,
+            previewImage: kind == .image ? imagePreview(from: resolvedURL) : nil
+        )
+    }
+
+    static func reordered(_ attachments: [PendingAttachment], from source: UUID, before destination: UUID) -> [PendingAttachment] {
+        guard source != destination,
+              let sourceIndex = attachments.firstIndex(where: { $0.id == source }),
+              let destinationIndex = attachments.firstIndex(where: { $0.id == destination }) else {
+            return attachments
+        }
+        var result = attachments
+        let attachment = result.remove(at: sourceIndex)
+        let adjustedDestination = sourceIndex < destinationIndex ? destinationIndex - 1 : destinationIndex
+        result.insert(attachment, at: adjustedDestination)
+        return result
+    }
+
+    static func remainingAfterFailure(_ attachments: [PendingAttachment], at failedIndex: Int) -> [PendingAttachment] {
+        Array(attachments.dropFirst(min(max(failedIndex, 0), attachments.count)))
+    }
+
+    private static func imagePreview(from url: URL) -> String? {
+        guard let image = NSImage(contentsOf: url), image.size.width > 0, image.size.height > 0 else { return nil }
+        let maximumDimension: CGFloat = 512
+        let scale = min(1, maximumDimension / max(image.size.width, image.size.height))
+        let size = NSSize(width: image.size.width * scale, height: image.size.height * scale)
+        let preview = NSImage(size: size)
+        preview.lockFocus()
+        image.draw(in: NSRect(origin: .zero, size: size), from: .zero, operation: .copy, fraction: 1)
+        preview.unlockFocus()
+        guard let tiff = preview.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiff),
+              let data = bitmap.representation(using: .jpeg, properties: [.compressionFactor: 0.72]) else {
+            return nil
+        }
+        return "data:image/jpeg;base64,\(data.base64EncodedString())"
+    }
+}
+
+enum AttachmentValidationError: LocalizedError, Equatable {
+    case notAReadableFile(String)
+    case tooLarge(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .notAReadableFile(name): "“\(name)” is not a readable file."
+        case let .tooLarge(name): "“\(name)” is larger than SimpleX’s 5 GB file limit."
+        }
+    }
+}
+
+enum MessageSelection {
+    static func updated(
+        current: Set<Int64>,
+        anchor: Int64?,
+        clicked: Int64,
+        orderedIDs: [Int64],
+        command: Bool,
+        shift: Bool
+    ) -> (selection: Set<Int64>, anchor: Int64?) {
+        if shift,
+           let anchor,
+           let anchorIndex = orderedIDs.firstIndex(of: anchor),
+           let clickedIndex = orderedIDs.firstIndex(of: clicked) {
+            let range = min(anchorIndex, clickedIndex)...max(anchorIndex, clickedIndex)
+            let rangeSelection = Set(range.map { orderedIDs[$0] })
+            return (command ? current.union(rangeSelection) : rangeSelection, anchor)
+        }
+        if command {
+            var selection = current
+            if !selection.insert(clicked).inserted { selection.remove(clicked) }
+            return (selection, clicked)
+        }
+        return ([clicked], clicked)
+    }
+}
+
+enum NotificationPreviewMode: String, CaseIterable, Identifiable, Sendable {
+    case message
+    case contact
+    case hidden
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .message: "Message"
+        case .contact: "Contact"
+        case .hidden: "Hidden"
+        }
+    }
+}
+
+enum NotificationPermissionState: String, Sendable {
+    case notDetermined
+    case denied
+    case authorized
+    case provisional
+    case unknown
+
+    var title: String {
+        switch self {
+        case .notDetermined: "Not Requested"
+        case .denied: "Denied"
+        case .authorized: "Allowed"
+        case .provisional: "Provisional"
+        case .unknown: "Unknown"
+        }
+    }
+}
+
+enum DesktopNotificationCategory: String, Sendable {
+    case message = "SIMPLEX_MESSAGE"
+    case contactRequest = "SIMPLEX_CONTACT_REQUEST"
+    case incomingCall = "SIMPLEX_INCOMING_CALL"
+}
+
+struct NotificationRoute: Hashable, Sendable {
+    let userID: Int64?
+    let remoteHostID: Int64?
+    let chatID: String
+    let messageID: Int64?
+
+    var identifier: String {
+        let safeChat = chatID.replacingOccurrences(
+            of: "[^A-Za-z0-9._-]",
+            with: "_",
+            options: .regularExpression
+        )
+        return "simplex.\(userID ?? -1).\(remoteHostID ?? -1).\(safeChat).\(messageID ?? -1)"
+    }
+}
+
+struct DesktopNotificationPayload: Sendable {
+    let route: NotificationRoute
+    let displayName: String
+    let preview: String
+    let category: DesktopNotificationCategory
+}
+
+struct DesktopNotificationPreview: Equatable, Sendable {
+    let title: String
+    let body: String
+}
+
+struct NotificationRouteQueue: Sendable {
+    private var routes: [NotificationRoute] = []
+
+    mutating func enqueue(_ route: NotificationRoute) {
+        if !routes.contains(route) { routes.append(route) }
+    }
+
+    mutating func consumeIfReady(_ ready: Bool) -> [NotificationRoute] {
+        guard ready else { return [] }
+        defer { routes = [] }
+        return routes
+    }
+}
+
+enum NativeNotificationParser {
+    static func payload(from data: Data) -> DesktopNotificationPayload? {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let result = root["result"] as? [String: Any],
+              let type = result["type"] as? String else {
+            return nil
+        }
+        let remoteHostID = int64(root["remoteHostId"])
+        switch type {
+        case "newChatItems":
+            guard let user = result["user"] as? [String: Any],
+                  let userID = int64(user["userId"]),
+                  let entries = result["chatItems"] as? [[String: Any]] else { return nil }
+            for entry in entries {
+                guard let info = entry["chatInfo"] as? [String: Any],
+                      let item = entry["chatItem"] as? [String: Any],
+                      let meta = item["meta"] as? [String: Any],
+                      let messageID = int64(meta["itemId"]),
+                      isReceived(item) else { continue }
+                guard let identity = chatIdentity(info) else { continue }
+                return DesktopNotificationPayload(
+                    route: NotificationRoute(
+                        userID: userID,
+                        remoteHostID: remoteHostID,
+                        chatID: identity.id,
+                        messageID: messageID
+                    ),
+                    displayName: identity.name,
+                    preview: (meta["itemText"] as? String) ?? "New message",
+                    category: .message
+                )
+            }
+            return nil
+        case "receivedContactRequest":
+            guard let user = result["user"] as? [String: Any],
+                  let request = result["contactRequest"] as? [String: Any],
+                  let requestID = int64(request["contactRequestId"]) else { return nil }
+            let profile = request["profile"] as? [String: Any]
+            let name = (profile?["displayName"] as? String)
+                ?? (request["localDisplayName"] as? String)
+                ?? "New contact"
+            return DesktopNotificationPayload(
+                route: NotificationRoute(
+                    userID: int64(user["userId"]),
+                    remoteHostID: remoteHostID,
+                    chatID: "<@\(requestID)",
+                    messageID: nil
+                ),
+                displayName: name,
+                preview: "New contact request",
+                category: .contactRequest
+            )
+        case "callInvitation":
+            guard let invitation = result["callInvitation"] as? [String: Any],
+                  let user = invitation["user"] as? [String: Any],
+                  let contact = invitation["contact"] as? [String: Any],
+                  let contactID = int64(contact["contactId"]) else { return nil }
+            let profile = contact["profile"] as? [String: Any]
+            let callType = invitation["callType"] as? [String: Any]
+            let media = callType?["media"] as? String
+            return DesktopNotificationPayload(
+                route: NotificationRoute(
+                    userID: int64(user["userId"]),
+                    remoteHostID: int64(invitation["remoteHostId"]) ?? remoteHostID,
+                    chatID: "@\(contactID)",
+                    messageID: nil
+                ),
+                displayName: (contact["localDisplayName"] as? String)
+                    ?? (profile?["displayName"] as? String)
+                    ?? "Incoming call",
+                preview: media == "video" ? "Incoming video call" : "Incoming audio call",
+                category: .incomingCall
+            )
+        default:
+            return nil
+        }
+    }
+
+    static func shouldSuppress(
+        windowFocused: Bool,
+        activeUserID: Int64?,
+        activeRemoteHostID: Int64?,
+        activeChatID: String?,
+        route: NotificationRoute
+    ) -> Bool {
+        windowFocused
+            && activeUserID == route.userID
+            && activeRemoteHostID == route.remoteHostID
+            && activeChatID == route.chatID
+    }
+
+    static func preview(
+        for payload: DesktopNotificationPayload,
+        mode: NotificationPreviewMode
+    ) -> DesktopNotificationPreview {
+        let genericBody = switch payload.category {
+        case .message: "New message"
+        case .contactRequest: "New contact request"
+        case .incomingCall: "Incoming call"
+        }
+        return switch mode {
+        case .message:
+            DesktopNotificationPreview(title: payload.displayName, body: payload.preview)
+        case .contact:
+            DesktopNotificationPreview(title: payload.displayName, body: genericBody)
+        case .hidden:
+            DesktopNotificationPreview(title: "SimpleX Chat", body: genericBody)
+        }
+    }
+
+    private static func isReceived(_ item: [String: Any]) -> Bool {
+        guard let direction = item["chatDir"] as? [String: Any] else { return false }
+        let type = (direction["type"] as? String) ?? direction.keys.first ?? ""
+        return type.hasSuffix("Rcv")
+    }
+
+    private static func chatIdentity(_ info: [String: Any]) -> (id: String, name: String)? {
+        guard let type = info["type"] as? String else { return nil }
+        let payload: [String: Any]
+        let prefix: String
+        let identifier: Int64?
+        switch type {
+        case "direct":
+            payload = info["contact"] as? [String: Any] ?? [:]
+            prefix = "@"
+            identifier = int64(payload["contactId"])
+        case "group":
+            payload = info["groupInfo"] as? [String: Any] ?? [:]
+            prefix = "#"
+            identifier = int64(payload["groupId"])
+        default:
+            return nil
+        }
+        guard let identifier else { return nil }
+        let profile = payload["profile"] as? [String: Any]
+        let groupProfile = payload["groupProfile"] as? [String: Any]
+        let name = (payload["localDisplayName"] as? String)
+            ?? (profile?["displayName"] as? String)
+            ?? (groupProfile?["displayName"] as? String)
+            ?? "SimpleX"
+        return ("\(prefix)\(identifier)", name)
+    }
+
+    private static func int64(_ value: Any?) -> Int64? {
+        if let value = value as? Int64 { return value }
+        if let value = value as? NSNumber { return value.int64Value }
+        return nil
+    }
+}

--- a/apps/macos-native/Sources/SimpleXNative/Models/DesktopModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/DesktopModels.swift
@@ -169,6 +169,26 @@ enum MessageSelection {
     }
 }
 
+enum ConversationSearch {
+    static func matches(_ messages: [NativeMessage], query: String) -> [NativeMessage] {
+        guard !query.isEmpty else { return [] }
+        return messages.filter { $0.text.localizedCaseInsensitiveContains(query) }
+    }
+
+    static func nextID(in matches: [NativeMessage], currentID: Int64?, offset: Int) -> Int64? {
+        guard !matches.isEmpty else { return nil }
+        let currentIndex = currentID.flatMap { id in matches.firstIndex(where: { $0.id == id }) } ?? 0
+        let nextIndex = (currentIndex + offset + matches.count) % matches.count
+        return matches[nextIndex].id
+    }
+
+    static func resultDescription(matches: [NativeMessage], selectedID: Int64?, queryIsEmpty: Bool) -> String {
+        guard !matches.isEmpty else { return queryIsEmpty ? "" : "No Results" }
+        let index = selectedID.flatMap { id in matches.firstIndex(where: { $0.id == id }) } ?? 0
+        return "\(index + 1) of \(matches.count)"
+    }
+}
+
 enum NotificationPreviewMode: String, CaseIterable, Identifiable, Sendable {
     case message
     case contact

--- a/apps/macos-native/Sources/SimpleXNative/Models/DesktopModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/DesktopModels.swift
@@ -37,6 +37,17 @@ struct DesktopDensityTokens: Equatable, Sendable {
     let composerPadding: CGFloat
 }
 
+enum ComposerReturnAction: Equatable, Sendable {
+    case send
+    case insertNewline
+}
+
+enum ComposerKeyboard {
+    static func returnAction(shiftPressed: Bool) -> ComposerReturnAction {
+        shiftPressed ? .insertNewline : .send
+    }
+}
+
 enum PendingAttachmentKind: String, Sendable {
     case image
     case video

--- a/apps/macos-native/Sources/SimpleXNative/Models/DesktopModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/DesktopModels.swift
@@ -202,6 +202,12 @@ enum MessageSelection {
     }
 }
 
+enum MessageReplyControlVisibility {
+    static func isVisible(canReply: Bool, hovering: Bool, selected: Bool) -> Bool {
+        canReply && (hovering || selected)
+    }
+}
+
 enum ConversationSearch {
     static func matches(_ messages: [NativeMessage], query: String) -> [NativeMessage] {
         guard !query.isEmpty else { return [] }

--- a/apps/macos-native/Sources/SimpleXNative/Models/DesktopModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/DesktopModels.swift
@@ -48,6 +48,15 @@ enum ComposerKeyboard {
     }
 }
 
+enum DesktopCopyCommandRoute: Equatable, Sendable {
+    case selectedMessages
+    case firstResponder
+
+    static func resolve(transcriptFocused: Bool, selectedMessageCount: Int) -> Self {
+        transcriptFocused && selectedMessageCount > 0 ? .selectedMessages : .firstResponder
+    }
+}
+
 enum PendingAttachmentKind: String, Sendable {
     case image
     case video

--- a/apps/macos-native/Sources/SimpleXNative/Models/DesktopModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/DesktopModels.swift
@@ -200,6 +200,10 @@ enum MessageSelection {
         }
         return ([clicked], clicked)
     }
+
+    static func clipboardText(for messages: [NativeMessage]) -> String {
+        messages.map(\.replyPreview).joined(separator: "\n\n")
+    }
 }
 
 enum MessageReplyControlVisibility {

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
@@ -1,0 +1,237 @@
+import AppKit
+import Foundation
+
+enum NativeChatKind: String, Sendable {
+    case direct = "@"
+    case group = "#"
+    case local = "*"
+    case contactRequest = "<@"
+    case contactConnection = ":"
+
+    var canSend: Bool {
+        self == .direct || self == .group || self == .local
+    }
+}
+
+struct NativeProfile: Sendable {
+    let userID: Int64
+    let displayName: String
+    let image: String?
+}
+
+struct NativeChat: Identifiable, Hashable, Sendable {
+    let id: String
+    let apiID: Int64
+    let kind: NativeChatKind
+    let displayName: String
+    let image: String?
+    let preview: String
+    let timestamp: Date?
+    let unreadCount: Int
+    let sendAsGroup: Bool
+
+    var accessibilityDescription: String {
+        let unread = unreadCount == 0 ? "" : ", \(unreadCount) unread"
+        let message = preview.isEmpty ? "" : ", \(preview)"
+        return "\(displayName)\(unread)\(message)"
+    }
+}
+
+struct NativeMessage: Identifiable, Hashable, Sendable {
+    let id: Int64
+    let text: String
+    let timestamp: Date?
+    let sent: Bool
+    let author: String?
+}
+
+enum NativeChatParser {
+    static func profile(from data: Data) throws -> NativeProfile {
+        let result = try responseResult(from: data, expectedType: "activeUser")
+        guard let user = result["user"] as? [String: Any] else {
+            throw NativeChatError.invalidResponse("The active profile was missing from the core response.")
+        }
+        let profile = user["profile"] as? [String: Any]
+        guard let userID = int64(user["userId"]),
+              let displayName = string(profile?["displayName"]) ?? string(user["localDisplayName"]) else {
+            throw NativeChatError.invalidResponse("The active profile could not be decoded.")
+        }
+        return NativeProfile(userID: userID, displayName: displayName, image: string(profile?["image"]))
+    }
+
+    static func chats(from data: Data) throws -> [NativeChat] {
+        let result = try responseResult(from: data, expectedType: "apiChats")
+        guard let rawChats = result["chats"] as? [[String: Any]] else {
+            throw NativeChatError.invalidResponse("The chat list was missing from the core response.")
+        }
+        return rawChats.compactMap(parseChat)
+    }
+
+    static func messages(from data: Data) throws -> [NativeMessage] {
+        let result = try responseResult(from: data, expectedType: "apiChat")
+        guard let chat = result["chat"] as? [String: Any],
+              let items = chat["chatItems"] as? [[String: Any]] else {
+            throw NativeChatError.invalidResponse("The conversation was missing from the core response.")
+        }
+        return items.compactMap(parseMessage)
+    }
+
+    static func migrationSucceeded(_ data: Data) -> Bool {
+        guard let value = try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) else { return false }
+        if let string = value as? String { return string == "ok" }
+        guard let object = value as? [String: Any] else { return false }
+        return string(object["type"]) == "ok" || object["ok"] != nil
+    }
+
+    static func migrationError(from data: Data) -> String {
+        guard let value = try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) else {
+            return String(data: data, encoding: .utf8) ?? "Unable to open the database."
+        }
+        if let object = value as? [String: Any] {
+            let type = string(object["type"]) ?? object.keys.first ?? "databaseError"
+            switch type {
+            case "errorNotADatabase": return "That database passphrase is not correct."
+            case "errorMigration": return "The database needs a migration confirmation before it can be opened."
+            case "errorSQL": return "The database could not be read."
+            default: return "Unable to open the database (\(type))."
+            }
+        }
+        return "Unable to open the database."
+    }
+
+    static func image(from encoded: String?) -> NSImage? {
+        guard var encoded, !encoded.isEmpty else { return nil }
+        if let comma = encoded.firstIndex(of: ","), encoded[..<comma].contains("base64") {
+            encoded = String(encoded[encoded.index(after: comma)...])
+        }
+        guard let data = Data(base64Encoded: encoded) else { return nil }
+        return NSImage(data: data)
+    }
+
+    private static func responseResult(from data: Data, expectedType: String) throws -> [String: Any] {
+        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw NativeChatError.invalidResponse("The SimpleX core returned invalid JSON.")
+        }
+        if let error = root["error"] {
+            throw NativeChatError.core(String(describing: error))
+        }
+        guard let result = root["result"] as? [String: Any] else {
+            throw NativeChatError.invalidResponse("The SimpleX core response had no result.")
+        }
+        if string(result["type"]) == expectedType { return result }
+        if let nested = result[expectedType] as? [String: Any] {
+            return nested.merging(["type": expectedType]) { current, _ in current }
+        }
+        throw NativeChatError.invalidResponse("Expected \(expectedType), received \(string(result["type"]) ?? "an unknown response").")
+    }
+
+    private static func parseChat(_ object: [String: Any]) -> NativeChat? {
+        guard let info = object["chatInfo"] as? [String: Any],
+              let type = string(info["type"]),
+              let kind = kind(for: type) else { return nil }
+
+        let payload: [String: Any]
+        let idKeys: [String]
+        switch kind {
+        case .direct:
+            payload = info["contact"] as? [String: Any] ?? [:]
+            idKeys = ["contactId", "apiId"]
+        case .group:
+            payload = info["groupInfo"] as? [String: Any] ?? [:]
+            idKeys = ["groupId", "apiId"]
+        case .local:
+            payload = info["noteFolder"] as? [String: Any] ?? [:]
+            idKeys = ["noteFolderId", "apiId"]
+        case .contactRequest:
+            payload = info["contactRequest"] as? [String: Any] ?? [:]
+            idKeys = ["contactRequestId", "apiId"]
+        case .contactConnection:
+            payload = info["contactConnection"] as? [String: Any] ?? [:]
+            idKeys = ["contactConnectionId", "apiId"]
+        }
+        guard let apiID = idKeys.lazy.compactMap({ int64(payload[$0]) }).first else { return nil }
+
+        let profile = payload["profile"] as? [String: Any]
+        let groupProfile = payload["groupProfile"] as? [String: Any]
+        let displayName = string(payload["localDisplayName"])
+            ?? string(payload["displayName"])
+            ?? string(profile?["displayName"])
+            ?? string(groupProfile?["displayName"])
+            ?? "Conversation"
+        let image = string(profile?["image"])
+            ?? string(groupProfile?["image"])
+            ?? string(payload["image"])
+        let items = object["chatItems"] as? [[String: Any]] ?? []
+        let lastMeta = items.last?["meta"] as? [String: Any]
+        let stats = object["chatStats"] as? [String: Any]
+        return NativeChat(
+            id: "\(kind.rawValue)\(apiID)",
+            apiID: apiID,
+            kind: kind,
+            displayName: displayName,
+            image: image,
+            preview: string(lastMeta?["itemText"]) ?? "",
+            timestamp: date(lastMeta?["itemTs"]),
+            unreadCount: int(stats?["unreadCount"]) ?? 0,
+            sendAsGroup: bool(payload["sendAsGroup"]) ?? false
+        )
+    }
+
+    private static func parseMessage(_ object: [String: Any]) -> NativeMessage? {
+        guard let meta = object["meta"] as? [String: Any],
+              let id = int64(meta["itemId"]) else { return nil }
+        let direction = object["chatDir"] as? [String: Any]
+        let directionType = string(direction?["type"]) ?? direction?.keys.first ?? ""
+        let member = direction?["groupMember"] as? [String: Any]
+        let profile = member?["memberProfile"] as? [String: Any]
+        return NativeMessage(
+            id: id,
+            text: string(meta["itemText"]) ?? "",
+            timestamp: date(meta["itemTs"]),
+            sent: directionType.hasSuffix("Snd"),
+            author: string(profile?["displayName"]) ?? string(member?["localDisplayName"])
+        )
+    }
+
+    private static func kind(for type: String) -> NativeChatKind? {
+        switch type {
+        case "direct": .direct
+        case "group": .group
+        case "local": .local
+        case "contactRequest": .contactRequest
+        case "contactConnection": .contactConnection
+        default: nil
+        }
+    }
+
+    private static func string(_ value: Any?) -> String? { value as? String }
+    private static func bool(_ value: Any?) -> Bool? { value as? Bool }
+    private static func int(_ value: Any?) -> Int? {
+        if let value = value as? Int { return value }
+        if let value = value as? NSNumber { return value.intValue }
+        return nil
+    }
+    private static func int64(_ value: Any?) -> Int64? {
+        if let value = value as? Int64 { return value }
+        if let value = value as? NSNumber { return value.int64Value }
+        return nil
+    }
+    private static func date(_ value: Any?) -> Date? {
+        guard let raw = value as? String else { return nil }
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return fractional.date(from: raw) ?? ISO8601DateFormatter().date(from: raw)
+    }
+}
+
+enum NativeChatError: LocalizedError, Sendable {
+    case core(String)
+    case invalidResponse(String)
+    case unavailable(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .core(message), let .invalidResponse(message), let .unavailable(message): message
+        }
+    }
+}

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
@@ -12,6 +12,10 @@ enum NativeChatKind: String, Sendable {
         self == .direct || self == .group || self == .local
     }
 
+    var canReply: Bool {
+        self == .direct || self == .group
+    }
+
     var toolbarSubtitle: String {
         switch self {
         case .direct: "SimpleX contact"
@@ -55,26 +59,70 @@ struct NativeMessage: Identifiable, Hashable, Sendable {
     let author: String?
     let deletable: Bool
     let content: NativeMessageContent
+    let quotedItem: NativeQuote?
+    let fileSource: NativeCryptoFile?
+
+    init(
+        id: Int64,
+        text: String,
+        timestamp: Date?,
+        sent: Bool,
+        author: String?,
+        deletable: Bool,
+        content: NativeMessageContent,
+        quotedItem: NativeQuote? = nil,
+        fileSource: NativeCryptoFile? = nil
+    ) {
+        self.id = id
+        self.text = text
+        self.timestamp = timestamp
+        self.sent = sent
+        self.author = author
+        self.deletable = deletable
+        self.content = content
+        self.quotedItem = quotedItem
+        self.fileSource = fileSource
+    }
 }
 
 enum NativeMessageContent: Hashable, Sendable {
     case text
-    case image(preview: String?, fileName: String?, filePath: String?)
-    case video(preview: String?, fileName: String?, filePath: String?)
-    case file(fileName: String?, filePath: String?)
+    case image(preview: String?, fileName: String?)
+    case video(preview: String?, fileName: String?)
+    case file(fileName: String?)
 
-    var fileURL: URL? {
-        let path: String?
+    var attachmentDescription: String? {
         switch self {
-        case .text: path = nil
-        case let .image(_, _, filePath), let .video(_, _, filePath), let .file(_, filePath): path = filePath
+        case .text: nil
+        case let .image(_, fileName): fileName ?? "Photo"
+        case let .video(_, fileName): fileName ?? "Video"
+        case let .file(fileName): fileName ?? "File"
         }
-        guard let path, !path.isEmpty else { return nil }
-        if path.hasPrefix("/") { return URL(fileURLWithPath: path) }
+    }
+}
+
+struct NativeQuote: Hashable, Sendable {
+    let messageID: Int64?
+    let text: String
+    let sent: Bool
+    let author: String?
+}
+
+struct NativeCryptoFile: Hashable, Sendable {
+    let filePath: String
+    let cryptoArgs: NativeCryptoFileArgs?
+
+    var sourceURL: URL {
+        if filePath.hasPrefix("/") { return URL(fileURLWithPath: filePath) }
         return FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".local/share/simplex/simplex_v1_files", isDirectory: true)
-            .appendingPathComponent(path)
+            .appendingPathComponent(filePath)
     }
+}
+
+struct NativeCryptoFileArgs: Hashable, Sendable {
+    let fileKey: String
+    let fileNonce: String
 }
 
 enum NativeChatParser {
@@ -237,14 +285,20 @@ enum NativeChatParser {
         let fileSource = file?["fileSource"] as? [String: Any]
         let fileName = string(file?["fileName"])
         let filePath = string(fileSource?["filePath"])
+        let cryptoArgsObject = fileSource?["cryptoArgs"] as? [String: Any]
+        let cryptoArgs = cryptoArgsObject.flatMap { args -> NativeCryptoFileArgs? in
+            guard let key = string(args["fileKey"]), let nonce = string(args["fileNonce"]) else { return nil }
+            return NativeCryptoFileArgs(fileKey: key, fileNonce: nonce)
+        }
+        let nativeFileSource = filePath.map { NativeCryptoFile(filePath: $0, cryptoArgs: cryptoArgs) }
         let content: NativeMessageContent
         switch string(messageContent?["type"]) {
         case "image":
-            content = .image(preview: string(messageContent?["image"]), fileName: fileName, filePath: filePath)
+            content = .image(preview: string(messageContent?["image"]), fileName: fileName)
         case "video":
-            content = .video(preview: string(messageContent?["image"]), fileName: fileName, filePath: filePath)
+            content = .video(preview: string(messageContent?["image"]), fileName: fileName)
         case "file":
-            content = .file(fileName: fileName, filePath: filePath)
+            content = .file(fileName: fileName)
         default:
             content = .text
         }
@@ -255,7 +309,37 @@ enum NativeChatParser {
             sent: directionType.hasSuffix("Snd"),
             author: string(profile?["displayName"]) ?? string(member?["localDisplayName"]),
             deletable: bool(meta["deletable"]) ?? false,
-            content: content
+            content: content,
+            quotedItem: parseQuote(object["quotedItem"]),
+            fileSource: nativeFileSource
+        )
+    }
+
+    private static func parseQuote(_ value: Any?) -> NativeQuote? {
+        guard let object = value as? [String: Any],
+              let content = object["content"] as? [String: Any] else { return nil }
+        let direction = object["chatDir"] as? [String: Any]
+        let directionType = string(direction?["type"]) ?? direction?.keys.first ?? ""
+        let member = direction?["groupMember"] as? [String: Any]
+        let memberProfile = member?["memberProfile"] as? [String: Any]
+        let rawText = string(content["text"]) ?? ""
+        let text: String
+        if !rawText.isEmpty {
+            text = rawText
+        } else {
+            switch string(content["type"]) {
+            case "image": text = "Photo"
+            case "video": text = "Video"
+            case "voice": text = "Voice message"
+            case "file": text = "File"
+            default: text = "Message"
+            }
+        }
+        return NativeQuote(
+            messageID: int64(object["itemId"]),
+            text: text,
+            sent: directionType.hasSuffix("Snd"),
+            author: string(memberProfile?["displayName"]) ?? string(member?["localDisplayName"])
         )
     }
 

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
@@ -83,6 +83,11 @@ struct NativeMessage: Identifiable, Hashable, Sendable {
         self.quotedItem = quotedItem
         self.fileSource = fileSource
     }
+
+    var replyPreview: String {
+        let normalizedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalizedText.isEmpty ? (content.attachmentDescription ?? "Message") : normalizedText
+    }
 }
 
 enum NativeMessageContent: Hashable, Sendable {
@@ -94,10 +99,15 @@ enum NativeMessageContent: Hashable, Sendable {
     var attachmentDescription: String? {
         switch self {
         case .text: nil
-        case let .image(_, fileName): fileName ?? "Photo"
-        case let .video(_, fileName): fileName ?? "Video"
-        case let .file(fileName): fileName ?? "File"
+        case let .image(_, fileName): Self.description(fileName, fallback: "Photo")
+        case let .video(_, fileName): Self.description(fileName, fallback: "Video")
+        case let .file(fileName): Self.description(fileName, fallback: "File")
         }
+    }
+
+    private static func description(_ fileName: String?, fallback: String) -> String {
+        let normalizedName = fileName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return normalizedName.isEmpty ? fallback : normalizedName
     }
 }
 
@@ -322,7 +332,7 @@ enum NativeChatParser {
         let directionType = string(direction?["type"]) ?? direction?.keys.first ?? ""
         let member = direction?["groupMember"] as? [String: Any]
         let memberProfile = member?["memberProfile"] as? [String: Any]
-        let rawText = string(content["text"]) ?? ""
+        let rawText = string(content["text"])?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let text: String
         if !rawText.isEmpty {
             text = rawText

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
@@ -178,6 +178,10 @@ struct NativeLinkPreview: Hashable, Sendable {
         NativeMessageLink.standaloneURL(in: uri)
     }
 
+    var inlineVideoURL: URL? {
+        NativeMessageLink.youtubeEmbedURL(for: uri)
+    }
+
     var displayHost: String {
         destination?.host(percentEncoded: false) ?? uri
     }
@@ -196,6 +200,81 @@ enum NativeMessageLink {
               ["http", "https"].contains(components.scheme?.lowercased() ?? ""),
               components.host?.isEmpty == false else { return nil }
         return components.url
+    }
+
+    static func youtubeEmbedURL(for text: String) -> URL? {
+        guard let destination = standaloneURL(in: text),
+              let components = URLComponents(url: destination, resolvingAgainstBaseURL: false),
+              let host = components.host?.lowercased() else { return nil }
+
+        let normalizedHost = host
+            .replacingOccurrences(of: "www.", with: "")
+            .replacingOccurrences(of: "m.", with: "")
+        let pathComponents = components.path.split(separator: "/").map(String.init)
+        let videoID: String?
+        if normalizedHost == "youtu.be" {
+            videoID = pathComponents.first
+        } else if ["youtube.com", "youtube-nocookie.com"].contains(normalizedHost) {
+            if components.path == "/watch" {
+                videoID = components.queryItems?.first(where: { $0.name == "v" })?.value
+            } else if let route = pathComponents.first,
+                      ["embed", "shorts", "live"].contains(route) {
+                videoID = pathComponents.dropFirst().first
+            } else {
+                videoID = nil
+            }
+        } else {
+            videoID = nil
+        }
+
+        guard let videoID, isYouTubeVideoID(videoID) else { return nil }
+
+        var embed = URLComponents()
+        embed.scheme = "https"
+        embed.host = "www.youtube-nocookie.com"
+        embed.path = "/embed/\(videoID)"
+        var queryItems = [
+            URLQueryItem(name: "autoplay", value: "1"),
+            URLQueryItem(name: "playsinline", value: "1"),
+            URLQueryItem(name: "rel", value: "0"),
+        ]
+        if let start = youtubeStartSeconds(in: components), start > 0 {
+            queryItems.append(URLQueryItem(name: "start", value: String(start)))
+        }
+        embed.queryItems = queryItems
+        return embed.url
+    }
+
+    private static func isYouTubeVideoID(_ value: String) -> Bool {
+        value.count == 11 && value.allSatisfy { character in
+            character.isASCII && (character.isLetter || character.isNumber || character == "-" || character == "_")
+        }
+    }
+
+    private static func youtubeStartSeconds(in components: URLComponents) -> Int? {
+        guard let value = components.queryItems?
+            .first(where: { ["t", "start"].contains($0.name.lowercased()) })?
+            .value?.lowercased() else { return nil }
+        if let seconds = Int(value) { return seconds }
+
+        var total = 0
+        var digits = ""
+        for character in value {
+            if character.isNumber {
+                digits.append(character)
+                continue
+            }
+            guard let amount = Int(digits) else { return nil }
+            switch character {
+            case "h": total += amount * 3_600
+            case "m": total += amount * 60
+            case "s": total += amount
+            default: return nil
+            }
+            digits = ""
+        }
+        if let trailing = Int(digits) { total += trailing }
+        return total > 0 ? total : nil
     }
 }
 

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
@@ -154,9 +154,10 @@ struct NativeCryptoFileArgs: Hashable, Sendable {
 }
 
 struct NativeSendReceipt: Equatable, Sendable {
+    let committedMessages: [NativeMessage]
     let replyContextConfirmed: Bool
 
-    static let confirmed = NativeSendReceipt(replyContextConfirmed: true)
+    static let confirmed = NativeSendReceipt(committedMessages: [], replyContextConfirmed: true)
 }
 
 enum NativeChatParser {
@@ -269,16 +270,24 @@ enum NativeChatParser {
             expectedType: "newChatItems",
             requireChatItems: true
         )
-        guard let quotedItemID else { return .confirmed }
         let root = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         let result = root?["result"] as? [String: Any]
         let chatItems = result?["chatItems"] as? [[String: Any]] ?? []
-        let confirmed = chatItems.contains { item in
+        let committedMessages = chatItems.compactMap { item in
             let chatItem = item["chatItem"] as? [String: Any] ?? item
-            let quote = chatItem["quotedItem"] as? [String: Any]
-            return int64(quote?["itemId"]) == quotedItemID
+            return parseMessage(chatItem)
         }
-        return NativeSendReceipt(replyContextConfirmed: confirmed)
+        let replyContextConfirmed = quotedItemID.map { quotedItemID in
+            chatItems.contains { item in
+                let chatItem = item["chatItem"] as? [String: Any] ?? item
+                let quote = chatItem["quotedItem"] as? [String: Any]
+                return int64(quote?["itemId"]) == quotedItemID
+            }
+        } ?? true
+        return NativeSendReceipt(
+            committedMessages: committedMessages,
+            replyContextConfirmed: replyContextConfirmed
+        )
     }
 
     static func image(from encoded: String?) -> NSImage? {

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
@@ -157,6 +157,21 @@ struct NativeQuote: Hashable, Sendable {
     let text: String
     let sent: Bool
     let author: String?
+    let visual: NativeReplyContextVisual?
+
+    init(
+        messageID: Int64?,
+        text: String,
+        sent: Bool,
+        author: String?,
+        visual: NativeReplyContextVisual? = nil
+    ) {
+        self.messageID = messageID
+        self.text = text
+        self.sent = sent
+        self.author = author
+        self.visual = visual
+    }
 }
 
 struct NativeCryptoFile: Hashable, Sendable {
@@ -496,8 +511,19 @@ enum NativeChatParser {
             messageID: int64(object["itemId"]),
             text: text,
             sent: directionType.hasSuffix("Snd"),
-            author: string(member?["localDisplayName"]) ?? string(memberProfile?["displayName"])
+            author: string(member?["localDisplayName"]) ?? string(memberProfile?["displayName"]),
+            visual: quoteVisual(content)
         )
+    }
+
+    private static func quoteVisual(_ content: [String: Any]) -> NativeReplyContextVisual? {
+        switch string(content["type"]) {
+        case "image": .image(string(content["image"]))
+        case "video": .video(string(content["image"]))
+        case "voice": .voice
+        case "file": .file
+        default: nil
+        }
     }
 
     private static func kind(for type: String) -> NativeChatKind? {

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
@@ -327,7 +327,7 @@ enum NativeChatParser {
             text: string(meta["itemText"]) ?? "",
             timestamp: date(meta["itemTs"]),
             sent: directionType.hasSuffix("Snd"),
-            author: string(profile?["displayName"]) ?? string(member?["localDisplayName"]),
+            author: string(member?["localDisplayName"]) ?? string(profile?["displayName"]),
             deletable: bool(meta["deletable"]) ?? false,
             content: content,
             replyable: replyable,
@@ -360,7 +360,7 @@ enum NativeChatParser {
             messageID: int64(object["itemId"]),
             text: text,
             sent: directionType.hasSuffix("Snd"),
-            author: string(memberProfile?["displayName"]) ?? string(member?["localDisplayName"])
+            author: string(member?["localDisplayName"]) ?? string(memberProfile?["displayName"])
         )
     }
 

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
@@ -43,6 +43,28 @@ struct NativeMessage: Identifiable, Hashable, Sendable {
     let timestamp: Date?
     let sent: Bool
     let author: String?
+    let deletable: Bool
+    let content: NativeMessageContent
+}
+
+enum NativeMessageContent: Hashable, Sendable {
+    case text
+    case image(preview: String?, fileName: String?, filePath: String?)
+    case video(preview: String?, fileName: String?, filePath: String?)
+    case file(fileName: String?, filePath: String?)
+
+    var fileURL: URL? {
+        let path: String?
+        switch self {
+        case .text: path = nil
+        case let .image(_, _, filePath), let .video(_, _, filePath), let .file(_, filePath): path = filePath
+        }
+        guard let path, !path.isEmpty else { return nil }
+        if path.hasPrefix("/") { return URL(fileURLWithPath: path) }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".local/share/simplex/simplex_v1_files", isDirectory: true)
+            .appendingPathComponent(path)
+    }
 }
 
 enum NativeChatParser {
@@ -97,6 +119,19 @@ enum NativeChatParser {
             }
         }
         return "Unable to open the database."
+    }
+
+    static func commandError(from data: Data) -> String? {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let error = root["error"] else { return nil }
+        if let error = error as? [String: Any] {
+            let type = (error["errorType"] as? [String: Any]).flatMap { string($0["type"]) }
+                ?? string(error["type"])
+                ?? error.keys.first
+                ?? "coreError"
+            return "SimpleX could not complete the action (\(type))."
+        }
+        return "SimpleX could not complete the action."
     }
 
     static func image(from encoded: String?) -> NSImage? {
@@ -184,12 +219,33 @@ enum NativeChatParser {
         let directionType = string(direction?["type"]) ?? direction?.keys.first ?? ""
         let member = direction?["groupMember"] as? [String: Any]
         let profile = member?["memberProfile"] as? [String: Any]
+        let contentContainer = object["content"] as? [String: Any]
+        let messageContent = (contentContainer?["msgContent"] as? [String: Any])
+            ?? ((contentContainer?["sndMsgContent"] as? [String: Any])?["msgContent"] as? [String: Any])
+            ?? ((contentContainer?["rcvMsgContent"] as? [String: Any])?["msgContent"] as? [String: Any])
+        let file = object["file"] as? [String: Any]
+        let fileSource = file?["fileSource"] as? [String: Any]
+        let fileName = string(file?["fileName"])
+        let filePath = string(fileSource?["filePath"])
+        let content: NativeMessageContent
+        switch string(messageContent?["type"]) {
+        case "image":
+            content = .image(preview: string(messageContent?["image"]), fileName: fileName, filePath: filePath)
+        case "video":
+            content = .video(preview: string(messageContent?["image"]), fileName: fileName, filePath: filePath)
+        case "file":
+            content = .file(fileName: fileName, filePath: filePath)
+        default:
+            content = .text
+        }
         return NativeMessage(
             id: id,
             text: string(meta["itemText"]) ?? "",
             timestamp: date(meta["itemTs"]),
             sent: directionType.hasSuffix("Snd"),
-            author: string(profile?["displayName"]) ?? string(member?["localDisplayName"])
+            author: string(profile?["displayName"]) ?? string(member?["localDisplayName"]),
+            deletable: bool(meta["deletable"]) ?? false,
+            content: content
         )
     }
 

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
@@ -128,6 +128,14 @@ enum NativeMessageContent: Hashable, Sendable {
         }
     }
 
+    var inlineAudioFileName: String? {
+        switch self {
+        case let .voice(fileName, _): fileName ?? "Voice message"
+        case let .file(fileName): NativeAudioFile.supports(fileName) ? fileName : nil
+        case .text, .link, .image, .video: nil
+        }
+    }
+
     var replyContextVisual: NativeReplyContextVisual? {
         switch self {
         case .text, .link: nil
@@ -164,6 +172,18 @@ enum NativeMessageContent: Hashable, Sendable {
     private static func voiceDescription(duration: Int?) -> String {
         guard let duration, duration > 0 else { return "Voice message" }
         return "Voice message, \(Duration.seconds(Double(duration)).formatted(.time(pattern: .minuteSecond)))"
+    }
+}
+
+enum NativeAudioFile {
+    private static let supportedExtensions: Set<String> = [
+        "aac", "aif", "aiff", "caf", "flac", "m4a", "mp3", "wav",
+    ]
+
+    static func supports(_ fileName: String?) -> Bool {
+        guard let fileName else { return false }
+        let fileExtension = URL(fileURLWithPath: fileName).pathExtension.lowercased()
+        return supportedExtensions.contains(fileExtension)
     }
 }
 

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
@@ -50,6 +50,20 @@ struct NativeChat: Identifiable, Hashable, Sendable {
         return "\(displayName)\(unread)\(message)"
     }
 
+    func markingRead() -> NativeChat {
+        NativeChat(
+            id: id,
+            apiID: apiID,
+            kind: kind,
+            displayName: displayName,
+            image: image,
+            preview: preview,
+            timestamp: timestamp,
+            unreadCount: 0,
+            sendAsGroup: sendAsGroup
+        )
+    }
+
     func displayedMessageAuthor(sent: Bool, author: String?) -> String {
         if sent { return sendAsGroup ? displayName : "You" }
         let normalizedAuthor = author?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
@@ -220,10 +220,12 @@ enum NativeChatParser {
         return "SimpleX could not complete the action."
     }
 
-    static func commandErrorIsInvalidQuote(_ data: Data) -> Bool {
+    static func commandErrorMakesReplyTargetUnavailable(_ data: Data) -> Bool {
         guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let error = root["error"] else { return false }
-        return containsType("invalidQuote", in: error)
+        return ["invalidQuote", "chatItemNotFound", "badChatItem"].contains {
+            containsType($0, in: error)
+        }
     }
 
     static func validateCommandResponse(

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
@@ -106,6 +106,13 @@ enum NativeMessageContent: Hashable, Sendable {
     case voice(fileName: String?, duration: Int?)
     case file(fileName: String?)
 
+    var opensInQuickLook: Bool {
+        switch self {
+        case .image, .video: true
+        case .text, .voice, .file: false
+        }
+    }
+
     var replyContextVisual: NativeReplyContextVisual? {
         switch self {
         case .text: nil

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
@@ -321,7 +321,7 @@ enum NativeChatParser {
         let itemDeleted = meta["itemDeleted"].map { !($0 is NSNull) } ?? false
         let isLive = bool(meta["isLive"]) ?? false
         let isReport = string(messageContent?["type"]) == "report"
-        let replyable = isMessageContent && !itemDeleted && !isLive && id != -2 && !isReport
+        let replyable = isMessageContent && !itemDeleted && !isLive && id >= 0 && !isReport
         return NativeMessage(
             id: id,
             text: string(meta["itemText"]) ?? "",

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
@@ -285,6 +285,10 @@ enum NativeChatParser {
         let items = object["chatItems"] as? [[String: Any]] ?? []
         let lastMeta = items.last?["meta"] as? [String: Any]
         let stats = object["chatStats"] as? [String: Any]
+        let sendAsGroup = switch kind {
+        case .group: groupSendsAsGroup(info: info, groupInfo: payload)
+        default: bool(payload["sendAsGroup"]) ?? false
+        }
         return NativeChat(
             id: "\(kind.rawValue)\(apiID)",
             apiID: apiID,
@@ -294,8 +298,16 @@ enum NativeChatParser {
             preview: string(lastMeta?["itemText"]) ?? "",
             timestamp: date(lastMeta?["itemTs"]),
             unreadCount: int(stats?["unreadCount"]) ?? 0,
-            sendAsGroup: bool(payload["sendAsGroup"]) ?? false
+            sendAsGroup: sendAsGroup
         )
+    }
+
+    private static func groupSendsAsGroup(info: [String: Any], groupInfo: [String: Any]) -> Bool {
+        if let explicit = bool(groupInfo["sendAsGroup"]) { return explicit }
+        if let scope = info["groupChatScope"], !(scope is NSNull) { return false }
+        let membership = groupInfo["membership"] as? [String: Any]
+        return bool(groupInfo["useRelays"]) == true
+            && string(membership?["memberRole"]) == "owner"
     }
 
     private static func parseMessage(_ object: [String: Any]) -> NativeMessage? {
@@ -336,7 +348,10 @@ enum NativeChatParser {
         }
         let isMessageContent = contentType == "sndMsgContent" || contentType == "rcvMsgContent"
         let itemDeleted = meta["itemDeleted"].map { !($0 is NSNull) } ?? false
-        let isLive = bool(meta["isLive"]) ?? false
+        // The core serializes CIMeta's stored field as `itemLive`; `isLive` is
+        // only a derived property in the existing Apple and Kotlin clients.
+        // Keep the older alias as a defensive fallback for preview fixtures.
+        let isLive = bool(meta["itemLive"]) ?? bool(meta["isLive"]) ?? false
         let isReport = string(messageContent?["type"]) == "report"
         let replyable = isMessageContent && !itemDeleted && !isLive && id >= 0 && !isReport
         return NativeMessage(

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
@@ -97,6 +97,7 @@ enum NativeMessageContent: Hashable, Sendable {
     case text
     case image(preview: String?, fileName: String?)
     case video(preview: String?, fileName: String?)
+    case voice(fileName: String?, duration: Int?)
     case file(fileName: String?)
 
     var attachmentDescription: String? {
@@ -104,13 +105,27 @@ enum NativeMessageContent: Hashable, Sendable {
         case .text: nil
         case let .image(_, fileName): Self.description(fileName, fallback: "Photo")
         case let .video(_, fileName): Self.description(fileName, fallback: "Video")
+        case let .voice(_, duration): Self.voiceDescription(duration: duration)
         case let .file(fileName): Self.description(fileName, fallback: "File")
+        }
+    }
+
+    var fileName: String? {
+        switch self {
+        case .text: nil
+        case let .image(_, fileName), let .video(_, fileName), let .voice(fileName, _), let .file(fileName):
+            fileName
         }
     }
 
     private static func description(_ fileName: String?, fallback: String) -> String {
         let normalizedName = fileName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return normalizedName.isEmpty ? fallback : normalizedName
+    }
+
+    private static func voiceDescription(duration: Int?) -> String {
+        guard let duration, duration > 0 else { return "Voice message" }
+        return "Voice message, \(Duration.seconds(Double(duration)).formatted(.time(pattern: .minuteSecond)))"
     }
 }
 
@@ -312,6 +327,8 @@ enum NativeChatParser {
             content = .image(preview: string(messageContent?["image"]), fileName: fileName)
         case "video":
             content = .video(preview: string(messageContent?["image"]), fileName: fileName)
+        case "voice":
+            content = .voice(fileName: fileName, duration: int(messageContent?["duration"]))
         case "file":
             content = .file(fileName: fileName)
         default:

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
@@ -115,6 +115,7 @@ struct NativeMessage: Identifiable, Hashable, Sendable {
 
 enum NativeMessageContent: Hashable, Sendable {
     case text
+    case link(NativeLinkPreview)
     case image(preview: String?, fileName: String?)
     case video(preview: String?, fileName: String?)
     case voice(fileName: String?, duration: Int?)
@@ -123,13 +124,13 @@ enum NativeMessageContent: Hashable, Sendable {
     var opensInQuickLook: Bool {
         switch self {
         case .image, .video: true
-        case .text, .voice, .file: false
+        case .text, .link, .voice, .file: false
         }
     }
 
     var replyContextVisual: NativeReplyContextVisual? {
         switch self {
-        case .text: nil
+        case .text, .link: nil
         case let .image(preview, _): .image(preview)
         case let .video(preview, _): .video(preview)
         case .voice: .voice
@@ -139,7 +140,7 @@ enum NativeMessageContent: Hashable, Sendable {
 
     var attachmentDescription: String? {
         switch self {
-        case .text: nil
+        case .text, .link: nil
         case let .image(_, fileName): Self.description(fileName, fallback: "Photo")
         case let .video(_, fileName): Self.description(fileName, fallback: "Video")
         case let .voice(_, duration): Self.voiceDescription(duration: duration)
@@ -149,7 +150,7 @@ enum NativeMessageContent: Hashable, Sendable {
 
     var fileName: String? {
         switch self {
-        case .text: nil
+        case .text, .link: nil
         case let .image(_, fileName), let .video(_, fileName), let .voice(fileName, _), let .file(fileName):
             fileName
         }
@@ -163,6 +164,38 @@ enum NativeMessageContent: Hashable, Sendable {
     private static func voiceDescription(duration: Int?) -> String {
         guard let duration, duration > 0 else { return "Voice message" }
         return "Voice message, \(Duration.seconds(Double(duration)).formatted(.time(pattern: .minuteSecond)))"
+    }
+}
+
+struct NativeLinkPreview: Hashable, Sendable {
+    let uri: String
+    let title: String
+    let description: String
+    let image: String?
+    let videoDuration: Int?
+
+    var destination: URL? {
+        NativeMessageLink.standaloneURL(in: uri)
+    }
+
+    var displayHost: String {
+        destination?.host(percentEncoded: false) ?? uri
+    }
+
+    var durationLabel: String? {
+        guard let videoDuration, videoDuration > 0 else { return nil }
+        return Duration.seconds(Double(videoDuration)).formatted(.time(pattern: .minuteSecond))
+    }
+}
+
+enum NativeMessageLink {
+    static func standaloneURL(in text: String) -> URL? {
+        let normalized = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty,
+              let components = URLComponents(string: normalized),
+              ["http", "https"].contains(components.scheme?.lowercased() ?? ""),
+              components.host?.isEmpty == false else { return nil }
+        return components.url
     }
 }
 
@@ -475,6 +508,21 @@ enum NativeChatParser {
         let nativeFileSource = filePath.map { NativeCryptoFile(filePath: $0, cryptoArgs: cryptoArgs) }
         let content: NativeMessageContent
         switch string(messageContent?["type"]) {
+        case "link":
+            if let preview = messageContent?["preview"] as? [String: Any] {
+                let linkContent = preview["content"] as? [String: Any]
+                content = .link(NativeLinkPreview(
+                    uri: string(preview["uri"]) ?? string(messageContent?["text"]) ?? "",
+                    title: string(preview["title"]) ?? "",
+                    description: string(preview["description"]) ?? "",
+                    image: string(preview["image"]),
+                    videoDuration: string(linkContent?["type"]) == "video"
+                        ? int(linkContent?["duration"])
+                        : nil
+                ))
+            } else {
+                content = .text
+            }
         case "image":
             content = .image(preview: string(messageContent?["image"]), fileName: fileName)
         case "video":

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
@@ -153,6 +153,12 @@ struct NativeCryptoFileArgs: Hashable, Sendable {
     let fileNonce: String
 }
 
+struct NativeSendReceipt: Equatable, Sendable {
+    let replyContextConfirmed: Bool
+
+    static let confirmed = NativeSendReceipt(replyContextConfirmed: true)
+}
+
 enum NativeChatParser {
     static func profile(from data: Data) throws -> NativeProfile {
         let result = try responseResult(from: data, expectedType: "activeUser")
@@ -255,6 +261,24 @@ enum NativeChatParser {
                 )
             }
         }
+    }
+
+    static func validateSendResponse(_ data: Data, quotedItemID: Int64?) throws -> NativeSendReceipt {
+        try validateCommandResponse(
+            data,
+            expectedType: "newChatItems",
+            requireChatItems: true
+        )
+        guard let quotedItemID else { return .confirmed }
+        let root = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let result = root?["result"] as? [String: Any]
+        let chatItems = result?["chatItems"] as? [[String: Any]] ?? []
+        let confirmed = chatItems.contains { item in
+            let chatItem = item["chatItem"] as? [String: Any] ?? item
+            let quote = chatItem["quotedItem"] as? [String: Any]
+            return int64(quote?["itemId"]) == quotedItemID
+        }
+        return NativeSendReceipt(replyContextConfirmed: confirmed)
     }
 
     static func image(from encoded: String?) -> NSImage? {

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
@@ -106,6 +106,16 @@ enum NativeMessageContent: Hashable, Sendable {
     case voice(fileName: String?, duration: Int?)
     case file(fileName: String?)
 
+    var replyContextVisual: NativeReplyContextVisual? {
+        switch self {
+        case .text: nil
+        case let .image(preview, _): .image(preview)
+        case let .video(preview, _): .video(preview)
+        case .voice: .voice
+        case .file: .file
+        }
+    }
+
     var attachmentDescription: String? {
         switch self {
         case .text: nil
@@ -133,6 +143,13 @@ enum NativeMessageContent: Hashable, Sendable {
         guard let duration, duration > 0 else { return "Voice message" }
         return "Voice message, \(Duration.seconds(Double(duration)).formatted(.time(pattern: .minuteSecond)))"
     }
+}
+
+enum NativeReplyContextVisual: Hashable, Sendable {
+    case image(String?)
+    case video(String?)
+    case voice
+    case file
 }
 
 struct NativeQuote: Hashable, Sendable {

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
@@ -220,6 +220,41 @@ enum NativeChatParser {
         return "SimpleX could not complete the action."
     }
 
+    static func commandErrorIsInvalidQuote(_ data: Data) -> Bool {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let error = root["error"] else { return false }
+        return containsType("invalidQuote", in: error)
+    }
+
+    static func validateCommandResponse(
+        _ data: Data,
+        expectedType: String? = nil,
+        requireChatItems: Bool = false
+    ) throws {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw NativeChatError.invalidResponse("The SimpleX core returned invalid JSON.")
+        }
+        if let message = commandError(from: data) {
+            throw NativeChatError.core(message)
+        }
+        guard let result = root["result"] as? [String: Any],
+              let resultType = string(result["type"]) else {
+            throw NativeChatError.invalidResponse("The SimpleX core response had no result.")
+        }
+        if let expectedType, resultType != expectedType {
+            throw NativeChatError.invalidResponse(
+                "Expected \(expectedType), received \(resultType)."
+            )
+        }
+        if requireChatItems {
+            guard let chatItems = result["chatItems"] as? [[String: Any]], !chatItems.isEmpty else {
+                throw NativeChatError.invalidResponse(
+                    "SimpleX accepted the send command without returning the sent message."
+                )
+            }
+        }
+    }
+
     static func image(from encoded: String?) -> NSImage? {
         guard var encoded, !encoded.isEmpty else { return nil }
         if let comma = encoded.firstIndex(of: ","), encoded[..<comma].contains("base64") {
@@ -244,6 +279,17 @@ enum NativeChatParser {
             return nested.merging(["type": expectedType]) { current, _ in current }
         }
         throw NativeChatError.invalidResponse("Expected \(expectedType), received \(string(result["type"]) ?? "an unknown response").")
+    }
+
+    private static func containsType(_ expectedType: String, in value: Any) -> Bool {
+        if let object = value as? [String: Any] {
+            if string(object["type"]) == expectedType { return true }
+            return object.values.contains { containsType(expectedType, in: $0) }
+        }
+        if let values = value as? [Any] {
+            return values.contains { containsType(expectedType, in: $0) }
+        }
+        return false
     }
 
     private static func parseChat(_ object: [String: Any]) -> NativeChat? {
@@ -430,11 +476,13 @@ enum NativeChatParser {
 enum NativeChatError: LocalizedError, Sendable {
     case core(String)
     case invalidResponse(String)
+    case replyTargetUnavailable
     case unavailable(String)
 
     var errorDescription: String? {
         switch self {
         case let .core(message), let .invalidResponse(message), let .unavailable(message): message
+        case .replyTargetUnavailable: "The message being replied to is no longer available."
         }
     }
 }

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
@@ -11,6 +11,16 @@ enum NativeChatKind: String, Sendable {
     var canSend: Bool {
         self == .direct || self == .group || self == .local
     }
+
+    var toolbarSubtitle: String {
+        switch self {
+        case .direct: "SimpleX contact"
+        case .group: "Group"
+        case .local: "Private notes"
+        case .contactRequest: "Contact request"
+        case .contactConnection: "Connecting"
+        }
+    }
 }
 
 struct NativeProfile: Sendable {

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
@@ -59,6 +59,7 @@ struct NativeMessage: Identifiable, Hashable, Sendable {
     let author: String?
     let deletable: Bool
     let content: NativeMessageContent
+    let replyable: Bool
     let quotedItem: NativeQuote?
     let fileSource: NativeCryptoFile?
 
@@ -70,6 +71,7 @@ struct NativeMessage: Identifiable, Hashable, Sendable {
         author: String?,
         deletable: Bool,
         content: NativeMessageContent,
+        replyable: Bool = true,
         quotedItem: NativeQuote? = nil,
         fileSource: NativeCryptoFile? = nil
     ) {
@@ -80,6 +82,7 @@ struct NativeMessage: Identifiable, Hashable, Sendable {
         self.author = author
         self.deletable = deletable
         self.content = content
+        self.replyable = replyable
         self.quotedItem = quotedItem
         self.fileSource = fileSource
     }
@@ -288,6 +291,8 @@ enum NativeChatParser {
         let member = direction?["groupMember"] as? [String: Any]
         let profile = member?["memberProfile"] as? [String: Any]
         let contentContainer = object["content"] as? [String: Any]
+        let contentType = string(contentContainer?["type"])
+            ?? contentContainer?.keys.first
         let messageContent = (contentContainer?["msgContent"] as? [String: Any])
             ?? ((contentContainer?["sndMsgContent"] as? [String: Any])?["msgContent"] as? [String: Any])
             ?? ((contentContainer?["rcvMsgContent"] as? [String: Any])?["msgContent"] as? [String: Any])
@@ -312,6 +317,11 @@ enum NativeChatParser {
         default:
             content = .text
         }
+        let isMessageContent = contentType == "sndMsgContent" || contentType == "rcvMsgContent"
+        let itemDeleted = meta["itemDeleted"].map { !($0 is NSNull) } ?? false
+        let isLive = bool(meta["isLive"]) ?? false
+        let isReport = string(messageContent?["type"]) == "report"
+        let replyable = isMessageContent && !itemDeleted && !isLive && id != -2 && !isReport
         return NativeMessage(
             id: id,
             text: string(meta["itemText"]) ?? "",
@@ -320,6 +330,7 @@ enum NativeChatParser {
             author: string(profile?["displayName"]) ?? string(member?["localDisplayName"]),
             deletable: bool(meta["deletable"]) ?? false,
             content: content,
+            replyable: replyable,
             quotedItem: parseQuote(object["quotedItem"]),
             fileSource: nativeFileSource
         )

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativeChatModels.swift
@@ -49,6 +49,12 @@ struct NativeChat: Identifiable, Hashable, Sendable {
         let message = preview.isEmpty ? "" : ", \(preview)"
         return "\(displayName)\(unread)\(message)"
     }
+
+    func displayedMessageAuthor(sent: Bool, author: String?) -> String {
+        if sent { return sendAsGroup ? displayName : "You" }
+        let normalizedAuthor = author?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return normalizedAuthor.isEmpty ? displayName : normalizedAuthor
+    }
 }
 
 struct NativeMessage: Identifiable, Hashable, Sendable {

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativePreviewData.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativePreviewData.swift
@@ -71,7 +71,8 @@ enum NativePreviewData {
                     messageID: 4,
                     text: "The photos came through perfectly.",
                     sent: false,
-                    author: "Maya"
+                    author: "Maya",
+                    visual: .image(sampleImage)
                 )
             ),
         ]

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativePreviewData.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativePreviewData.swift
@@ -57,9 +57,23 @@ enum NativePreviewData {
                 minutesAgo: 4,
                 sent: false,
                 author: "Maya",
-                content: .image(preview: sampleImage, fileName: "evening.jpg", filePath: nil)
+                content: .image(preview: sampleImage, fileName: "evening.jpg")
             ),
-            message(5, "Nice. The native image view was worth fixing.", minutesAgo: 2, sent: true),
+            NativeMessage(
+                id: 5,
+                text: "Nice. The native image view was worth fixing.",
+                timestamp: Date().addingTimeInterval(-2 * 60),
+                sent: true,
+                author: nil,
+                deletable: true,
+                content: .text,
+                quotedItem: NativeQuote(
+                    messageID: 4,
+                    text: "The photos came through perfectly.",
+                    sent: false,
+                    author: "Maya"
+                )
+            ),
         ]
     }
 

--- a/apps/macos-native/Sources/SimpleXNative/Models/NativePreviewData.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Models/NativePreviewData.swift
@@ -1,0 +1,105 @@
+import AppKit
+import Foundation
+
+enum NativePreviewData {
+    static let profile = NativeProfile(userID: 1, displayName: "Alex", image: nil)
+
+    static let chats: [NativeChat] = [
+        NativeChat(
+            id: "@1",
+            apiID: 1,
+            kind: .direct,
+            displayName: "Maya",
+            image: nil,
+            preview: "The photos came through perfectly.",
+            timestamp: Date().addingTimeInterval(-240),
+            unreadCount: 2,
+            sendAsGroup: false
+        ),
+        NativeChat(
+            id: "#2",
+            apiID: 2,
+            kind: .group,
+            displayName: "Weekend plans",
+            image: nil,
+            preview: "Jordan: Saturday works for me",
+            timestamp: Date().addingTimeInterval(-3_600),
+            unreadCount: 0,
+            sendAsGroup: false
+        ),
+        NativeChat(
+            id: "*3",
+            apiID: 3,
+            kind: .local,
+            displayName: "Private notes",
+            image: nil,
+            preview: "Packing list",
+            timestamp: Calendar.current.date(byAdding: .day, value: -1, to: Date()),
+            unreadCount: 0,
+            sendAsGroup: false
+        ),
+    ]
+
+    static func messages(for chatID: String) -> [NativeMessage] {
+        guard chatID == "@1" else {
+            return [
+                message(20, "This is a quiet preview conversation.", minutesAgo: 70, sent: false, author: "Jordan"),
+                message(21, "It already feels much more like a Mac app.", minutesAgo: 65, sent: true),
+            ]
+        }
+        return [
+            message(1, "Hey! Are you still free this evening?", minutesAgo: 38, sent: false, author: "Maya"),
+            message(2, "Yep — around seven should work.", minutesAgo: 36, sent: true),
+            message(3, "Perfect. I’ll send the address in a minute.", minutesAgo: 35, sent: false, author: "Maya"),
+            message(
+                4,
+                "The photos came through perfectly.",
+                minutesAgo: 4,
+                sent: false,
+                author: "Maya",
+                content: .image(preview: sampleImage, fileName: "evening.jpg", filePath: nil)
+            ),
+            message(5, "Nice. The native image view was worth fixing.", minutesAgo: 2, sent: true),
+        ]
+    }
+
+    private static func message(
+        _ id: Int64,
+        _ text: String,
+        minutesAgo: TimeInterval,
+        sent: Bool,
+        author: String? = nil,
+        content: NativeMessageContent = .text
+    ) -> NativeMessage {
+        NativeMessage(
+            id: id,
+            text: text,
+            timestamp: Date().addingTimeInterval(-minutesAgo * 60),
+            sent: sent,
+            author: author,
+            deletable: true,
+            content: content
+        )
+    }
+
+    private static let sampleImage: String? = {
+        let size = NSSize(width: 640, height: 360)
+        let image = NSImage(size: size)
+        image.lockFocus()
+        NSGradient(colors: [.systemIndigo, .systemTeal])?.draw(in: NSRect(origin: .zero, size: size), angle: -20)
+        let symbol = NSImage(systemSymbolName: "photo.on.rectangle.angled", accessibilityDescription: nil)
+        symbol?.draw(
+            in: NSRect(x: 272, y: 132, width: 96, height: 96),
+            from: .zero,
+            operation: .sourceOver,
+            fraction: 0.8
+        )
+        image.unlockFocus()
+        guard let tiff = image.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiff),
+              let data = bitmap.representation(using: .jpeg, properties: [.compressionFactor: 0.82]) else {
+            return nil
+        }
+        return "data:image/jpeg;base64,\(data.base64EncodedString())"
+    }()
+}

--- a/apps/macos-native/Sources/SimpleXNative/Notifications/NativeNotificationManager.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Notifications/NativeNotificationManager.swift
@@ -1,0 +1,203 @@
+import AppKit
+import Foundation
+@preconcurrency import UserNotifications
+
+@MainActor
+final class NativeNotificationManager: NSObject, ObservableObject, UNUserNotificationCenterDelegate {
+    @Published private(set) var permissionState: NotificationPermissionState = .unknown
+    @Published var showingPermissionExplanation = false
+    @Published var previewMode: NotificationPreviewMode {
+        didSet { UserDefaults.standard.set(previewMode.rawValue, forKey: Self.previewModeKey) }
+    }
+    @Published var soundsEnabled: Bool {
+        didSet { UserDefaults.standard.set(soundsEnabled, forKey: Self.soundsKey) }
+    }
+
+    weak var model: AppModel?
+
+    private let center = UNUserNotificationCenter.current()
+    private static let previewModeKey = "nativeNotificationPreviewMode"
+    private static let soundsKey = "nativeNotificationSounds"
+    private static let explanationKey = "nativeNotificationExplanationShown"
+
+    override init() {
+        previewMode = NotificationPreviewMode(
+            rawValue: UserDefaults.standard.string(forKey: Self.previewModeKey) ?? ""
+        ) ?? .message
+        if UserDefaults.standard.object(forKey: Self.soundsKey) == nil {
+            soundsEnabled = true
+        } else {
+            soundsEnabled = UserDefaults.standard.bool(forKey: Self.soundsKey)
+        }
+        super.init()
+        center.delegate = self
+        registerCategories()
+        refreshPermissionState()
+    }
+
+    func chatSetupReady() {
+        center.getNotificationSettings { [weak self] settings in
+            Task { @MainActor in
+                guard let self else { return }
+                self.permissionState = self.permissionState(for: settings.authorizationStatus)
+                if self.permissionState == .notDetermined,
+                   !UserDefaults.standard.bool(forKey: Self.explanationKey) {
+                    self.showingPermissionExplanation = true
+                }
+            }
+        }
+    }
+
+    func respondToPermissionExplanation(requestPermission: Bool) {
+        UserDefaults.standard.set(true, forKey: Self.explanationKey)
+        showingPermissionExplanation = false
+        guard requestPermission else { return }
+        Task {
+            do {
+                _ = try await center.requestAuthorization(options: [.alert, .badge, .sound])
+            } catch {
+                permissionState = .denied
+            }
+            refreshPermissionState()
+        }
+    }
+
+    func handleCoreEvent(_ data: Data) {
+        guard permissionState == .authorized || permissionState == .provisional,
+              let payload = NativeNotificationParser.payload(from: data),
+              let model else { return }
+        let windowFocused = NSApp.isActive && NSApp.keyWindow?.isKeyWindow == true
+        guard !NativeNotificationParser.shouldSuppress(
+            windowFocused: windowFocused,
+            activeUserID: model.profile?.userID,
+            activeRemoteHostID: nil,
+            activeChatID: model.selectedChatID,
+            route: payload.route
+        ) else {
+            return
+        }
+
+        let content = UNMutableNotificationContent()
+        let preview = NativeNotificationParser.preview(for: payload, mode: previewMode)
+        content.title = preview.title
+        content.body = preview.body
+        content.categoryIdentifier = payload.category.rawValue
+        content.sound = soundsEnabled ? .default : nil
+        content.userInfo = routeDictionary(payload.route)
+
+        center.add(UNNotificationRequest(
+            identifier: payload.route.identifier,
+            content: content,
+            trigger: nil
+        ))
+    }
+
+    func removeDeliveredNotifications(chatID: String) {
+        center.getDeliveredNotifications { [center] notifications in
+            let identifiers = notifications.compactMap { notification -> String? in
+                notification.request.content.userInfo["chatID"] as? String == chatID
+                    ? notification.request.identifier
+                    : nil
+            }
+            center.removeDeliveredNotifications(withIdentifiers: identifiers)
+            center.removePendingNotificationRequests(withIdentifiers: identifiers)
+        }
+    }
+
+    func openSystemSettings() {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension") else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification
+    ) async -> UNNotificationPresentationOptions {
+        await MainActor.run {
+            guard let model,
+                  let route = route(from: notification.request.content.userInfo) else {
+                return [.banner, .sound]
+            }
+            let focused = NSApp.isActive && NSApp.keyWindow?.isKeyWindow == true
+            if NativeNotificationParser.shouldSuppress(
+                windowFocused: focused,
+                activeUserID: model.profile?.userID,
+                activeRemoteHostID: nil,
+                activeChatID: model.selectedChatID,
+                route: route
+            ) {
+                return []
+            }
+            return soundsEnabled ? [.banner, .sound] : [.banner]
+        }
+    }
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
+        await MainActor.run {
+            guard let route = route(from: response.notification.request.content.userInfo) else { return }
+            NSApp.activate(ignoringOtherApps: true)
+            model?.openNotificationRoute(route)
+        }
+    }
+
+    private func registerCategories() {
+        let open = UNNotificationAction(identifier: "SIMPLEX_OPEN", title: "Open", options: [.foreground])
+        center.setNotificationCategories([
+            UNNotificationCategory(
+                identifier: DesktopNotificationCategory.message.rawValue,
+                actions: [open],
+                intentIdentifiers: []
+            ),
+            UNNotificationCategory(
+                identifier: DesktopNotificationCategory.contactRequest.rawValue,
+                actions: [open],
+                intentIdentifiers: []
+            ),
+            UNNotificationCategory(
+                identifier: DesktopNotificationCategory.incomingCall.rawValue,
+                actions: [open],
+                intentIdentifiers: []
+            ),
+        ])
+    }
+
+    private func refreshPermissionState() {
+        center.getNotificationSettings { [weak self] settings in
+            Task { @MainActor in
+                self?.permissionState = self?.permissionState(for: settings.authorizationStatus) ?? .unknown
+            }
+        }
+    }
+
+    private func permissionState(for status: UNAuthorizationStatus) -> NotificationPermissionState {
+        switch status {
+        case .notDetermined: .notDetermined
+        case .denied: .denied
+        case .authorized: .authorized
+        case .provisional: .provisional
+        case .ephemeral: .unknown
+        @unknown default: .unknown
+        }
+    }
+
+    private func routeDictionary(_ route: NotificationRoute) -> [AnyHashable: Any] {
+        var dictionary: [AnyHashable: Any] = ["chatID": route.chatID]
+        if let userID = route.userID { dictionary["userID"] = userID }
+        if let remoteHostID = route.remoteHostID { dictionary["remoteHostID"] = remoteHostID }
+        if let messageID = route.messageID { dictionary["messageID"] = messageID }
+        return dictionary
+    }
+
+    private func route(from dictionary: [AnyHashable: Any]) -> NotificationRoute? {
+        guard let chatID = dictionary["chatID"] as? String else { return nil }
+        return NotificationRoute(
+            userID: (dictionary["userID"] as? NSNumber)?.int64Value,
+            remoteHostID: (dictionary["remoteHostID"] as? NSNumber)?.int64Value,
+            chatID: chatID,
+            messageID: (dictionary["messageID"] as? NSNumber)?.int64Value
+        )
+    }
+}

--- a/apps/macos-native/Sources/SimpleXNative/Notifications/NativeNotificationManager.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Notifications/NativeNotificationManager.swift
@@ -33,6 +33,18 @@ final class NativeNotificationManager: NSObject, ObservableObject, UNUserNotific
         center.delegate = self
         registerCategories()
         refreshPermissionState()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(windowBecameFocused),
+            name: NSWindow.didBecomeKeyNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationBecameActive),
+            name: NSApplication.didBecomeActiveNotification,
+            object: nil
+        )
     }
 
     func chatSetupReady() {
@@ -107,6 +119,14 @@ final class NativeNotificationManager: NSObject, ObservableObject, UNUserNotific
     func openSystemSettings() {
         guard let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension") else { return }
         NSWorkspace.shared.open(url)
+    }
+
+    @objc private func windowBecameFocused() {
+        model?.markSelectedChatReadIfVisible()
+    }
+
+    @objc private func applicationBecameActive() {
+        model?.markSelectedChatReadIfVisible()
     }
 
     nonisolated func userNotificationCenter(

--- a/apps/macos-native/Sources/SimpleXNative/Security/DatabasePassphraseStore.swift
+++ b/apps/macos-native/Sources/SimpleXNative/Security/DatabasePassphraseStore.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Security
+
+protocol DatabasePassphraseStore: Sendable {
+    func load() async throws -> String?
+    func save(_ passphrase: String) async throws
+    func delete() async throws
+}
+
+actor DatabasePassphraseKeychain: DatabasePassphraseStore {
+    private let service: String
+    private let account: String
+
+    init(
+        service: String = "chat.simplex.native.database",
+        account: String = "simplex_v1"
+    ) {
+        self.service = service
+        self.account = account
+    }
+
+    func load() async throws -> String? {
+        var query = baseQuery()
+        query[kSecReturnData] = true
+        query[kSecMatchLimit] = kSecMatchLimitOne
+
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        switch status {
+        case errSecSuccess:
+            guard let data = result as? Data,
+                  let passphrase = String(data: data, encoding: .utf8) else {
+                throw DatabasePassphraseKeychainError.unexpectedData
+            }
+            return passphrase
+        case errSecItemNotFound:
+            return nil
+        case errSecInteractionNotAllowed:
+            throw DatabasePassphraseKeychainError.interactionNotAllowed
+        default:
+            throw DatabasePassphraseKeychainError.unhandledStatus(status)
+        }
+    }
+
+    func save(_ passphrase: String) async throws {
+        let data = Data(passphrase.utf8)
+        let query = baseQuery()
+        var addQuery = query
+        addQuery[kSecValueData] = data
+        addQuery[kSecAttrAccessible] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        switch addStatus {
+        case errSecSuccess:
+            return
+        case errSecDuplicateItem:
+            let updates: [CFString: Any] = [kSecValueData: data]
+            let updateStatus = SecItemUpdate(query as CFDictionary, updates as CFDictionary)
+            switch updateStatus {
+            case errSecSuccess:
+                return
+            case errSecInteractionNotAllowed:
+                throw DatabasePassphraseKeychainError.interactionNotAllowed
+            default:
+                throw DatabasePassphraseKeychainError.unhandledStatus(updateStatus)
+            }
+        case errSecInteractionNotAllowed:
+            throw DatabasePassphraseKeychainError.interactionNotAllowed
+        default:
+            throw DatabasePassphraseKeychainError.unhandledStatus(addStatus)
+        }
+    }
+
+    func delete() async throws {
+        let status = SecItemDelete(baseQuery() as CFDictionary)
+        switch status {
+        case errSecSuccess, errSecItemNotFound:
+            return
+        case errSecInteractionNotAllowed:
+            throw DatabasePassphraseKeychainError.interactionNotAllowed
+        default:
+            throw DatabasePassphraseKeychainError.unhandledStatus(status)
+        }
+    }
+
+    private func baseQuery() -> [CFString: Any] {
+        [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+            kSecUseDataProtectionKeychain: true,
+        ]
+    }
+}
+
+enum DatabasePassphraseKeychainError: LocalizedError, Equatable, Sendable {
+    case interactionNotAllowed
+    case unexpectedData
+    case unhandledStatus(OSStatus)
+
+    var errorDescription: String? {
+        switch self {
+        case .interactionNotAllowed:
+            "The Mac Keychain is locked. Unlock your Mac and try again."
+        case .unexpectedData:
+            "The saved database passphrase could not be read."
+        case let .unhandledStatus(status):
+            SecCopyErrorMessageString(status, nil) as String?
+                ?? "The Mac Keychain returned error \(status)."
+        }
+    }
+}

--- a/apps/macos-native/Sources/SimpleXNative/SimpleXNativeApp.swift
+++ b/apps/macos-native/Sources/SimpleXNative/SimpleXNativeApp.swift
@@ -1,12 +1,20 @@
+import AppKit
 import SwiftUI
 
 @main
 struct SimpleXNativeApp: App {
-    @StateObject private var model = AppModel()
+    @StateObject private var model: AppModel
+    @StateObject private var notifications: NativeNotificationManager
+
+    init() {
+        let notifications = NativeNotificationManager()
+        _notifications = StateObject(wrappedValue: notifications)
+        _model = StateObject(wrappedValue: AppModel(notificationManager: notifications))
+    }
 
     var body: some Scene {
         WindowGroup {
-            RootView(model: model)
+            RootView(model: model, notifications: notifications)
                 .frame(minWidth: 760, minHeight: 520)
         }
         .defaultSize(width: 1120, height: 720)
@@ -14,20 +22,80 @@ struct SimpleXNativeApp: App {
         .commands {
             SidebarCommands()
             CommandGroup(replacing: .newItem) {}
+            CommandGroup(replacing: .pasteboard) {
+                Button("Cut") { sendFirstResponderAction("cut:") }
+                    .keyboardShortcut("x")
+                Button("Copy") {
+                    if model.transcriptFocused {
+                        model.copySelectedMessages()
+                    } else {
+                        sendFirstResponderAction("copy:")
+                    }
+                }
+                    .keyboardShortcut("c")
+                    .disabled(model.transcriptFocused && model.selectedMessageIDs.isEmpty)
+                Button("Paste") { sendFirstResponderAction("paste:") }
+                    .keyboardShortcut("v")
+                Button("Select All") {
+                    if model.transcriptFocused {
+                        model.selectAllMessages()
+                    } else {
+                        sendFirstResponderAction("selectAll:")
+                    }
+                }
+                .keyboardShortcut("a")
+            }
+            CommandGroup(after: .textEditing) {
+                Button("Delete Selected Messages") { model.requestDeleteSelectedMessages() }
+                    .keyboardShortcut(.delete, modifiers: [])
+                    .disabled(!model.transcriptFocused || !model.canDeleteSelectedMessages)
+                Button("Clear Selection or Attachments") { model.dismissNearestState() }
+                    .keyboardShortcut(.escape, modifiers: [])
+                    .disabled(model.selectedMessageIDs.isEmpty && model.pendingAttachments.isEmpty)
+            }
             CommandMenu("Conversation") {
                 Button("Refresh") { model.refresh() }
                     .keyboardShortcut("r")
+                Divider()
+                Picker("Density", selection: $model.density) {
+                    ForEach(DesktopChatDensity.allCases) { density in
+                        Text(density.title).tag(density)
+                    }
+                }
             }
         }
 
         Settings {
             Form {
-                LabeledContent("Appearance", value: "Follows macOS")
-                LabeledContent("Profile", value: model.profile?.displayName ?? "Locked")
+                Section("Interface") {
+                    LabeledContent("Appearance", value: "Follows macOS")
+                    LabeledContent("Profile", value: model.profile?.displayName ?? "Locked")
+                    Picker("Chat density", selection: $model.density) {
+                        ForEach(DesktopChatDensity.allCases) { density in
+                            Text(density.title).tag(density)
+                        }
+                    }
+                    .pickerStyle(.radioGroup)
+                }
+
+                Section("Notifications") {
+                    LabeledContent("Permission", value: notifications.permissionState.title)
+                    Picker("Show previews", selection: $notifications.previewMode) {
+                        ForEach(NotificationPreviewMode.allCases) { mode in
+                            Text(mode.title).tag(mode)
+                        }
+                    }
+                    Toggle("Play notification sounds", isOn: $notifications.soundsEnabled)
+                    Button("Open Mac Notification Settings", action: notifications.openSystemSettings)
+                }
             }
             .formStyle(.grouped)
             .padding(20)
             .frame(width: 420)
         }
+    }
+
+    private func sendFirstResponderAction(_ name: String) {
+        NSApp.sendAction(Selector(name), to: nil, from: nil)
     }
 }

--- a/apps/macos-native/Sources/SimpleXNative/SimpleXNativeApp.swift
+++ b/apps/macos-native/Sources/SimpleXNative/SimpleXNativeApp.swift
@@ -21,7 +21,6 @@ struct SimpleXNativeApp: App {
         .windowToolbarStyle(.unifiedCompact)
         .commands {
             SidebarCommands()
-            CommandGroup(replacing: .newItem) {}
             CommandGroup(replacing: .pasteboard) {
                 Button("Cut") { sendFirstResponderAction("cut:") }
                     .keyboardShortcut("x")
@@ -63,11 +62,7 @@ struct SimpleXNativeApp: App {
                     .disabled(!model.transcriptFocused || !model.canDeleteSelectedMessages)
                 Button("Cancel Current Action") { model.dismissNearestState() }
                     .keyboardShortcut(.escape, modifiers: [])
-                    .disabled(
-                        model.selectedMessageIDs.isEmpty
-                            && model.pendingAttachments.isEmpty
-                            && model.replyingTo == nil
-                    )
+                    .disabled(!model.canDismissNearestState)
             }
             CommandMenu("Conversation") {
                 Button("Refresh") { model.refresh() }

--- a/apps/macos-native/Sources/SimpleXNative/SimpleXNativeApp.swift
+++ b/apps/macos-native/Sources/SimpleXNative/SimpleXNativeApp.swift
@@ -45,6 +45,15 @@ struct SimpleXNativeApp: App {
                 }
                 .keyboardShortcut("a")
             }
+            CommandGroup(after: .pasteboard) {
+                Divider()
+                Button("Find in Conversation") { model.beginConversationSearch() }
+                    .keyboardShortcut("f")
+                    .disabled(model.selectedChat == nil)
+                Button("Search Chats") { model.sidebarSearchPresented = true }
+                    .keyboardShortcut("k")
+                    .disabled(model.phase != .ready)
+            }
             CommandGroup(after: .textEditing) {
                 Button("Delete Selected Messages") { model.requestDeleteSelectedMessages() }
                     .keyboardShortcut(.delete, modifiers: [])
@@ -88,6 +97,20 @@ struct SimpleXNativeApp: App {
                     Toggle("Play notification sounds", isOn: $notifications.soundsEnabled)
                     Button("Open Mac Notification Settings", action: notifications.openSystemSettings)
                 }
+
+                Section("Security") {
+                    LabeledContent(
+                        "Database passphrase",
+                        value: keychainPassphraseStatus
+                    )
+                    Button("Forget Saved Passphrase", role: .destructive, action: model.forgetSavedPassphrase)
+                        .disabled(!model.keychainPassphraseStorageAvailable || !model.hasStoredPassphrase)
+                    if let message = model.keychainStatusMessage {
+                        Text(message)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
             }
             .formStyle(.grouped)
             .padding(20)
@@ -97,5 +120,12 @@ struct SimpleXNativeApp: App {
 
     private func sendFirstResponderAction(_ name: String) {
         NSApp.sendAction(Selector(name), to: nil, from: nil)
+    }
+
+    private var keychainPassphraseStatus: String {
+        guard model.keychainPassphraseStorageAvailable else {
+            return "Unavailable in this development build"
+        }
+        return model.hasStoredPassphrase ? "Saved in Mac Keychain" : "Not saved"
     }
 }

--- a/apps/macos-native/Sources/SimpleXNative/SimpleXNativeApp.swift
+++ b/apps/macos-native/Sources/SimpleXNative/SimpleXNativeApp.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+@main
+struct SimpleXNativeApp: App {
+    @StateObject private var model = AppModel()
+
+    var body: some Scene {
+        WindowGroup {
+            RootView(model: model)
+                .frame(minWidth: 760, minHeight: 520)
+        }
+        .defaultSize(width: 1120, height: 720)
+        .windowToolbarStyle(.unifiedCompact)
+        .commands {
+            SidebarCommands()
+            CommandGroup(replacing: .newItem) {}
+            CommandMenu("Conversation") {
+                Button("Refresh") { model.refresh() }
+                    .keyboardShortcut("r")
+            }
+        }
+
+        Settings {
+            Form {
+                LabeledContent("Appearance", value: "Follows macOS")
+                LabeledContent("Profile", value: model.profile?.displayName ?? "Locked")
+            }
+            .formStyle(.grouped)
+            .padding(20)
+            .frame(width: 420)
+        }
+    }
+}

--- a/apps/macos-native/Sources/SimpleXNative/SimpleXNativeApp.swift
+++ b/apps/macos-native/Sources/SimpleXNative/SimpleXNativeApp.swift
@@ -57,11 +57,7 @@ struct SimpleXNativeApp: App {
             CommandGroup(after: .textEditing) {
                 Button("Reply to Selected Message") { model.replyToSelectedMessage() }
                     .keyboardShortcut("r", modifiers: [.command, .shift])
-                    .disabled(
-                        model.selectedMessagesInTranscriptOrder.count != 1
-                            || model.selectedChat?.kind.canReply != true
-                            || model.isSendingSelectedChat
-                    )
+                    .disabled(!model.canReplyToSelectedMessage)
                 Button("Delete Selected Messages") { model.requestDeleteSelectedMessages() }
                     .keyboardShortcut(.delete, modifiers: [])
                     .disabled(!model.transcriptFocused || !model.canDeleteSelectedMessages)

--- a/apps/macos-native/Sources/SimpleXNative/SimpleXNativeApp.swift
+++ b/apps/macos-native/Sources/SimpleXNative/SimpleXNativeApp.swift
@@ -60,7 +60,7 @@ struct SimpleXNativeApp: App {
                     .disabled(
                         model.selectedMessagesInTranscriptOrder.count != 1
                             || model.selectedChat?.kind.canReply != true
-                            || model.isSending
+                            || model.isSendingSelectedChat
                     )
                 Button("Delete Selected Messages") { model.requestDeleteSelectedMessages() }
                     .keyboardShortcut(.delete, modifiers: [])

--- a/apps/macos-native/Sources/SimpleXNative/SimpleXNativeApp.swift
+++ b/apps/macos-native/Sources/SimpleXNative/SimpleXNativeApp.swift
@@ -13,13 +13,14 @@ struct SimpleXNativeApp: App {
     }
 
     var body: some Scene {
-        WindowGroup {
+        Window("SimpleX", id: MainWindowCommands.windowID) {
             RootView(model: model, notifications: notifications)
                 .frame(minWidth: 760, minHeight: 520)
         }
         .defaultSize(width: 1120, height: 720)
         .windowToolbarStyle(.unifiedCompact)
         .commands {
+            MainWindowCommands()
             SidebarCommands()
             CommandGroup(replacing: .pasteboard) {
                 Button("Cut") { sendFirstResponderAction("cut:") }

--- a/apps/macos-native/Sources/SimpleXNative/SimpleXNativeApp.swift
+++ b/apps/macos-native/Sources/SimpleXNative/SimpleXNativeApp.swift
@@ -3,10 +3,16 @@ import SwiftUI
 
 @main
 struct SimpleXNativeApp: App {
+    private let instanceGuard: SingleInstanceGuard
     @StateObject private var model: AppModel
     @StateObject private var notifications: NativeNotificationManager
 
     init() {
+        guard let instanceGuard = SingleInstanceGuard() else {
+            SingleInstanceGuard.activateExistingApplication()
+            Darwin.exit(EXIT_SUCCESS)
+        }
+        self.instanceGuard = instanceGuard
         let notifications = NativeNotificationManager()
         _notifications = StateObject(wrappedValue: notifications)
         _model = StateObject(wrappedValue: AppModel(notificationManager: notifications))

--- a/apps/macos-native/Sources/SimpleXNative/SimpleXNativeApp.swift
+++ b/apps/macos-native/Sources/SimpleXNative/SimpleXNativeApp.swift
@@ -32,14 +32,17 @@ struct SimpleXNativeApp: App {
                 Button("Cut") { sendFirstResponderAction("cut:") }
                     .keyboardShortcut("x")
                 Button("Copy") {
-                    if model.transcriptFocused {
+                    switch DesktopCopyCommandRoute.resolve(
+                        transcriptFocused: model.transcriptFocused,
+                        selectedMessageCount: model.selectedMessageIDs.count
+                    ) {
+                    case .selectedMessages:
                         model.copySelectedMessages()
-                    } else {
+                    case .firstResponder:
                         sendFirstResponderAction("copy:")
                     }
                 }
-                    .keyboardShortcut("c")
-                    .disabled(model.transcriptFocused && model.selectedMessageIDs.isEmpty)
+                .keyboardShortcut("c")
                 Button("Paste") { sendFirstResponderAction("paste:") }
                     .keyboardShortcut("v")
                 Button("Select All") {

--- a/apps/macos-native/Sources/SimpleXNative/SimpleXNativeApp.swift
+++ b/apps/macos-native/Sources/SimpleXNative/SimpleXNativeApp.swift
@@ -55,12 +55,23 @@ struct SimpleXNativeApp: App {
                     .disabled(model.phase != .ready)
             }
             CommandGroup(after: .textEditing) {
+                Button("Reply to Selected Message") { model.replyToSelectedMessage() }
+                    .keyboardShortcut("r", modifiers: [.command, .shift])
+                    .disabled(
+                        model.selectedMessagesInTranscriptOrder.count != 1
+                            || model.selectedChat?.kind.canReply != true
+                            || model.isSending
+                    )
                 Button("Delete Selected Messages") { model.requestDeleteSelectedMessages() }
                     .keyboardShortcut(.delete, modifiers: [])
                     .disabled(!model.transcriptFocused || !model.canDeleteSelectedMessages)
-                Button("Clear Selection or Attachments") { model.dismissNearestState() }
+                Button("Cancel Current Action") { model.dismissNearestState() }
                     .keyboardShortcut(.escape, modifiers: [])
-                    .disabled(model.selectedMessageIDs.isEmpty && model.pendingAttachments.isEmpty)
+                    .disabled(
+                        model.selectedMessageIDs.isEmpty
+                            && model.pendingAttachments.isEmpty
+                            && model.replyingTo == nil
+                    )
             }
             CommandMenu("Conversation") {
                 Button("Refresh") { model.refresh() }

--- a/apps/macos-native/Sources/SimpleXNative/SingleInstanceGuard.swift
+++ b/apps/macos-native/Sources/SimpleXNative/SingleInstanceGuard.swift
@@ -6,7 +6,10 @@ import Foundation
 final class SingleInstanceGuard {
     private let descriptor: Int32
 
-    init?(lockURL: URL = SingleInstanceGuard.defaultLockURL) {
+    init?(
+        lockURL: URL = SingleInstanceGuard.defaultLockURL,
+        otherApplicationRunning: () -> Bool = SingleInstanceGuard.hasOtherRunningApplication
+    ) {
         do {
             try FileManager.default.createDirectory(
                 at: lockURL.deletingLastPathComponent(),
@@ -22,6 +25,11 @@ final class SingleInstanceGuard {
             Darwin.close(descriptor)
             return nil
         }
+        guard !otherApplicationRunning() else {
+            sx_unlock_file(descriptor)
+            Darwin.close(descriptor)
+            return nil
+        }
         self.descriptor = descriptor
     }
 
@@ -34,6 +42,13 @@ final class SingleInstanceGuard {
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".local/share/simplex", isDirectory: true)
             .appendingPathComponent("simplex-native.lock")
+    }
+
+    private static func hasOtherRunningApplication() -> Bool {
+        guard let bundleIdentifier = Bundle.main.bundleIdentifier else { return false }
+        let currentProcessID = ProcessInfo.processInfo.processIdentifier
+        return NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier)
+            .contains(where: { $0.processIdentifier != currentProcessID })
     }
 
     @MainActor

--- a/apps/macos-native/Sources/SimpleXNative/SingleInstanceGuard.swift
+++ b/apps/macos-native/Sources/SimpleXNative/SingleInstanceGuard.swift
@@ -1,0 +1,47 @@
+import AppKit
+import CoreBridge
+import Darwin
+import Foundation
+
+final class SingleInstanceGuard {
+    private let descriptor: Int32
+
+    init?(lockURL: URL = SingleInstanceGuard.defaultLockURL) {
+        do {
+            try FileManager.default.createDirectory(
+                at: lockURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+        } catch {
+            return nil
+        }
+
+        let descriptor = Darwin.open(lockURL.path, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)
+        guard descriptor >= 0 else { return nil }
+        guard sx_try_lock_file(descriptor) else {
+            Darwin.close(descriptor)
+            return nil
+        }
+        self.descriptor = descriptor
+    }
+
+    deinit {
+        sx_unlock_file(descriptor)
+        Darwin.close(descriptor)
+    }
+
+    static var defaultLockURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".local/share/simplex", isDirectory: true)
+            .appendingPathComponent("simplex-native.lock")
+    }
+
+    @MainActor
+    static func activateExistingApplication() {
+        guard let bundleIdentifier = Bundle.main.bundleIdentifier else { return }
+        let currentProcessID = ProcessInfo.processInfo.processIdentifier
+        NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier)
+            .first(where: { $0.processIdentifier != currentProcessID })?
+            .activate(options: [.activateAllWindows])
+    }
+}

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -912,6 +912,8 @@ private struct AttachmentCard: View {
 }
 
 private struct MessageContentView: View {
+    @State private var playingLinkVideo = false
+
     let message: NativeMessage
     let chat: NativeChat
     let openingAttachment: Bool
@@ -994,7 +996,9 @@ private struct MessageContentView: View {
 
     @ViewBuilder
     private func linkPreview(_ preview: NativeLinkPreview) -> some View {
-        if let destination = preview.destination {
+        if let destination = preview.destination, let inlineVideoURL = preview.inlineVideoURL {
+            playableLinkPreview(preview, destination: destination, inlineVideoURL: inlineVideoURL)
+        } else if let destination = preview.destination {
             Link(destination: destination) {
                 linkPreviewContent(preview)
             }
@@ -1006,17 +1010,97 @@ private struct MessageContentView: View {
         }
     }
 
+    private func playableLinkPreview(
+        _ preview: NativeLinkPreview,
+        destination: URL,
+        inlineVideoURL: URL
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if playingLinkVideo {
+                InlineVideoPlayer(url: inlineVideoURL)
+                    .aspectRatio(16 / 9, contentMode: .fit)
+                    .frame(maxWidth: 480)
+                    .accessibilityElement(children: .contain)
+            } else {
+                Button {
+                    playingLinkVideo = true
+                } label: {
+                    linkPreviewArtwork(preview, showPlayButton: true)
+                }
+                .buttonStyle(.plain)
+                .help("Play video here")
+                .accessibilityLabel("Play \(preview.title.isEmpty ? "YouTube Video" : preview.title)") // [VERIFY] Uses the visible preview title when available.
+                .accessibilityInputLabels(["Play Video", preview.title].filter { !$0.isEmpty })
+            }
+
+            linkPreviewMetadata(preview)
+
+            HStack(spacing: 12) {
+                if playingLinkVideo {
+                    Button("Close Video") {
+                        playingLinkVideo = false
+                    }
+                }
+                Spacer(minLength: 0)
+                Link("Open in Browser", destination: destination)
+            }
+            .font(.caption)
+            .padding(.horizontal, 12)
+            .padding(.bottom, 12)
+        }
+        .frame(maxWidth: 480, alignment: .leading)
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: 10))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .accessibilityElement(children: .contain)
+        .onKeyPress(.escape) {
+            guard playingLinkVideo else { return .ignored }
+            playingLinkVideo = false
+            return .handled
+        }
+    }
+
     private func linkPreviewContent(_ preview: NativeLinkPreview) -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            if let image = NativeChatParser.image(from: preview.image) {
-                ZStack(alignment: .bottomTrailing) {
-                    Image(nsImage: image)
-                        .resizable()
-                        .scaledToFit()
-                        .accessibilityHidden(true)
-                        .accessibilityIgnoresInvertColors()
+            if preview.image != nil {
+                linkPreviewArtwork(preview, showPlayButton: false)
+            }
+            linkPreviewMetadata(preview)
+        }
+        .frame(maxWidth: 480, alignment: .leading)
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: 10))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .accessibilityElement(children: .combine)
+    }
 
-                    if let duration = preview.durationLabel {
+    private func linkPreviewArtwork(_ preview: NativeLinkPreview, showPlayButton: Bool) -> some View {
+        ZStack {
+            if let image = NativeChatParser.image(from: preview.image) {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFit()
+                    .accessibilityHidden(true)
+                    .accessibilityIgnoresInvertColors()
+            } else {
+                Rectangle()
+                    .fill(.quaternary)
+                    .aspectRatio(16 / 9, contentMode: .fit)
+                    .accessibilityHidden(true)
+            }
+
+            if showPlayButton {
+                Image(systemName: "play.circle.fill")
+                    .font(.system(size: 48))
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(.white)
+                    .shadow(radius: 4)
+                    .accessibilityHidden(true)
+            }
+
+            if let duration = preview.durationLabel {
+                VStack {
+                    Spacer(minLength: 0)
+                    HStack {
+                        Spacer(minLength: 0)
                         Text(duration)
                             .font(.caption.monospacedDigit())
                             .padding(.horizontal, 8)
@@ -1026,33 +1110,32 @@ private struct MessageContentView: View {
                             .padding(8)
                     }
                 }
-                .frame(maxWidth: 420, maxHeight: 236)
-                .clipped()
             }
-
-            VStack(alignment: .leading, spacing: 4) {
-                if !preview.title.isEmpty {
-                    Text(preview.title)
-                        .font(.headline)
-                        .lineLimit(2)
-                }
-                if !preview.description.isEmpty {
-                    Text(preview.description)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(3)
-                }
-                Text(preview.displayHost)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-            }
-            .padding(12)
         }
-        .frame(maxWidth: 420, alignment: .leading)
-        .background(.quaternary, in: RoundedRectangle(cornerRadius: 10))
-        .clipShape(RoundedRectangle(cornerRadius: 10))
-        .accessibilityElement(children: .combine)
+        .aspectRatio(16 / 9, contentMode: .fit)
+        .frame(maxWidth: 480)
+        .clipped()
+    }
+
+    private func linkPreviewMetadata(_ preview: NativeLinkPreview) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if !preview.title.isEmpty {
+                Text(preview.title)
+                    .font(.headline)
+                    .lineLimit(2)
+            }
+            if !preview.description.isEmpty {
+                Text(preview.description)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(3)
+            }
+            Text(preview.displayHost)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .padding(12)
     }
 
     @ViewBuilder

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -118,7 +118,7 @@ struct ConversationView: View {
                             density: model.density,
                             startsGroup: startsGroup(at: index),
                             endsGroup: endsGroup(at: index),
-                            openingAttachment: model.openingAttachmentIDs.contains(message.id),
+                            openingAttachment: model.isOpeningAttachment(message.id),
                             canReply: model.canReply(to: message),
                             canOpenQuote: model.canNavigateConversationHistory
                         ) {

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -377,7 +377,7 @@ private struct ConversationAlertsModifier: ViewModifier {
             } message: {
                 Text(model.quoteNavigationError ?? "")
             }
-            .alert("Reply Cancelled", isPresented: replyContextErrorPresented) {
+            .alert("Reply Issue", isPresented: replyContextErrorPresented) {
                 Button("OK") { model.replyContextError = nil }
             } message: {
                 Text(model.replyContextError ?? "")

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -90,12 +90,14 @@ struct ConversationView: View {
                     model.jumpToLatest()
                 }
                 .labelStyle(.iconOnly)
+                .disabled(!model.canNavigateConversationHistory)
                 .help("Jump to Latest")
                 .accessibilityInputLabels(["Jump to Latest", "Latest Messages"])
             }
 
             Button("Refresh Conversation", systemImage: "arrow.clockwise", action: model.refresh)
                 .labelStyle(.iconOnly)
+                .disabled(!model.canRefreshConversation)
                 .help("Refresh Conversation")
                 .accessibilityInputLabels(["Refresh Conversation", "Refresh"])
         }
@@ -117,7 +119,8 @@ struct ConversationView: View {
                             startsGroup: startsGroup(at: index),
                             endsGroup: endsGroup(at: index),
                             openingAttachment: model.openingAttachmentIDs.contains(message.id),
-                            canReply: model.canReply(to: message)
+                            canReply: model.canReply(to: message),
+                            canOpenQuote: model.canNavigateConversationHistory
                         ) {
                             transcriptFocused = true
                             model.selectMessage(message.id, modifiers: NSApp.currentEvent?.modifierFlags ?? [])
@@ -225,6 +228,7 @@ struct ConversationView: View {
                 ReplyContextBar(
                     message: message,
                     chat: chat,
+                    canOpen: model.canNavigateConversationHistory,
                     canCancel: !model.isSendingSelectedChat,
                     open: { model.openReplyTarget() },
                     cancel: model.cancelReply
@@ -475,6 +479,7 @@ private struct MessageRow: View {
     let endsGroup: Bool
     let openingAttachment: Bool
     let canReply: Bool
+    let canOpenQuote: Bool
     let select: () -> Void
     let copy: () -> Void
     let delete: () -> Void
@@ -510,6 +515,7 @@ private struct MessageRow: View {
                     message: message,
                     chatName: chat.displayName,
                     openingAttachment: openingAttachment,
+                    canOpenQuote: canOpenQuote,
                     openQuote: openQuote,
                     openAttachment: openAttachment
                 )
@@ -559,7 +565,7 @@ private struct MessageRow: View {
             .accessibilityAddTraits(selected ? [.isSelected, .isButton] : .isButton)
             .accessibilityActions {
                 Button(selected ? "Deselect Message" : "Select Message", action: select)
-                if let quote = message.quotedItem {
+                if canOpenQuote, let quote = message.quotedItem {
                     Button("Show Quoted Message") { openQuote(quote) }
                 }
                 if canReply {
@@ -632,6 +638,7 @@ private struct TranscriptDateHeader: View {
 private struct ReplyContextBar: View {
     let message: NativeMessage
     let chat: NativeChat
+    let canOpen: Bool
     let canCancel: Bool
     let open: () -> Void
     let cancel: () -> Void
@@ -659,6 +666,7 @@ private struct ReplyContextBar: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .disabled(!canOpen)
             .help("Show Original Message")
             .accessibilityHint("Moves to the message being replied to in this conversation.")
             .accessibilityInputLabels(["Replying to \(sender)", "Show Original Message"]) // [VERIFY] The first label matches visible text.
@@ -796,6 +804,7 @@ private struct MessageContentView: View {
     let message: NativeMessage
     let chatName: String
     let openingAttachment: Bool
+    let canOpenQuote: Bool
     let openQuote: (NativeQuote) -> Void
     let openAttachment: () -> Void
 
@@ -807,6 +816,7 @@ private struct MessageContentView: View {
                     chatName: chatName,
                     outgoing: message.sent,
                     containingMessageID: message.id,
+                    enabled: canOpenQuote,
                     open: { openQuote(quote) }
                 )
             }
@@ -947,11 +957,13 @@ private struct QuotedMessagePreview: View {
     let chatName: String
     let outgoing: Bool
     let containingMessageID: Int64
+    let enabled: Bool
     let open: () -> Void
 
     var body: some View {
         Button(action: open) { content }
             .buttonStyle(.plain)
+            .disabled(!enabled)
             .help("Show Quoted Message")
             .accessibilityHint("Moves to the original message in this conversation.")
             .accessibilityInputLabels([quote.text, "Quoted Message"]) // [VERIFY] The first label matches visible quote text.

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -258,6 +258,7 @@ struct ConversationView: View {
                     .textFieldStyle(.plain)
                     .lineLimit(1...8)
                     .focused($composerFocused)
+                    .accessibilityIdentifier("composer.message")
                     .padding(.horizontal, 12)
                     .padding(.vertical, model.density.tokens.composerPadding)
                     .background(Color(nsColor: .textBackgroundColor), in: RoundedRectangle(cornerRadius: 10))
@@ -291,6 +292,7 @@ struct ConversationView: View {
                 .help("Send Message")
                 .accessibilityLabel("Send Message") // [VERIFY] Matches the visible tooltip.
                 .accessibilityInputLabels(["Send Message", "Send"])
+                .accessibilityIdentifier("composer.send")
             }
             .padding(12)
         }
@@ -318,6 +320,7 @@ private struct MessageSelectionBar: View {
                 Button(action: reply) {
                     Label("Reply", systemImage: "arrowshape.turn.up.left")
                 }
+                .accessibilityIdentifier("selection.reply")
             }
 
             Button(action: copy) {
@@ -537,6 +540,7 @@ private struct MessageRow: View {
                             .help("Reply")
                             .accessibilityLabel("Reply") // [VERIFY] Matches the visible tooltip.
                             .accessibilityInputLabels(["Reply", "Quote Message"])
+                            .accessibilityIdentifier("message.\(message.id).reply")
                         }
                     }
                     .contentShape(bubbleShape)
@@ -578,6 +582,7 @@ private struct MessageRow: View {
                 Button("Delete…", role: .destructive, action: delete)
             }
         }
+        .accessibilityIdentifier("message.\(message.id)")
     }
 
     private var bubbleBackground: Color {
@@ -657,6 +662,7 @@ private struct ReplyContextBar: View {
             .help("Show Original Message")
             .accessibilityHint("Moves to the message being replied to in this conversation.")
             .accessibilityInputLabels(["Replying to \(sender)", "Show Original Message"]) // [VERIFY] The first label matches visible text.
+            .accessibilityIdentifier("composer.replyContext")
 
             Spacer(minLength: 8)
 
@@ -668,6 +674,7 @@ private struct ReplyContextBar: View {
             .help("Cancel Reply")
             .accessibilityLabel("Cancel Reply") // [VERIFY] Matches the visible tooltip.
             .accessibilityInputLabels(["Cancel Reply", "Cancel"])
+            .accessibilityIdentifier("composer.cancelReply")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
@@ -799,6 +806,7 @@ private struct MessageContentView: View {
                     quote: quote,
                     chatName: chatName,
                     outgoing: message.sent,
+                    containingMessageID: message.id,
                     open: { openQuote(quote) }
                 )
             }
@@ -938,6 +946,7 @@ private struct QuotedMessagePreview: View {
     let quote: NativeQuote
     let chatName: String
     let outgoing: Bool
+    let containingMessageID: Int64
     let open: () -> Void
 
     var body: some View {
@@ -946,6 +955,7 @@ private struct QuotedMessagePreview: View {
             .help("Show Quoted Message")
             .accessibilityHint("Moves to the original message in this conversation.")
             .accessibilityInputLabels([quote.text, "Quoted Message"]) // [VERIFY] The first label matches visible quote text.
+            .accessibilityIdentifier("message.\(containingMessageID).quote")
     }
 
     private var content: some View {

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -699,6 +699,11 @@ private struct ReplyContextBar: View {
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
                     }
+
+                    if let visual = message.content.replyContextVisual {
+                        Spacer(minLength: 8)
+                        ReplyContextVisualView(visual: visual)
+                    }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .contentShape(Rectangle())
@@ -714,7 +719,10 @@ private struct ReplyContextBar: View {
 
             Button(action: cancel) {
                 Image(systemName: "xmark")
+                    .frame(width: 28, height: 28)
             }
+            .frame(width: 44, height: 44)
+            .contentShape(Rectangle())
             .buttonStyle(.borderless)
             .disabled(!canCancel)
             .help("Cancel Reply")
@@ -733,6 +741,51 @@ private struct ReplyContextBar: View {
 
     private var preview: String {
         message.replyPreview
+    }
+}
+
+private struct ReplyContextVisualView: View {
+    let visual: NativeReplyContextVisual
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(.quaternary)
+
+            switch visual {
+            case let .image(preview):
+                mediaPreview(preview, fallback: "photo")
+            case let .video(preview):
+                mediaPreview(preview, fallback: "film")
+                Image(systemName: "play.circle.fill")
+                    .font(.title3)
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(Color(nsColor: .selectedControlTextColor))
+                    .shadow(radius: 2)
+            case .voice:
+                Image(systemName: "waveform")
+                    .foregroundStyle(.secondary)
+            case .file:
+                Image(systemName: "doc")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(width: 40, height: 40)
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .accessibilityHidden(true)
+    }
+
+    @ViewBuilder
+    private func mediaPreview(_ preview: String?, fallback: String) -> some View {
+        if let image = NativeChatParser.image(from: preview) {
+            Image(nsImage: image)
+                .resizable()
+                .scaledToFill()
+                .accessibilityIgnoresInvertColors()
+        } else {
+            Image(systemName: fallback)
+                .foregroundStyle(.secondary)
+        }
     }
 }
 

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -619,7 +619,7 @@ private struct ReplyContextBar: View {
     }
 
     private var preview: String {
-        message.text.isEmpty ? (message.content.attachmentDescription ?? "Message") : message.text
+        message.replyPreview
     }
 }
 

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -23,7 +23,7 @@ struct ConversationView: View {
                 .navigationTitle("")
                 .toolbar { conversationToolbar(chat: chat) }
                 .dropDestination(for: URL.self) { urls, _ in
-                    guard !model.isSending else { return false }
+                    guard !model.isSendingSelectedChat else { return false }
                     model.stageAttachments(urls)
                     composerFocused = true
                     return !urls.isEmpty
@@ -125,7 +125,7 @@ struct ConversationView: View {
                             startsGroup: startsGroup(at: index),
                             endsGroup: endsGroup(at: index),
                             openingAttachment: model.openingAttachmentIDs.contains(message.id),
-                            canReply: chat.kind.canReply && !model.isSending
+                            canReply: chat.kind.canReply && !model.isSendingSelectedChat
                         ) {
                             transcriptFocused = true
                             model.selectMessage(message.id, modifiers: NSApp.currentEvent?.modifierFlags ?? [])
@@ -221,7 +221,7 @@ struct ConversationView: View {
                     count: model.selectedMessageIDs.count,
                     canReply: model.selectedMessagesInTranscriptOrder.count == 1
                         && chat.kind.canReply
-                        && !model.isSending,
+                        && !model.isSendingSelectedChat,
                     canDelete: model.canDeleteSelectedMessages,
                     reply: model.replyToSelectedMessage,
                     copy: model.copySelectedMessages,
@@ -232,7 +232,12 @@ struct ConversationView: View {
             }
 
             if let message = model.replyingTo {
-                ReplyContextBar(message: message, chat: chat, cancel: model.cancelReply)
+                ReplyContextBar(
+                    message: message,
+                    chat: chat,
+                    canCancel: !model.isSendingSelectedChat,
+                    cancel: model.cancelReply
+                )
                 Divider()
             }
 
@@ -253,7 +258,7 @@ struct ConversationView: View {
                 }
                 .menuStyle(.borderlessButton)
                 .fixedSize()
-                .disabled(model.isSending)
+                .disabled(model.isSendingSelectedChat)
                 .help("Add Attachments")
                 .accessibilityLabel("Attachments") // [VERIFY] Matches the attachment menu action.
                 .accessibilityInputLabels(["Attachments", "Attach Files"])
@@ -278,7 +283,7 @@ struct ConversationView: View {
                     ZStack {
                         Circle()
                             .fill(model.canSendDraft ? Color.accentColor : Color(nsColor: .tertiaryLabelColor))
-                        if model.isSending {
+                        if model.isSendingSelectedChat {
                             ProgressView()
                                 .controlSize(.small)
                                 .tint(Color(nsColor: .selectedControlTextColor))
@@ -572,6 +577,7 @@ private struct TranscriptDateHeader: View {
 private struct ReplyContextBar: View {
     let message: NativeMessage
     let chat: NativeChat
+    let canCancel: Bool
     let cancel: () -> Void
 
     var body: some View {
@@ -598,6 +604,7 @@ private struct ReplyContextBar: View {
                 Image(systemName: "xmark")
             }
             .buttonStyle(.borderless)
+            .disabled(!canCancel)
             .help("Cancel Reply")
             .accessibilityLabel("Cancel Reply") // [VERIFY] Matches the visible tooltip.
             .accessibilityInputLabels(["Cancel Reply", "Cancel"])
@@ -649,7 +656,7 @@ private struct AttachmentTray: View {
                         }
                         Button("Remove Attachment") { model.removeAttachment(attachment.id) }
                     }
-                    .disabled(model.isSending)
+                    .disabled(model.isSendingSelectedChat)
                 }
             }
             .padding(.horizontal, 12)

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -550,7 +550,7 @@ private struct MessageRow: View {
 
                 MessageContentView(
                     message: message,
-                    chatName: chat.displayName,
+                    chat: chat,
                     openingAttachment: openingAttachment,
                     canOpenQuote: canOpenQuote,
                     openQuote: openQuote,
@@ -728,7 +728,7 @@ private struct ReplyContextBar: View {
     }
 
     private var sender: String {
-        message.sent ? "You" : (message.author ?? chat.displayName)
+        chat.displayedMessageAuthor(sent: message.sent, author: message.author)
     }
 
     private var preview: String {
@@ -840,7 +840,7 @@ private struct AttachmentCard: View {
 
 private struct MessageContentView: View {
     let message: NativeMessage
-    let chatName: String
+    let chat: NativeChat
     let openingAttachment: Bool
     let canOpenQuote: Bool
     let openQuote: (NativeQuote) -> Void
@@ -851,7 +851,7 @@ private struct MessageContentView: View {
             if let quote = message.quotedItem {
                 QuotedMessagePreview(
                     quote: quote,
-                    chatName: chatName,
+                    chat: chat,
                     outgoing: message.sent,
                     containingMessageID: message.id,
                     enabled: canOpenQuote,
@@ -992,7 +992,7 @@ private struct MessageContentView: View {
 
 private struct QuotedMessagePreview: View {
     let quote: NativeQuote
-    let chatName: String
+    let chat: NativeChat
     let outgoing: Bool
     let containingMessageID: Int64
     let enabled: Bool
@@ -1029,7 +1029,7 @@ private struct QuotedMessagePreview: View {
     }
 
     private var sender: String {
-        quote.author ?? (quote.sent ? "You" : chatName)
+        chat.displayedMessageAuthor(sent: quote.sent, author: quote.author)
     }
 }
 

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+struct ConversationView: View {
+    @ObservedObject var model: AppModel
+    @FocusState private var composerFocused: Bool
+
+    var body: some View {
+        Group {
+            if let chat = model.selectedChat {
+                VStack(spacing: 0) {
+                    transcript(chat: chat)
+                    Divider()
+                    composer(chat: chat)
+                }
+                .navigationTitle(chat.displayName)
+            } else {
+                ContentUnavailableView("Select a conversation", systemImage: "bubble.left.and.bubble.right")
+            }
+        }
+    }
+
+    private func transcript(chat: NativeChat) -> some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 8) {
+                    ForEach(model.messages) { message in
+                        MessageRow(message: message)
+                            .id(message.id)
+                    }
+                }
+                .padding(16)
+            }
+            .overlay {
+                if model.isLoadingConversation { ProgressView() }
+            }
+            .onChange(of: model.messages.last?.id) { _, lastID in
+                guard let lastID else { return }
+                proxy.scrollTo(lastID, anchor: .bottom)
+            }
+        }
+    }
+
+    private func composer(chat: NativeChat) -> some View {
+        HStack(alignment: .bottom, spacing: 8) {
+            TextField("Message", text: $model.draft, axis: .vertical)
+                .textFieldStyle(.plain)
+                .lineLimit(1...8)
+                .focused($composerFocused)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(.quaternary, in: RoundedRectangle(cornerRadius: 12))
+                .onSubmit(model.sendDraft)
+
+            Button(action: model.sendDraft) {
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.title2)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(
+                model.draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    ? Color.secondary
+                    : Color.accentColor
+            )
+            .disabled(model.draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || model.isSending || !chat.kind.canSend)
+            .help("Send Message")
+            .accessibilityLabel("Send Message") // [VERIFY] Matches the visible tooltip.
+            .accessibilityInputLabels(["Send Message", "Send"])
+        }
+        .padding(12)
+        .background(.bar)
+    }
+}
+
+private struct MessageRow: View {
+    let message: NativeMessage
+
+    var body: some View {
+        HStack {
+            if message.sent { Spacer(minLength: 80) }
+            VStack(alignment: .leading, spacing: 4) {
+                if !message.sent, let author = message.author {
+                    Text(author)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+                Text(message.text)
+                    .textSelection(.enabled)
+                if let timestamp = message.timestamp {
+                    Text(timestamp, format: .dateTime.hour().minute())
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(
+                message.sent ? AnyShapeStyle(Color.accentColor.opacity(0.16)) : AnyShapeStyle(.quaternary),
+                in: RoundedRectangle(cornerRadius: 12)
+            )
+            .accessibilityElement(children: .combine)
+            if !message.sent { Spacer(minLength: 80) }
+        }
+    }
+}

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -983,8 +983,7 @@ private struct MessageContentView: View {
     }
 
     private var messageText: some View {
-        Text(message.text)
-            .textSelection(.enabled)
+        MessageBodyText(text: message.text)
     }
 
     @ViewBuilder
@@ -1060,6 +1059,17 @@ private struct MessageContentView: View {
     private var attachmentExists: Bool {
         guard let source = message.fileSource else { return false }
         return FileManager.default.fileExists(atPath: source.sourceURL.path)
+    }
+}
+
+struct MessageBodyText: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .lineLimit(nil)
+            .fixedSize(horizontal: false, vertical: true)
+            .textSelection(.enabled)
     }
 }
 

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -1075,6 +1075,11 @@ private struct QuotedMessagePreview: View {
                     .font(.callout)
                     .lineLimit(2)
             }
+
+            if let visual = quote.visual {
+                Spacer(minLength: 8)
+                ReplyContextVisualView(visual: visual)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityElement(children: .combine)

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -45,21 +45,7 @@ struct ConversationView: View {
                 } message: {
                     Text("This removes the selected messages from this Mac. It does not delete them for other people.")
                 }
-                .alert("Couldn’t Add Attachment", isPresented: attachmentErrorPresented) {
-                    Button("OK") { model.attachmentError = nil }
-                } message: {
-                    Text(model.attachmentError ?? "")
-                }
-                .alert("Couldn’t Open Attachment", isPresented: attachmentOpenErrorPresented) {
-                    Button("OK") { model.attachmentOpenError = nil }
-                } message: {
-                    Text(model.attachmentOpenError ?? "")
-                }
-                .alert("Couldn’t Find Quoted Message", isPresented: quoteNavigationErrorPresented) {
-                    Button("OK") { model.quoteNavigationError = nil }
-                } message: {
-                    Text(model.quoteNavigationError ?? "")
-                }
+                .modifier(ConversationAlertsModifier(model: model))
             } else {
                 ContentUnavailableView {
                     Label("No Conversation Selected", systemImage: "bubble.left.and.bubble.right")
@@ -77,27 +63,6 @@ struct ConversationView: View {
         .onChange(of: model.composerFocusRequest) { _, _ in
             composerFocused = true
         }
-    }
-
-    private var attachmentErrorPresented: Binding<Bool> {
-        Binding(
-            get: { model.attachmentError != nil },
-            set: { if !$0 { model.attachmentError = nil } }
-        )
-    }
-
-    private var attachmentOpenErrorPresented: Binding<Bool> {
-        Binding(
-            get: { model.attachmentOpenError != nil },
-            set: { if !$0 { model.attachmentOpenError = nil } }
-        )
-    }
-
-    private var quoteNavigationErrorPresented: Binding<Bool> {
-        Binding(
-            get: { model.quoteNavigationError != nil },
-            set: { if !$0 { model.quoteNavigationError = nil } }
-        )
     }
 
     @ToolbarContentBuilder
@@ -145,7 +110,9 @@ struct ConversationView: View {
                             startsGroup: startsGroup(at: index),
                             endsGroup: endsGroup(at: index),
                             openingAttachment: model.openingAttachmentIDs.contains(message.id),
-                            canReply: chat.kind.canReply && !model.isSendingSelectedChat
+                            canReply: chat.kind.canReply
+                                && message.replyable
+                                && !model.isSendingSelectedChat
                         ) {
                             transcriptFocused = true
                             model.selectMessage(message.id, modifiers: NSApp.currentEvent?.modifierFlags ?? [])
@@ -239,9 +206,7 @@ struct ConversationView: View {
             if !model.selectedMessageIDs.isEmpty {
                 MessageSelectionBar(
                     count: model.selectedMessageIDs.count,
-                    canReply: model.selectedMessagesInTranscriptOrder.count == 1
-                        && chat.kind.canReply
-                        && !model.isSendingSelectedChat,
+                    canReply: model.canReplyToSelectedMessage,
                     canDelete: model.canDeleteSelectedMessages,
                     reply: model.replyToSelectedMessage,
                     copy: model.copySelectedMessages,
@@ -366,6 +331,62 @@ private struct MessageSelectionBar: View {
         .padding(.vertical, 8)
         .background(Color(nsColor: .windowBackgroundColor))
         .accessibilityElement(children: .contain)
+    }
+}
+
+private struct ConversationAlertsModifier: ViewModifier {
+    @ObservedObject var model: AppModel
+
+    func body(content: Content) -> some View {
+        content
+            .alert("Couldn’t Add Attachment", isPresented: attachmentErrorPresented) {
+                Button("OK") { model.attachmentError = nil }
+            } message: {
+                Text(model.attachmentError ?? "")
+            }
+            .alert("Couldn’t Open Attachment", isPresented: attachmentOpenErrorPresented) {
+                Button("OK") { model.attachmentOpenError = nil }
+            } message: {
+                Text(model.attachmentOpenError ?? "")
+            }
+            .alert("Couldn’t Find Quoted Message", isPresented: quoteNavigationErrorPresented) {
+                Button("OK") { model.quoteNavigationError = nil }
+            } message: {
+                Text(model.quoteNavigationError ?? "")
+            }
+            .alert("Reply Cancelled", isPresented: replyContextErrorPresented) {
+                Button("OK") { model.replyContextError = nil }
+            } message: {
+                Text(model.replyContextError ?? "")
+            }
+    }
+
+    private var attachmentErrorPresented: Binding<Bool> {
+        Binding(
+            get: { model.attachmentError != nil },
+            set: { if !$0 { model.attachmentError = nil } }
+        )
+    }
+
+    private var attachmentOpenErrorPresented: Binding<Bool> {
+        Binding(
+            get: { model.attachmentOpenError != nil },
+            set: { if !$0 { model.attachmentOpenError = nil } }
+        )
+    }
+
+    private var quoteNavigationErrorPresented: Binding<Bool> {
+        Binding(
+            get: { model.quoteNavigationError != nil },
+            set: { if !$0 { model.quoteNavigationError = nil } }
+        )
+    }
+
+    private var replyContextErrorPresented: Binding<Bool> {
+        Binding(
+            get: { model.replyContextError != nil },
+            set: { if !$0 { model.replyContextError = nil } }
+        )
     }
 }
 

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -11,11 +11,17 @@ struct ConversationView: View {
         Group {
             if let chat = model.selectedChat {
                 VStack(spacing: 0) {
-                    transcript
+                    if model.conversationSearchPresented {
+                        ConversationSearchBar(model: model)
+                        Divider()
+                    }
+                    transcript(chat: chat)
                     Divider()
                     composer(chat: chat)
                 }
-                .navigationTitle(chat.displayName)
+                .background(Color(nsColor: .textBackgroundColor))
+                .navigationTitle("")
+                .toolbar { conversationToolbar(chat: chat) }
                 .dropDestination(for: URL.self) { urls, _ in
                     model.stageAttachments(urls)
                     composerFocused = true
@@ -45,7 +51,11 @@ struct ConversationView: View {
                     Text(model.attachmentError ?? "")
                 }
             } else {
-                ContentUnavailableView("Select a conversation", systemImage: "bubble.left.and.bubble.right")
+                ContentUnavailableView {
+                    Label("No Conversation Selected", systemImage: "bubble.left.and.bubble.right")
+                } description: {
+                    Text("Choose a chat from the sidebar to start messaging.")
+                }
             }
         }
         .onChange(of: transcriptFocused) { _, focused in
@@ -56,24 +66,70 @@ struct ConversationView: View {
         }
     }
 
-    private var transcript: some View {
+    @ToolbarContentBuilder
+    private func conversationToolbar(chat: NativeChat) -> some ToolbarContent {
+        ToolbarItem(placement: .principal) {
+            HStack(spacing: 8) {
+                ProfileAvatar(image: chat.image, name: chat.displayName, size: 28)
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(chat.displayName)
+                        .font(.headline)
+                        .lineLimit(1)
+                    Text(chat.kind.toolbarSubtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Conversation with (chat.displayName)")
+        }
+
+        ToolbarItem(placement: .primaryAction) {
+            Button(action: model.refresh) {
+                Image(systemName: "arrow.clockwise")
+            }
+            .help("Refresh Conversation")
+            .accessibilityLabel("Refresh Conversation") // [VERIFY] Matches the visible tooltip.
+            .accessibilityInputLabels(["Refresh Conversation", "Refresh"])
+        }
+    }
+
+    private func transcript(chat: NativeChat) -> some View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(spacing: model.density.tokens.transcriptGap) {
-                    ForEach(model.messages) { message in
+                    ForEach(Array(model.messages.enumerated()), id: \.element.id) { index, message in
+                        if startsNewDay(at: index), let timestamp = message.timestamp {
+                            TranscriptDateHeader(date: timestamp)
+                        }
                         MessageRow(
                             message: message,
+                            chat: chat,
                             selected: model.selectedMessageIDs.contains(message.id),
-                            density: model.density
+                            density: model.density,
+                            startsGroup: startsGroup(at: index),
+                            endsGroup: endsGroup(at: index)
                         ) {
                             transcriptFocused = true
                             model.selectMessage(message.id, modifiers: NSApp.currentEvent?.modifierFlags ?? [])
+                        } copy: {
+                            transcriptFocused = true
+                            model.selectMessage(message.id, modifiers: [])
+                            model.copySelectedMessages()
+                        } delete: {
+                            transcriptFocused = true
+                            model.selectMessage(message.id, modifiers: [])
+                            model.requestDeleteSelectedMessages()
                         }
                         .id(message.id)
                     }
                 }
-                .padding(16)
+                .padding(.horizontal, 20)
+                .padding(.vertical, 16)
             }
+            .defaultScrollAnchor(.bottom)
+            .background(Color(nsColor: .textBackgroundColor))
             .focusable()
             .focused($transcriptFocused)
             .focusEffectDisabled()
@@ -112,6 +168,29 @@ struct ConversationView: View {
         }
     }
 
+    private func startsNewDay(at index: Int) -> Bool {
+        guard index > 0 else { return true }
+        guard let current = model.messages[index].timestamp,
+              let previous = model.messages[index - 1].timestamp else { return false }
+        return !Calendar.current.isDate(current, inSameDayAs: previous)
+    }
+
+    private func startsGroup(at index: Int) -> Bool {
+        guard index > 0 else { return true }
+        return !messagesBelongToSameGroup(model.messages[index - 1], model.messages[index])
+    }
+
+    private func endsGroup(at index: Int) -> Bool {
+        guard index + 1 < model.messages.count else { return true }
+        return !messagesBelongToSameGroup(model.messages[index], model.messages[index + 1])
+    }
+
+    private func messagesBelongToSameGroup(_ first: NativeMessage, _ second: NativeMessage) -> Bool {
+        guard first.sent == second.sent, first.author == second.author,
+              let firstDate = first.timestamp, let secondDate = second.timestamp else { return false }
+        return abs(secondDate.timeIntervalSince(firstDate)) <= 5 * 60
+    }
+
     private func composer(chat: NativeChat) -> some View {
         VStack(spacing: 0) {
             if !model.pendingAttachments.isEmpty {
@@ -125,8 +204,9 @@ struct ConversationView: View {
                     Button("Paste Files", action: model.stageFilesFromPasteboard)
                         .keyboardShortcut("v", modifiers: [.command, .option])
                 } label: {
-                    Label("Attachments", systemImage: "paperclip")
-                        .labelStyle(.iconOnly)
+                    Image(systemName: "paperclip")
+                        .frame(width: 32, height: 32)
+                        .contentShape(Rectangle())
                 }
                 .menuStyle(.borderlessButton)
                 .fixedSize()
@@ -140,15 +220,33 @@ struct ConversationView: View {
                     .focused($composerFocused)
                     .padding(.horizontal, 12)
                     .padding(.vertical, model.density.tokens.composerPadding)
-                    .background(.quaternary, in: RoundedRectangle(cornerRadius: 12))
+                    .background(Color(nsColor: .textBackgroundColor), in: RoundedRectangle(cornerRadius: 10))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(
+                                composerFocused ? Color.accentColor : Color(nsColor: .separatorColor),
+                                lineWidth: composerFocused ? 2 : 1
+                            )
+                    }
                     .onSubmit(model.sendDraft)
 
                 Button(action: model.sendDraft) {
-                    Image(systemName: "arrow.up.circle.fill")
-                        .font(.title2)
+                    ZStack {
+                        Circle()
+                            .fill(model.canSendDraft ? Color.accentColor : Color(nsColor: .tertiaryLabelColor))
+                        if model.isSending {
+                            ProgressView()
+                                .controlSize(.small)
+                                .tint(Color(nsColor: .selectedControlTextColor))
+                        } else {
+                            Image(systemName: "arrow.up")
+                                .font(.body.weight(.bold))
+                                .foregroundStyle(Color(nsColor: .selectedControlTextColor))
+                        }
+                    }
+                    .frame(width: 32, height: 32)
                 }
                 .buttonStyle(.plain)
-                .foregroundStyle(model.canSendDraft ? Color.accentColor : Color.secondary)
                 .disabled(!model.canSendDraft || !chat.kind.canSend)
                 .help("Send Message")
                 .accessibilityLabel("Send Message") // [VERIFY] Matches the visible tooltip.
@@ -156,52 +254,191 @@ struct ConversationView: View {
             }
             .padding(12)
         }
-        .background(.bar)
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+}
+
+private struct ConversationSearchBar: View {
+    @ObservedObject var model: AppModel
+    @FocusState private var searchFocused: Bool
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+
+            TextField("Search Conversation", text: $model.conversationSearchText)
+                .textFieldStyle(.roundedBorder)
+                .focused($searchFocused)
+                .frame(maxWidth: 320)
+                .onSubmit { model.moveConversationSearchResult(by: 1) }
+
+            Text(model.conversationSearchResultDescription)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(minWidth: 64, alignment: .leading)
+
+            Button {
+                model.moveConversationSearchResult(by: -1)
+            } label: {
+                Image(systemName: "chevron.up")
+            }
+            .disabled(model.conversationSearchMatches.isEmpty)
+            .help("Previous Result")
+            .accessibilityLabel("Previous Result") // [VERIFY] Matches the visible tooltip.
+            .accessibilityInputLabels(["Previous Result", "Previous"])
+
+            Button {
+                model.moveConversationSearchResult(by: 1)
+            } label: {
+                Image(systemName: "chevron.down")
+            }
+            .disabled(model.conversationSearchMatches.isEmpty)
+            .help("Next Result")
+            .accessibilityLabel("Next Result") // [VERIFY] Matches the visible tooltip.
+            .accessibilityInputLabels(["Next Result", "Next"])
+
+            Button(action: model.dismissConversationSearch) {
+                Image(systemName: "xmark")
+            }
+            .help("Close Search")
+            .accessibilityLabel("Close Search") // [VERIFY] Matches the visible tooltip.
+            .accessibilityInputLabels(["Close Search", "Close"])
+
+            Spacer(minLength: 0)
+        }
+        .buttonStyle(.borderless)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .onAppear { searchFocused = true }
+        .onChange(of: model.conversationSearchText) { _, _ in
+            model.updateConversationSearchSelection()
+        }
+        .onKeyPress(.escape) {
+            model.dismissConversationSearch()
+            return .handled
+        }
     }
 }
 
 private struct MessageRow: View {
     let message: NativeMessage
+    let chat: NativeChat
     let selected: Bool
     let density: DesktopChatDensity
+    let startsGroup: Bool
+    let endsGroup: Bool
     let select: () -> Void
+    let copy: () -> Void
+    let delete: () -> Void
 
     var body: some View {
-        HStack {
+        HStack(alignment: .bottom, spacing: 8) {
+            if !message.sent {
+                Group {
+                    if endsGroup {
+                        ProfileAvatar(image: chat.image, name: message.author ?? chat.displayName, size: 28)
+                    } else {
+                        Color.clear
+                    }
+                }
+                .frame(width: 28, height: 28)
+                .accessibilityHidden(true)
+            }
+
             if message.sent { Spacer(minLength: 80) }
-            VStack(alignment: .leading, spacing: 4) {
-                if !message.sent, let author = message.author {
+
+            VStack(alignment: message.sent ? .trailing : .leading, spacing: 4) {
+                if startsGroup, !message.sent, let author = message.author, chat.kind == .group {
                     Text(author)
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(.secondary)
+                        .padding(.leading, 8)
                 }
+
                 MessageContentView(message: message)
-                if let timestamp = message.timestamp {
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, density.tokens.messagePadding)
+                    .background(bubbleBackground, in: bubbleShape)
+                    .foregroundStyle(message.sent ? Color(nsColor: .selectedControlTextColor) : Color.primary)
+                    .overlay {
+                        if selected {
+                            bubbleShape
+                                .stroke(Color.accentColor, lineWidth: 2)
+                                .padding(-2)
+                        }
+                    }
+                    .contentShape(bubbleShape)
+                    .onTapGesture(perform: select)
+                    .focusEffectDisabled()
+
+                if endsGroup, let timestamp = message.timestamp {
                     Text(timestamp, format: .dateTime.hour().minute())
                         .font(.caption2)
                         .foregroundStyle(.secondary)
+                        .padding(.horizontal, 8)
                 }
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, density.tokens.messagePadding)
-            .background(
-                message.sent ? AnyShapeStyle(Color.accentColor.opacity(0.15)) : AnyShapeStyle(.quaternary),
-                in: RoundedRectangle(cornerRadius: 12)
-            )
-            .overlay {
-                if selected {
-                    RoundedRectangle(cornerRadius: 12)
-                        .stroke(.tint, lineWidth: 2)
-                        .padding(-2)
-                }
-            }
-            .contentShape(RoundedRectangle(cornerRadius: 12))
-            .onTapGesture(perform: select)
+            .frame(maxWidth: 520, alignment: message.sent ? .trailing : .leading)
             .accessibilityElement(children: .combine)
             .accessibilityAddTraits(selected ? .isSelected : [])
             .accessibilityAction(named: selected ? "Deselect Message" : "Select Message", select)
+
             if !message.sent { Spacer(minLength: 80) }
         }
+        .contextMenu {
+            Button("Copy", action: copy)
+            Button(selected ? "Deselect Message" : "Select Message", action: select)
+            if message.deletable {
+                Divider()
+                Button("Delete…", role: .destructive, action: delete)
+            }
+        }
+    }
+
+    private var bubbleBackground: Color {
+        message.sent
+            ? Color(nsColor: .selectedContentBackgroundColor)
+            : Color(nsColor: .unemphasizedSelectedContentBackgroundColor)
+    }
+
+    private var bubbleShape: UnevenRoundedRectangle {
+        if message.sent {
+            UnevenRoundedRectangle(
+                topLeadingRadius: 16,
+                bottomLeadingRadius: 16,
+                bottomTrailingRadius: endsGroup ? 4 : 16,
+                topTrailingRadius: 16
+            )
+        } else {
+            UnevenRoundedRectangle(
+                topLeadingRadius: 16,
+                bottomLeadingRadius: endsGroup ? 4 : 16,
+                bottomTrailingRadius: 16,
+                topTrailingRadius: 16
+            )
+        }
+    }
+}
+
+private struct TranscriptDateHeader: View {
+    let date: Date
+
+    var body: some View {
+        Text(label)
+            .font(.caption.weight(.medium))
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+            .accessibilityAddTraits(.isHeader)
+    }
+
+    private var label: String {
+        if Calendar.current.isDateInToday(date) { return "Today" }
+        if Calendar.current.isDateInYesterday(date) { return "Yesterday" }
+        return date.formatted(.dateTime.month(.abbreviated).day().year())
     }
 }
 
@@ -211,15 +448,32 @@ private struct AttachmentTray: View {
     var body: some View {
         ScrollView(.horizontal) {
             HStack(spacing: 8) {
-                ForEach(model.pendingAttachments) { attachment in
-                    AttachmentCard(attachment: attachment) {
+                ForEach(Array(model.pendingAttachments.enumerated()), id: \.element.id) { index, attachment in
+                    AttachmentCard(
+                        attachment: attachment,
+                        canMoveEarlier: index > 0,
+                        canMoveLater: index + 1 < model.pendingAttachments.count
+                    ) {
                         model.removeAttachment(attachment.id)
+                    } moveEarlier: {
+                        model.moveAttachment(attachment.id, by: -1)
+                    } moveLater: {
+                        model.moveAttachment(attachment.id, by: 1)
                     }
                     .draggable(attachment.id.uuidString)
                     .dropDestination(for: String.self) { values, _ in
                         guard let value = values.first, let source = UUID(uuidString: value) else { return false }
                         model.reorderAttachment(source, before: attachment.id)
                         return true
+                    }
+                    .accessibilityActions {
+                        if index > 0 {
+                            Button("Move Earlier") { model.moveAttachment(attachment.id, by: -1) }
+                        }
+                        if index + 1 < model.pendingAttachments.count {
+                            Button("Move Later") { model.moveAttachment(attachment.id, by: 1) }
+                        }
+                        Button("Remove Attachment") { model.removeAttachment(attachment.id) }
                     }
                 }
             }
@@ -233,7 +487,11 @@ private struct AttachmentTray: View {
 
 private struct AttachmentCard: View {
     let attachment: PendingAttachment
+    let canMoveEarlier: Bool
+    let canMoveLater: Bool
     let remove: () -> Void
+    let moveEarlier: () -> Void
+    let moveLater: () -> Void
 
     var body: some View {
         HStack(spacing: 8) {
@@ -274,6 +532,14 @@ private struct AttachmentCard: View {
         .frame(width: 224, alignment: .leading)
         .background(.quaternary, in: RoundedRectangle(cornerRadius: 10))
         .accessibilityElement(children: .contain)
+        .contextMenu {
+            Button("Move Earlier", action: moveEarlier)
+                .disabled(!canMoveEarlier)
+            Button("Move Later", action: moveLater)
+                .disabled(!canMoveLater)
+            Divider()
+            Button("Remove Attachment", role: .destructive, action: remove)
+        }
     }
 }
 
@@ -367,11 +633,18 @@ private struct MessageContentView: View {
 }
 
 private struct DropTargetOverlay: View {
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
     var body: some View {
         Label("Drop files to attach", systemImage: "tray.and.arrow.down.fill")
             .font(.headline)
             .padding(24)
-            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+            .background {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(reduceTransparency
+                        ? AnyShapeStyle(Color(nsColor: .windowBackgroundColor))
+                        : AnyShapeStyle(.regularMaterial))
+            }
             .overlay {
                 RoundedRectangle(cornerRadius: 12)
                     .stroke(.tint, style: StrokeStyle(lineWidth: 2, dash: [8, 4]))

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -157,15 +157,7 @@ struct ConversationView: View {
             .focused($transcriptFocused)
             .focusEffectDisabled()
             .overlay {
-                ZStack {
-                    if transcriptFocused {
-                        RoundedRectangle(cornerRadius: 6, style: .continuous)
-                            .stroke(Color.accentColor.opacity(0.8), lineWidth: 2)
-                            .padding(2)
-                            .allowsHitTesting(false)
-                    }
-                    if model.isLoadingConversation { ProgressView() }
-                }
+                if model.isLoadingConversation { ProgressView() }
             }
             .accessibilityLabel("Conversation transcript") // [VERIFY] Names the keyboard-focusable transcript region.
             .accessibilityHint("Use the arrow keys to select messages. Press Return to reply to the selected message.") // [VERIFY] Describes the transcript keyboard actions.

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -349,6 +349,8 @@ private struct ConversationSearchBar: View {
 }
 
 private struct MessageRow: View {
+    @State private var hovering = false
+
     let message: NativeMessage
     let chat: NativeChat
     let selected: Bool
@@ -406,6 +408,24 @@ private struct MessageRow: View {
                                 .padding(-2)
                         }
                     }
+                    .overlay(alignment: message.sent ? .leading : .trailing) {
+                        if hovering, canReply {
+                            Button(action: reply) {
+                                Image(systemName: "arrowshape.turn.up.left")
+                                    .frame(width: 28, height: 28)
+                                    .background(Color(nsColor: .controlBackgroundColor), in: Circle())
+                                    .overlay {
+                                        Circle().stroke(Color(nsColor: .separatorColor))
+                                    }
+                                    .contentShape(Circle())
+                            }
+                            .buttonStyle(.plain)
+                            .offset(x: message.sent ? -40 : 40)
+                            .help("Reply")
+                            .accessibilityLabel("Reply") // [VERIFY] Matches the visible tooltip.
+                            .accessibilityInputLabels(["Reply", "Quote Message"])
+                        }
+                    }
                     .contentShape(bubbleShape)
                     .onTapGesture(perform: select)
                     .focusEffectDisabled()
@@ -429,6 +449,7 @@ private struct MessageRow: View {
 
             if !message.sent { Spacer(minLength: 80) }
         }
+        .onHover { hovering = $0 }
         .contextMenu {
             if canReply {
                 Button("Reply", action: reply)

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -121,6 +121,7 @@ struct ConversationView: View {
                             startsGroup: startsGroup(at: index),
                             endsGroup: endsGroup(at: index),
                             openingAttachment: model.isOpeningAttachment(message.id),
+                            inlineAudioURL: model.inlineAudioURL(message.id),
                             canReply: model.canReply(to: message),
                             canOpenQuote: model.canNavigateConversationHistory
                         ) {
@@ -141,6 +142,8 @@ struct ConversationView: View {
                             model.openQuotedMessage(quote, from: message.id)
                         } openAttachment: {
                             model.openAttachment(message)
+                        } prepareInlineAudio: {
+                            model.prepareInlineAudio(message)
                         }
                         .id(message.id)
                     }
@@ -517,6 +520,7 @@ private struct MessageRow: View {
     let startsGroup: Bool
     let endsGroup: Bool
     let openingAttachment: Bool
+    let inlineAudioURL: URL?
     let canReply: Bool
     let canOpenQuote: Bool
     let select: () -> Void
@@ -525,6 +529,7 @@ private struct MessageRow: View {
     let reply: () -> Void
     let openQuote: (NativeQuote) -> Void
     let openAttachment: () -> Void
+    let prepareInlineAudio: () -> Void
 
     var body: some View {
         HStack(alignment: .bottom, spacing: 8) {
@@ -566,7 +571,7 @@ private struct MessageRow: View {
                 }
             }
             .frame(maxWidth: 568, alignment: message.sent ? .trailing : .leading)
-            .accessibilityElement(children: .combine)
+            .accessibilityElement(children: .contain)
             .accessibilityAddTraits(selected ? [.isSelected, .isButton] : .isButton)
             .accessibilityActions {
                 Button(selected ? "Deselect Message" : "Select Message", action: select)
@@ -600,9 +605,11 @@ private struct MessageRow: View {
             message: message,
             chat: chat,
             openingAttachment: openingAttachment,
+            inlineAudioURL: inlineAudioURL,
             canOpenQuote: canOpenQuote,
             openQuote: openQuote,
-            openAttachment: openAttachment
+            openAttachment: openAttachment,
+            prepareInlineAudio: prepareInlineAudio
         )
         .padding(.horizontal, 12)
         .padding(.vertical, density.tokens.messagePadding)
@@ -913,13 +920,16 @@ private struct AttachmentCard: View {
 
 private struct MessageContentView: View {
     @State private var playingLinkVideo = false
+    @State private var requestedAudioPlayback = false
 
     let message: NativeMessage
     let chat: NativeChat
     let openingAttachment: Bool
+    let inlineAudioURL: URL?
     let canOpenQuote: Bool
     let openQuote: (NativeQuote) -> Void
     let openAttachment: () -> Void
+    let prepareInlineAudio: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -950,44 +960,60 @@ private struct MessageContentView: View {
                 mediaPreview(preview: preview, fileName: fileName ?? "Video", video: true)
                 if !message.text.isEmpty { messageText }
             case .voice(let fileName, let duration):
-                voiceAttachment(fileName: fileName, duration: duration)
+                audioAttachment(fileName: fileName ?? "Voice message", duration: duration)
                 if !message.text.isEmpty { messageText }
             case .file(let fileName):
-                fileAttachment(name: fileName ?? message.text)
+                if NativeAudioFile.supports(fileName) {
+                    audioAttachment(fileName: fileName ?? message.text, duration: nil)
+                } else {
+                    fileAttachment(name: fileName ?? message.text)
+                }
                 if !message.text.isEmpty, message.text != fileName { messageText }
             }
         }
     }
 
     @ViewBuilder
-    private func voiceAttachment(fileName: String?, duration: Int?) -> some View {
-        if attachmentExists {
-            Button(action: openAttachment) {
-                voiceAttachmentLabel(duration: duration)
+    private func audioAttachment(fileName: String, duration: Int?) -> some View {
+        if requestedAudioPlayback, let inlineAudioURL {
+            InlineAudioPlayer(
+                url: inlineAudioURL,
+                title: fileName,
+                fallbackDuration: duration,
+                close: { requestedAudioPlayback = false }
+            )
+        } else if attachmentExists {
+            Button {
+                requestedAudioPlayback = true
+                prepareInlineAudio()
+            } label: {
+                HStack(spacing: 12) {
+                    Image(systemName: "play.circle.fill")
+                        .font(.title)
+                        .accessibilityHidden(true)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(fileName)
+                            .lineLimit(1)
+                        Text(openingAttachment ? "Preparing audio…" : "Play audio")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    if openingAttachment {
+                        ProgressView()
+                            .controlSize(.small)
+                            .accessibilityLabel("Preparing Audio")
+                    }
+                }
             }
-            .buttonStyle(.link)
+            .buttonStyle(.plain)
             .disabled(openingAttachment)
-            .help("Open \(fileName ?? "voice message")")
+            .help("Play \(fileName)")
+            .accessibilityLabel("Play \(fileName)") // [VERIFY] Uses the visible audio file name.
+            .accessibilityInputLabels(["Play \(fileName)", "Play Audio"])
         } else {
-            voiceAttachmentLabel(duration: duration)
+            Label(fileName, systemImage: "waveform")
                 .foregroundStyle(.secondary)
         }
-    }
-
-    private func voiceAttachmentLabel(duration: Int?) -> some View {
-        HStack(spacing: 6) {
-            Label("Voice message", systemImage: "waveform")
-            if let duration, duration > 0 {
-                Text(Duration.seconds(Double(duration)), format: .time(pattern: .minuteSecond))
-                    .foregroundStyle(.secondary)
-            }
-            if openingAttachment {
-                ProgressView()
-                    .controlSize(.small)
-                    .accessibilityLabel("Decrypting Voice Message")
-            }
-        }
-        .accessibilityElement(children: .combine)
     }
 
     private var messageText: some View {

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -1,35 +1,82 @@
+import AppKit
 import SwiftUI
 
 struct ConversationView: View {
     @ObservedObject var model: AppModel
     @FocusState private var composerFocused: Bool
+    @FocusState private var transcriptFocused: Bool
+    @State private var dropTargeted = false
 
     var body: some View {
         Group {
             if let chat = model.selectedChat {
                 VStack(spacing: 0) {
-                    transcript(chat: chat)
+                    transcript
                     Divider()
                     composer(chat: chat)
                 }
                 .navigationTitle(chat.displayName)
+                .dropDestination(for: URL.self) { urls, _ in
+                    model.stageAttachments(urls)
+                    composerFocused = true
+                    return !urls.isEmpty
+                } isTargeted: { dropTargeted = $0 }
+                .overlay {
+                    if dropTargeted {
+                        DropTargetOverlay()
+                    }
+                }
+                .confirmationDialog(
+                    "Delete selected messages?",
+                    isPresented: $model.showingDeleteConfirmation,
+                    titleVisibility: .visible
+                ) {
+                    Button("Delete Locally", role: .destructive, action: model.deleteSelectedMessages)
+                    Button("Cancel", role: .cancel) {}
+                } message: {
+                    Text("This removes the selected messages from this Mac. It does not delete them for other people.")
+                }
+                .alert("Couldn’t Add Attachment", isPresented: Binding(
+                    get: { model.attachmentError != nil },
+                    set: { if !$0 { model.attachmentError = nil } }
+                )) {
+                    Button("OK") { model.attachmentError = nil }
+                } message: {
+                    Text(model.attachmentError ?? "")
+                }
             } else {
                 ContentUnavailableView("Select a conversation", systemImage: "bubble.left.and.bubble.right")
             }
         }
+        .onChange(of: transcriptFocused) { _, focused in
+            model.transcriptFocused = focused
+        }
+        .onChange(of: composerFocused) { _, focused in
+            if focused { model.transcriptFocused = false }
+        }
     }
 
-    private func transcript(chat: NativeChat) -> some View {
+    private var transcript: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                LazyVStack(spacing: 8) {
+                LazyVStack(spacing: model.density.tokens.transcriptGap) {
                     ForEach(model.messages) { message in
-                        MessageRow(message: message)
-                            .id(message.id)
+                        MessageRow(
+                            message: message,
+                            selected: model.selectedMessageIDs.contains(message.id),
+                            density: model.density
+                        ) {
+                            transcriptFocused = true
+                            model.selectMessage(message.id, modifiers: NSApp.currentEvent?.modifierFlags ?? [])
+                        }
+                        .id(message.id)
                     }
                 }
                 .padding(16)
             }
+            .focusable()
+            .focused($transcriptFocused)
+            .focusEffectDisabled()
             .overlay {
                 if model.isLoadingConversation { ProgressView() }
             }
@@ -37,42 +84,87 @@ struct ConversationView: View {
                 guard let lastID else { return }
                 proxy.scrollTo(lastID, anchor: .bottom)
             }
+            .onChange(of: model.selectedMessagesInTranscriptOrder.last?.id) { _, selectedID in
+                guard let selectedID else { return }
+                proxy.scrollTo(selectedID, anchor: .center)
+            }
+            .onChange(of: model.targetMessageID) { _, targetID in
+                guard let targetID else { return }
+                proxy.scrollTo(targetID, anchor: .center)
+                model.targetMessageID = nil
+            }
+            .onKeyPress(.upArrow) {
+                model.moveMessageSelection(by: -1)
+                return .handled
+            }
+            .onKeyPress(.downArrow) {
+                model.moveMessageSelection(by: 1)
+                return .handled
+            }
+            .onKeyPress(.delete) {
+                model.requestDeleteSelectedMessages()
+                return model.selectedMessageIDs.isEmpty ? .ignored : .handled
+            }
+            .onKeyPress(.escape) {
+                model.dismissNearestState()
+                return .handled
+            }
         }
     }
 
     private func composer(chat: NativeChat) -> some View {
-        HStack(alignment: .bottom, spacing: 8) {
-            TextField("Message", text: $model.draft, axis: .vertical)
-                .textFieldStyle(.plain)
-                .lineLimit(1...8)
-                .focused($composerFocused)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
-                .background(.quaternary, in: RoundedRectangle(cornerRadius: 12))
-                .onSubmit(model.sendDraft)
-
-            Button(action: model.sendDraft) {
-                Image(systemName: "arrow.up.circle.fill")
-                    .font(.title2)
+        VStack(spacing: 0) {
+            if !model.pendingAttachments.isEmpty {
+                AttachmentTray(model: model)
+                Divider()
             }
-            .buttonStyle(.plain)
-            .foregroundStyle(
-                model.draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                    ? Color.secondary
-                    : Color.accentColor
-            )
-            .disabled(model.draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || model.isSending || !chat.kind.canSend)
-            .help("Send Message")
-            .accessibilityLabel("Send Message") // [VERIFY] Matches the visible tooltip.
-            .accessibilityInputLabels(["Send Message", "Send"])
+
+            HStack(alignment: .bottom, spacing: 8) {
+                Menu {
+                    Button("Choose Files…", action: model.chooseAttachments)
+                    Button("Paste Files", action: model.stageFilesFromPasteboard)
+                        .keyboardShortcut("v", modifiers: [.command, .option])
+                } label: {
+                    Label("Attachments", systemImage: "paperclip")
+                        .labelStyle(.iconOnly)
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+                .help("Add Attachments")
+                .accessibilityLabel("Attachments") // [VERIFY] Matches the attachment menu action.
+                .accessibilityInputLabels(["Attachments", "Attach Files"])
+
+                TextField("Message", text: $model.draft, axis: .vertical)
+                    .textFieldStyle(.plain)
+                    .lineLimit(1...8)
+                    .focused($composerFocused)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, model.density.tokens.composerPadding)
+                    .background(.quaternary, in: RoundedRectangle(cornerRadius: 12))
+                    .onSubmit(model.sendDraft)
+
+                Button(action: model.sendDraft) {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.title2)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(model.canSendDraft ? Color.accentColor : Color.secondary)
+                .disabled(!model.canSendDraft || !chat.kind.canSend)
+                .help("Send Message")
+                .accessibilityLabel("Send Message") // [VERIFY] Matches the visible tooltip.
+                .accessibilityInputLabels(["Send Message", "Send"])
+            }
+            .padding(12)
         }
-        .padding(12)
         .background(.bar)
     }
 }
 
 private struct MessageRow: View {
     let message: NativeMessage
+    let selected: Bool
+    let density: DesktopChatDensity
+    let select: () -> Void
 
     var body: some View {
         HStack {
@@ -83,8 +175,7 @@ private struct MessageRow: View {
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(.secondary)
                 }
-                Text(message.text)
-                    .textSelection(.enabled)
+                MessageContentView(message: message)
                 if let timestamp = message.timestamp {
                     Text(timestamp, format: .dateTime.hour().minute())
                         .font(.caption2)
@@ -92,13 +183,199 @@ private struct MessageRow: View {
                 }
             }
             .padding(.horizontal, 12)
-            .padding(.vertical, 8)
+            .padding(.vertical, density.tokens.messagePadding)
             .background(
-                message.sent ? AnyShapeStyle(Color.accentColor.opacity(0.16)) : AnyShapeStyle(.quaternary),
+                message.sent ? AnyShapeStyle(Color.accentColor.opacity(0.15)) : AnyShapeStyle(.quaternary),
                 in: RoundedRectangle(cornerRadius: 12)
             )
+            .overlay {
+                if selected {
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(.tint, lineWidth: 2)
+                        .padding(-2)
+                }
+            }
+            .contentShape(RoundedRectangle(cornerRadius: 12))
+            .onTapGesture(perform: select)
             .accessibilityElement(children: .combine)
+            .accessibilityAddTraits(selected ? .isSelected : [])
+            .accessibilityAction(named: selected ? "Deselect Message" : "Select Message", select)
             if !message.sent { Spacer(minLength: 80) }
         }
+    }
+}
+
+private struct AttachmentTray: View {
+    @ObservedObject var model: AppModel
+
+    var body: some View {
+        ScrollView(.horizontal) {
+            HStack(spacing: 8) {
+                ForEach(model.pendingAttachments) { attachment in
+                    AttachmentCard(attachment: attachment) {
+                        model.removeAttachment(attachment.id)
+                    }
+                    .draggable(attachment.id.uuidString)
+                    .dropDestination(for: String.self) { values, _ in
+                        guard let value = values.first, let source = UUID(uuidString: value) else { return false }
+                        model.reorderAttachment(source, before: attachment.id)
+                        return true
+                    }
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+        }
+        .scrollIndicators(.never)
+        .accessibilityLabel("Pending Attachments")
+    }
+}
+
+private struct AttachmentCard: View {
+    let attachment: PendingAttachment
+    let remove: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Group {
+                if let image = NativeChatParser.image(from: attachment.previewImage) {
+                    Image(nsImage: image)
+                        .resizable()
+                        .scaledToFill()
+                        .accessibilityLabel("Preview of \(attachment.fileName)")
+                        .accessibilityIgnoresInvertColors()
+                } else {
+                    Image(systemName: attachment.kind.symbolName)
+                        .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
+                }
+            }
+            .frame(width: 32, height: 32)
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(attachment.fileName)
+                    .lineLimit(1)
+                Text(attachment.byteCount, format: .byteCount(style: .file))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Button(action: remove) {
+                Image(systemName: "xmark.circle.fill")
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .help("Remove \(attachment.fileName)")
+            .accessibilityLabel("Remove \(attachment.fileName)") // [VERIFY] Uses the visible file name.
+            .accessibilityInputLabels(["Remove \(attachment.fileName)", "Remove Attachment"])
+        }
+        .padding(8)
+        .frame(width: 224, alignment: .leading)
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: 10))
+        .accessibilityElement(children: .contain)
+    }
+}
+
+private struct MessageContentView: View {
+    let message: NativeMessage
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            switch message.content {
+            case .text:
+                messageText
+            case .image(let preview, let fileName, _):
+                mediaPreview(preview: preview, fileName: fileName ?? "Image", video: false)
+                if !message.text.isEmpty { messageText }
+            case .video(let preview, let fileName, _):
+                mediaPreview(preview: preview, fileName: fileName ?? "Video", video: true)
+                if !message.text.isEmpty { messageText }
+            case .file(let fileName, _):
+                fileAttachment(name: fileName ?? message.text)
+                if !message.text.isEmpty, message.text != fileName { messageText }
+            }
+        }
+    }
+
+    private var messageText: some View {
+        Text(message.text)
+            .textSelection(.enabled)
+    }
+
+    @ViewBuilder
+    private func mediaPreview(preview: String?, fileName: String, video: Bool) -> some View {
+        let previewView = ZStack {
+            if let image = NativeChatParser.image(from: preview) {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFit()
+                    .accessibilityIgnoresInvertColors()
+            } else {
+                Rectangle()
+                    .fill(.quaternary)
+                    .aspectRatio(4 / 3, contentMode: .fit)
+                    .overlay {
+                        Image(systemName: video ? "film" : "photo")
+                            .font(.title)
+                            .foregroundStyle(.secondary)
+                    }
+            }
+            if video {
+                Image(systemName: "play.circle.fill")
+                    .font(.largeTitle)
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(.white)
+                    .shadow(radius: 4)
+                    .accessibilityHidden(true)
+            }
+        }
+        .frame(maxWidth: 420, maxHeight: 320)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+
+        if let url = message.content.fileURL, FileManager.default.fileExists(atPath: url.path) {
+            Button {
+                NSWorkspace.shared.open(url)
+            } label: {
+                previewView
+            }
+            .buttonStyle(.plain)
+            .help("Open \(fileName)")
+            .accessibilityLabel("Open \(fileName)") // [VERIFY] Uses the attachment file name.
+            .accessibilityInputLabels(["Open \(fileName)", "Open Attachment"])
+        } else {
+            previewView
+                .accessibilityLabel(video ? "Video attachment, \(fileName)" : "Image attachment, \(fileName)")
+        }
+    }
+
+    @ViewBuilder
+    private func fileAttachment(name: String) -> some View {
+        if let url = message.content.fileURL, FileManager.default.fileExists(atPath: url.path) {
+            Button {
+                NSWorkspace.shared.open(url)
+            } label: {
+                Label(name.isEmpty ? "File" : name, systemImage: "doc")
+            }
+            .buttonStyle(.link)
+            .help("Open \(name)")
+        } else {
+            Label(name.isEmpty ? "File" : name, systemImage: "doc")
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+private struct DropTargetOverlay: View {
+    var body: some View {
+        Label("Drop files to attach", systemImage: "tray.and.arrow.down.fill")
+            .font(.headline)
+            .padding(24)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+            .overlay {
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(.tint, style: StrokeStyle(lineWidth: 2, dash: [8, 4]))
+            }
+            .accessibilityAddTraits(.isStaticText)
     }
 }

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -812,11 +812,45 @@ private struct MessageContentView: View {
             case .video(let preview, let fileName):
                 mediaPreview(preview: preview, fileName: fileName ?? "Video", video: true)
                 if !message.text.isEmpty { messageText }
+            case .voice(let fileName, let duration):
+                voiceAttachment(fileName: fileName, duration: duration)
+                if !message.text.isEmpty { messageText }
             case .file(let fileName):
                 fileAttachment(name: fileName ?? message.text)
                 if !message.text.isEmpty, message.text != fileName { messageText }
             }
         }
+    }
+
+    @ViewBuilder
+    private func voiceAttachment(fileName: String?, duration: Int?) -> some View {
+        if attachmentExists {
+            Button(action: openAttachment) {
+                voiceAttachmentLabel(duration: duration)
+            }
+            .buttonStyle(.link)
+            .disabled(openingAttachment)
+            .help("Open \(fileName ?? "voice message")")
+        } else {
+            voiceAttachmentLabel(duration: duration)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func voiceAttachmentLabel(duration: Int?) -> some View {
+        HStack(spacing: 6) {
+            Label("Voice message", systemImage: "waveform")
+            if let duration, duration > 0 {
+                Text(Duration.seconds(Double(duration)), format: .time(pattern: .minuteSecond))
+                    .foregroundStyle(.secondary)
+            }
+            if openingAttachment {
+                ProgressView()
+                    .controlSize(.small)
+                    .accessibilityLabel("Decrypting Voice Message")
+            }
+        }
+        .accessibilityElement(children: .combine)
     }
 
     private var messageText: some View {

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -38,7 +38,9 @@ struct ConversationView: View {
                     isPresented: $model.showingDeleteConfirmation,
                     titleVisibility: .visible
                 ) {
-                    Button("Delete Locally", role: .destructive, action: model.deleteSelectedMessages)
+                    Button("Delete Locally", role: .destructive) {
+                        model.deleteSelectedMessages()
+                    }
                     Button("Cancel", role: .cancel) {}
                 } message: {
                     Text("This removes the selected messages from this Mac. It does not delete them for other people.")

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -273,7 +273,17 @@ struct ConversationView: View {
                                 lineWidth: composerFocused ? 2 : 1
                             )
                     }
-                    .onSubmit(model.sendDraft)
+                    .onKeyPress(.return, phases: .down) { keyPress in
+                        switch ComposerKeyboard.returnAction(
+                            shiftPressed: keyPress.modifiers.contains(.shift)
+                        ) {
+                        case .send:
+                            model.sendDraft()
+                            return .handled
+                        case .insertNewline:
+                            return .ignored
+                        }
+                    }
 
                 Button(action: model.sendDraft) {
                     ZStack {

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -50,6 +50,14 @@ struct ConversationView: View {
                 } message: {
                     Text(model.attachmentError ?? "")
                 }
+                .alert("Couldn’t Open Attachment", isPresented: Binding(
+                    get: { model.attachmentOpenError != nil },
+                    set: { if !$0 { model.attachmentOpenError = nil } }
+                )) {
+                    Button("OK") { model.attachmentOpenError = nil }
+                } message: {
+                    Text(model.attachmentOpenError ?? "")
+                }
             } else {
                 ContentUnavailableView {
                     Label("No Conversation Selected", systemImage: "bubble.left.and.bubble.right")
@@ -63,6 +71,9 @@ struct ConversationView: View {
         }
         .onChange(of: composerFocused) { _, focused in
             if focused { model.transcriptFocused = false }
+        }
+        .onChange(of: model.composerFocusRequest) { _, _ in
+            composerFocused = true
         }
     }
 
@@ -82,7 +93,7 @@ struct ConversationView: View {
                 }
             }
             .accessibilityElement(children: .combine)
-            .accessibilityLabel("Conversation with (chat.displayName)")
+            .accessibilityLabel("Conversation with \(chat.displayName)")
         }
 
         ToolbarItem(placement: .primaryAction) {
@@ -109,7 +120,9 @@ struct ConversationView: View {
                             selected: model.selectedMessageIDs.contains(message.id),
                             density: model.density,
                             startsGroup: startsGroup(at: index),
-                            endsGroup: endsGroup(at: index)
+                            endsGroup: endsGroup(at: index),
+                            openingAttachment: model.openingAttachmentIDs.contains(message.id),
+                            canReply: chat.kind.canReply && !model.isSending
                         ) {
                             transcriptFocused = true
                             model.selectMessage(message.id, modifiers: NSApp.currentEvent?.modifierFlags ?? [])
@@ -121,6 +134,13 @@ struct ConversationView: View {
                             transcriptFocused = true
                             model.selectMessage(message.id, modifiers: [])
                             model.requestDeleteSelectedMessages()
+                        } reply: {
+                            model.beginReply(to: message)
+                            composerFocused = true
+                        } openQuote: { messageID in
+                            model.openQuotedMessage(messageID)
+                        } openAttachment: {
+                            model.openAttachment(message)
                         }
                         .id(message.id)
                     }
@@ -193,6 +213,11 @@ struct ConversationView: View {
 
     private func composer(chat: NativeChat) -> some View {
         VStack(spacing: 0) {
+            if let message = model.replyingTo {
+                ReplyContextBar(message: message, chat: chat, cancel: model.cancelReply)
+                Divider()
+            }
+
             if !model.pendingAttachments.isEmpty {
                 AttachmentTray(model: model)
                 Divider()
@@ -330,9 +355,14 @@ private struct MessageRow: View {
     let density: DesktopChatDensity
     let startsGroup: Bool
     let endsGroup: Bool
+    let openingAttachment: Bool
+    let canReply: Bool
     let select: () -> Void
     let copy: () -> Void
     let delete: () -> Void
+    let reply: () -> Void
+    let openQuote: (Int64) -> Void
+    let openAttachment: () -> Void
 
     var body: some View {
         HStack(alignment: .bottom, spacing: 8) {
@@ -358,7 +388,13 @@ private struct MessageRow: View {
                         .padding(.leading, 8)
                 }
 
-                MessageContentView(message: message)
+                MessageContentView(
+                    message: message,
+                    chatName: chat.displayName,
+                    openingAttachment: openingAttachment,
+                    openQuote: openQuote,
+                    openAttachment: openAttachment
+                )
                     .padding(.horizontal, 12)
                     .padding(.vertical, density.tokens.messagePadding)
                     .background(bubbleBackground, in: bubbleShape)
@@ -383,12 +419,21 @@ private struct MessageRow: View {
             }
             .frame(maxWidth: 520, alignment: message.sent ? .trailing : .leading)
             .accessibilityElement(children: .combine)
-            .accessibilityAddTraits(selected ? .isSelected : [])
-            .accessibilityAction(named: selected ? "Deselect Message" : "Select Message", select)
+            .accessibilityAddTraits(selected ? [.isSelected, .isButton] : .isButton)
+            .accessibilityActions {
+                Button(selected ? "Deselect Message" : "Select Message", action: select)
+                if canReply {
+                    Button("Reply", action: reply)
+                }
+            }
 
             if !message.sent { Spacer(minLength: 80) }
         }
         .contextMenu {
+            if canReply {
+                Button("Reply", action: reply)
+                Divider()
+            }
             Button("Copy", action: copy)
             Button(selected ? "Deselect Message" : "Select Message", action: select)
             if message.deletable {
@@ -439,6 +484,53 @@ private struct TranscriptDateHeader: View {
         if Calendar.current.isDateInToday(date) { return "Today" }
         if Calendar.current.isDateInYesterday(date) { return "Yesterday" }
         return date.formatted(.dateTime.month(.abbreviated).day().year())
+    }
+}
+
+private struct ReplyContextBar: View {
+    let message: NativeMessage
+    let chat: NativeChat
+    let cancel: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Rectangle()
+                .fill(.tint)
+                .frame(width: 4)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Replying to \(sender)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.tint)
+                Text(preview)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .accessibilityElement(children: .combine)
+
+            Spacer(minLength: 8)
+
+            Button(action: cancel) {
+                Image(systemName: "xmark")
+            }
+            .buttonStyle(.borderless)
+            .help("Cancel Reply")
+            .accessibilityLabel("Cancel Reply") // [VERIFY] Matches the visible tooltip.
+            .accessibilityInputLabels(["Cancel Reply", "Cancel"])
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    private var sender: String {
+        message.sent ? "You" : (message.author ?? chat.displayName)
+    }
+
+    private var preview: String {
+        message.text.isEmpty ? (message.content.attachmentDescription ?? "Message") : message.text
     }
 }
 
@@ -545,19 +637,32 @@ private struct AttachmentCard: View {
 
 private struct MessageContentView: View {
     let message: NativeMessage
+    let chatName: String
+    let openingAttachment: Bool
+    let openQuote: (Int64) -> Void
+    let openAttachment: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
+            if let quote = message.quotedItem {
+                QuotedMessagePreview(
+                    quote: quote,
+                    chatName: chatName,
+                    outgoing: message.sent,
+                    open: openQuote
+                )
+            }
+
             switch message.content {
             case .text:
                 messageText
-            case .image(let preview, let fileName, _):
+            case .image(let preview, let fileName):
                 mediaPreview(preview: preview, fileName: fileName ?? "Image", video: false)
                 if !message.text.isEmpty { messageText }
-            case .video(let preview, let fileName, _):
+            case .video(let preview, let fileName):
                 mediaPreview(preview: preview, fileName: fileName ?? "Video", video: true)
                 if !message.text.isEmpty { messageText }
-            case .file(let fileName, _):
+            case .file(let fileName):
                 fileAttachment(name: fileName ?? message.text)
                 if !message.text.isEmpty, message.text != fileName { messageText }
             }
@@ -595,17 +700,21 @@ private struct MessageContentView: View {
                     .shadow(radius: 4)
                     .accessibilityHidden(true)
             }
+            if openingAttachment {
+                ProgressView()
+                    .controlSize(.small)
+                    .accessibilityLabel("Decrypting Attachment")
+            }
         }
         .frame(maxWidth: 420, maxHeight: 320)
         .clipShape(RoundedRectangle(cornerRadius: 8))
 
-        if let url = message.content.fileURL, FileManager.default.fileExists(atPath: url.path) {
-            Button {
-                NSWorkspace.shared.open(url)
-            } label: {
+        if attachmentExists {
+            Button(action: openAttachment) {
                 previewView
             }
             .buttonStyle(.plain)
+            .disabled(openingAttachment)
             .help("Open \(fileName)")
             .accessibilityLabel("Open \(fileName)") // [VERIFY] Uses the attachment file name.
             .accessibilityInputLabels(["Open \(fileName)", "Open Attachment"])
@@ -617,18 +726,71 @@ private struct MessageContentView: View {
 
     @ViewBuilder
     private func fileAttachment(name: String) -> some View {
-        if let url = message.content.fileURL, FileManager.default.fileExists(atPath: url.path) {
-            Button {
-                NSWorkspace.shared.open(url)
-            } label: {
+        if attachmentExists {
+            Button(action: openAttachment) {
                 Label(name.isEmpty ? "File" : name, systemImage: "doc")
+                if openingAttachment {
+                    ProgressView()
+                        .controlSize(.small)
+                        .accessibilityLabel("Decrypting Attachment")
+                }
             }
             .buttonStyle(.link)
+            .disabled(openingAttachment)
             .help("Open \(name)")
         } else {
             Label(name.isEmpty ? "File" : name, systemImage: "doc")
                 .foregroundStyle(.secondary)
         }
+    }
+
+    private var attachmentExists: Bool {
+        guard let source = message.fileSource else { return false }
+        return FileManager.default.fileExists(atPath: source.sourceURL.path)
+    }
+}
+
+private struct QuotedMessagePreview: View {
+    let quote: NativeQuote
+    let chatName: String
+    let outgoing: Bool
+    let open: (Int64) -> Void
+
+    var body: some View {
+        Group {
+            if let messageID = quote.messageID {
+                Button { open(messageID) } label: { content }
+                    .buttonStyle(.plain)
+                    .help("Show Quoted Message")
+                    .accessibilityHint("Moves to the original message in this conversation.")
+            } else {
+                content
+            }
+        }
+    }
+
+    private var content: some View {
+        HStack(spacing: 8) {
+            Rectangle()
+                .fill(outgoing ? Color(nsColor: .selectedControlTextColor) : Color.accentColor)
+                .frame(width: 4)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(sender)
+                    .font(.caption.weight(.semibold))
+                Text(quote.text)
+                    .font(.callout)
+                    .lineLimit(2)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Quoted message from \(sender): \(quote.text)")
+    }
+
+    private var sender: String {
+        quote.author ?? (quote.sent ? "You" : chatName)
     }
 }
 

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -84,13 +84,20 @@ struct ConversationView: View {
             .accessibilityLabel("Conversation with \(chat.displayName)")
         }
 
-        ToolbarItem(placement: .primaryAction) {
-            Button(action: model.refresh) {
-                Image(systemName: "arrow.clockwise")
+        ToolbarItemGroup(placement: .primaryAction) {
+            if model.isViewingConversationHistory {
+                Button("Jump to Latest", systemImage: "arrow.down.to.line") {
+                    model.jumpToLatest()
+                }
+                .labelStyle(.iconOnly)
+                .help("Jump to Latest")
+                .accessibilityInputLabels(["Jump to Latest", "Latest Messages"])
             }
-            .help("Refresh Conversation")
-            .accessibilityLabel("Refresh Conversation") // [VERIFY] Matches the visible tooltip.
-            .accessibilityInputLabels(["Refresh Conversation", "Refresh"])
+
+            Button("Refresh Conversation", systemImage: "arrow.clockwise", action: model.refresh)
+                .labelStyle(.iconOnly)
+                .help("Refresh Conversation")
+                .accessibilityInputLabels(["Refresh Conversation", "Refresh"])
         }
     }
 

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -382,6 +382,11 @@ private struct ConversationAlertsModifier: ViewModifier {
             } message: {
                 Text(model.replyContextError ?? "")
             }
+            .alert("Message Sent", isPresented: sendStatusPresented) {
+                Button("OK") { model.sendStatusMessage = nil }
+            } message: {
+                Text(model.sendStatusMessage ?? "")
+            }
     }
 
     private var attachmentErrorPresented: Binding<Bool> {
@@ -409,6 +414,13 @@ private struct ConversationAlertsModifier: ViewModifier {
         Binding(
             get: { model.replyContextError != nil },
             set: { if !$0 { model.replyContextError = nil } }
+        )
+    }
+
+    private var sendStatusPresented: Binding<Bool> {
+        Binding(
+            get: { model.sendStatusMessage != nil },
+            set: { if !$0 { model.sendStatusMessage = nil } }
         )
     }
 }

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -152,8 +152,18 @@ struct ConversationView: View {
             .focused($transcriptFocused)
             .focusEffectDisabled()
             .overlay {
-                if model.isLoadingConversation { ProgressView() }
+                ZStack {
+                    if transcriptFocused {
+                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            .stroke(Color.accentColor.opacity(0.8), lineWidth: 2)
+                            .padding(2)
+                            .allowsHitTesting(false)
+                    }
+                    if model.isLoadingConversation { ProgressView() }
+                }
             }
+            .accessibilityLabel("Conversation transcript") // [VERIFY] Names the keyboard-focusable transcript region.
+            .accessibilityHint("Use the arrow keys to select messages. Press Return to reply to the selected message.") // [VERIFY] Describes the transcript keyboard actions.
             .onChange(of: model.messages.last?.id) { _, lastID in
                 guard let lastID, model.targetMessageID == nil else { return }
                 proxy.scrollTo(lastID, anchor: .bottom)
@@ -173,6 +183,11 @@ struct ConversationView: View {
             }
             .onKeyPress(.downArrow) {
                 model.moveMessageSelection(by: 1)
+                return .handled
+            }
+            .onKeyPress(.return) {
+                guard model.replyToSelectedMessage() else { return .ignored }
+                composerFocused = true
                 return .handled
             }
             .onKeyPress(.delete) {
@@ -216,7 +231,7 @@ struct ConversationView: View {
                     count: model.selectedMessageIDs.count,
                     canReply: model.canReplyToSelectedMessage,
                     canDelete: model.canDeleteSelectedMessages,
-                    reply: model.replyToSelectedMessage,
+                    reply: { model.replyToSelectedMessage() },
                     copy: model.copySelectedMessages,
                     delete: model.requestDeleteSelectedMessages,
                     clear: model.clearMessageSelection
@@ -553,7 +568,7 @@ private struct MessageRow: View {
                         }
                     }
                     .overlay(alignment: message.sent ? .leading : .trailing) {
-                        if hovering, canReply {
+                        if (hovering || selected) && canReply {
                             Button(action: reply) {
                                 Image(systemName: "arrowshape.turn.up.left")
                                     .frame(width: 28, height: 28)
@@ -561,10 +576,11 @@ private struct MessageRow: View {
                                     .overlay {
                                         Circle().stroke(Color(nsColor: .separatorColor))
                                     }
-                                    .contentShape(Circle())
                             }
+                            .frame(width: 44, height: 44)
+                            .contentShape(Rectangle())
                             .buttonStyle(.plain)
-                            .offset(x: message.sent ? -40 : 40)
+                            .offset(x: message.sent ? -46 : 46)
                             .help("Reply")
                             .accessibilityLabel("Reply") // [VERIFY] Matches the visible tooltip.
                             .accessibilityInputLabels(["Reply", "Quote Message"])

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -147,7 +147,7 @@ struct ConversationView: View {
                 if model.isLoadingConversation { ProgressView() }
             }
             .onChange(of: model.messages.last?.id) { _, lastID in
-                guard let lastID else { return }
+                guard let lastID, model.targetMessageID == nil else { return }
                 proxy.scrollTo(lastID, anchor: .bottom)
             }
             .onChange(of: model.selectedMessagesInTranscriptOrder.last?.id) { _, selectedID in

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -110,9 +110,7 @@ struct ConversationView: View {
                             startsGroup: startsGroup(at: index),
                             endsGroup: endsGroup(at: index),
                             openingAttachment: model.openingAttachmentIDs.contains(message.id),
-                            canReply: chat.kind.canReply
-                                && message.replyable
-                                && !model.isSendingSelectedChat
+                            canReply: model.canReply(to: message)
                         ) {
                             transcriptFocused = true
                             model.selectMessage(message.id, modifiers: NSApp.currentEvent?.modifierFlags ?? [])
@@ -221,6 +219,7 @@ struct ConversationView: View {
                     message: message,
                     chat: chat,
                     canCancel: !model.isSendingSelectedChat,
+                    open: { model.openReplyTarget() },
                     cancel: model.cancelReply
                 )
                 Divider()
@@ -622,25 +621,35 @@ private struct ReplyContextBar: View {
     let message: NativeMessage
     let chat: NativeChat
     let canCancel: Bool
+    let open: () -> Void
     let cancel: () -> Void
 
     var body: some View {
         HStack(spacing: 8) {
-            Rectangle()
-                .fill(.tint)
-                .frame(width: 4)
-                .accessibilityHidden(true)
+            Button(action: open) {
+                HStack(spacing: 8) {
+                    Rectangle()
+                        .fill(.tint)
+                        .frame(width: 4)
+                        .accessibilityHidden(true)
 
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Replying to \(sender)")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.tint)
-                Text(preview)
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Replying to \(sender)")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.tint)
+                        Text(preview)
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
             }
-            .accessibilityElement(children: .combine)
+            .buttonStyle(.plain)
+            .help("Show Original Message")
+            .accessibilityHint("Moves to the message being replied to in this conversation.")
+            .accessibilityInputLabels(["Replying to \(sender)", "Show Original Message"]) // [VERIFY] The first label matches visible text.
 
             Spacer(minLength: 8)
 

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -45,21 +45,20 @@ struct ConversationView: View {
                 } message: {
                     Text("This removes the selected messages from this Mac. It does not delete them for other people.")
                 }
-                .alert("Couldn’t Add Attachment", isPresented: Binding(
-                    get: { model.attachmentError != nil },
-                    set: { if !$0 { model.attachmentError = nil } }
-                )) {
+                .alert("Couldn’t Add Attachment", isPresented: attachmentErrorPresented) {
                     Button("OK") { model.attachmentError = nil }
                 } message: {
                     Text(model.attachmentError ?? "")
                 }
-                .alert("Couldn’t Open Attachment", isPresented: Binding(
-                    get: { model.attachmentOpenError != nil },
-                    set: { if !$0 { model.attachmentOpenError = nil } }
-                )) {
+                .alert("Couldn’t Open Attachment", isPresented: attachmentOpenErrorPresented) {
                     Button("OK") { model.attachmentOpenError = nil }
                 } message: {
                     Text(model.attachmentOpenError ?? "")
+                }
+                .alert("Couldn’t Find Quoted Message", isPresented: quoteNavigationErrorPresented) {
+                    Button("OK") { model.quoteNavigationError = nil }
+                } message: {
+                    Text(model.quoteNavigationError ?? "")
                 }
             } else {
                 ContentUnavailableView {
@@ -78,6 +77,27 @@ struct ConversationView: View {
         .onChange(of: model.composerFocusRequest) { _, _ in
             composerFocused = true
         }
+    }
+
+    private var attachmentErrorPresented: Binding<Bool> {
+        Binding(
+            get: { model.attachmentError != nil },
+            set: { if !$0 { model.attachmentError = nil } }
+        )
+    }
+
+    private var attachmentOpenErrorPresented: Binding<Bool> {
+        Binding(
+            get: { model.attachmentOpenError != nil },
+            set: { if !$0 { model.attachmentOpenError = nil } }
+        )
+    }
+
+    private var quoteNavigationErrorPresented: Binding<Bool> {
+        Binding(
+            get: { model.quoteNavigationError != nil },
+            set: { if !$0 { model.quoteNavigationError = nil } }
+        )
     }
 
     @ToolbarContentBuilder
@@ -140,8 +160,8 @@ struct ConversationView: View {
                         } reply: {
                             model.beginReply(to: message)
                             composerFocused = true
-                        } openQuote: { messageID in
-                            model.openQuotedMessage(messageID)
+                        } openQuote: { quote in
+                            model.openQuotedMessage(quote, from: message.id)
                         } openAttachment: {
                             model.openAttachment(message)
                         }
@@ -429,7 +449,7 @@ private struct MessageRow: View {
     let copy: () -> Void
     let delete: () -> Void
     let reply: () -> Void
-    let openQuote: (Int64) -> Void
+    let openQuote: (NativeQuote) -> Void
     let openAttachment: () -> Void
 
     var body: some View {
@@ -508,6 +528,9 @@ private struct MessageRow: View {
             .accessibilityAddTraits(selected ? [.isSelected, .isButton] : .isButton)
             .accessibilityActions {
                 Button(selected ? "Deselect Message" : "Select Message", action: select)
+                if let quote = message.quotedItem {
+                    Button("Show Quoted Message") { openQuote(quote) }
+                }
                 if canReply {
                     Button("Reply", action: reply)
                 }
@@ -729,7 +752,7 @@ private struct MessageContentView: View {
     let message: NativeMessage
     let chatName: String
     let openingAttachment: Bool
-    let openQuote: (Int64) -> Void
+    let openQuote: (NativeQuote) -> Void
     let openAttachment: () -> Void
 
     var body: some View {
@@ -739,7 +762,7 @@ private struct MessageContentView: View {
                     quote: quote,
                     chatName: chatName,
                     outgoing: message.sent,
-                    open: openQuote
+                    open: { openQuote(quote) }
                 )
             }
 
@@ -844,19 +867,14 @@ private struct QuotedMessagePreview: View {
     let quote: NativeQuote
     let chatName: String
     let outgoing: Bool
-    let open: (Int64) -> Void
+    let open: () -> Void
 
     var body: some View {
-        Group {
-            if let messageID = quote.messageID {
-                Button { open(messageID) } label: { content }
-                    .buttonStyle(.plain)
-                    .help("Show Quoted Message")
-                    .accessibilityHint("Moves to the original message in this conversation.")
-            } else {
-                content
-            }
-        }
+        Button(action: open) { content }
+            .buttonStyle(.plain)
+            .help("Show Quoted Message")
+            .accessibilityHint("Moves to the original message in this conversation.")
+            .accessibilityInputLabels([quote.text, "Quoted Message"]) // [VERIFY] The first label matches visible quote text.
     }
 
     private var content: some View {

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -23,6 +23,7 @@ struct ConversationView: View {
                 .navigationTitle("")
                 .toolbar { conversationToolbar(chat: chat) }
                 .dropDestination(for: URL.self) { urls, _ in
+                    guard !model.isSending else { return false }
                     model.stageAttachments(urls)
                     composerFocused = true
                     return !urls.isEmpty
@@ -235,6 +236,7 @@ struct ConversationView: View {
                 }
                 .menuStyle(.borderlessButton)
                 .fixedSize()
+                .disabled(model.isSending)
                 .help("Add Attachments")
                 .accessibilityLabel("Attachments") // [VERIFY] Matches the attachment menu action.
                 .accessibilityInputLabels(["Attachments", "Attach Files"])
@@ -588,6 +590,7 @@ private struct AttachmentTray: View {
                         }
                         Button("Remove Attachment") { model.removeAttachment(attachment.id) }
                     }
+                    .disabled(model.isSending)
                 }
             }
             .padding(.horizontal, 12)

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -548,48 +548,13 @@ private struct MessageRow: View {
                         .padding(.leading, 8)
                 }
 
-                MessageContentView(
-                    message: message,
-                    chat: chat,
-                    openingAttachment: openingAttachment,
-                    canOpenQuote: canOpenQuote,
-                    openQuote: openQuote,
-                    openAttachment: openAttachment
-                )
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, density.tokens.messagePadding)
-                    .background(bubbleBackground, in: bubbleShape)
-                    .foregroundStyle(message.sent ? Color(nsColor: .selectedControlTextColor) : Color.primary)
-                    .overlay {
-                        if selected {
-                            bubbleShape
-                                .stroke(Color.accentColor, lineWidth: 2)
-                                .padding(-2)
-                        }
-                    }
-                    .overlay(alignment: message.sent ? .leading : .trailing) {
-                        if (hovering || selected) && canReply {
-                            Button(action: reply) {
-                                Image(systemName: "arrowshape.turn.up.left")
-                                    .frame(width: 28, height: 28)
-                                    .background(Color(nsColor: .controlBackgroundColor), in: Circle())
-                                    .overlay {
-                                        Circle().stroke(Color(nsColor: .separatorColor))
-                                    }
-                            }
-                            .frame(width: 44, height: 44)
-                            .contentShape(Rectangle())
-                            .buttonStyle(.plain)
-                            .offset(x: message.sent ? -46 : 46)
-                            .help("Reply")
-                            .accessibilityLabel("Reply") // [VERIFY] Matches the visible tooltip.
-                            .accessibilityInputLabels(["Reply", "Quote Message"])
-                            .accessibilityIdentifier("message.\(message.id).reply")
-                        }
-                    }
-                    .contentShape(bubbleShape)
-                    .onTapGesture(perform: select)
-                    .focusEffectDisabled()
+                HStack(alignment: .center, spacing: 4) {
+                    if message.sent, canReply { replyControlSlot }
+                    messageBubble
+                    if !message.sent, canReply { replyControlSlot }
+                }
+                .contentShape(Rectangle())
+                .onHover { hovering = $0 }
 
                 if endsGroup, let timestamp = message.timestamp {
                     Text(timestamp, format: .dateTime.hour().minute())
@@ -598,7 +563,7 @@ private struct MessageRow: View {
                         .padding(.horizontal, 8)
                 }
             }
-            .frame(maxWidth: 520, alignment: message.sent ? .trailing : .leading)
+            .frame(maxWidth: 568, alignment: message.sent ? .trailing : .leading)
             .accessibilityElement(children: .combine)
             .accessibilityAddTraits(selected ? [.isSelected, .isButton] : .isButton)
             .accessibilityActions {
@@ -613,7 +578,6 @@ private struct MessageRow: View {
 
             if !message.sent { Spacer(minLength: 80) }
         }
-        .onHover { hovering = $0 }
         .contextMenu {
             if canReply {
                 Button("Reply", action: reply)
@@ -627,6 +591,60 @@ private struct MessageRow: View {
             }
         }
         .accessibilityIdentifier("message.\(message.id)")
+    }
+
+    private var messageBubble: some View {
+        MessageContentView(
+            message: message,
+            chat: chat,
+            openingAttachment: openingAttachment,
+            canOpenQuote: canOpenQuote,
+            openQuote: openQuote,
+            openAttachment: openAttachment
+        )
+        .padding(.horizontal, 12)
+        .padding(.vertical, density.tokens.messagePadding)
+        .background(bubbleBackground, in: bubbleShape)
+        .foregroundStyle(message.sent ? Color(nsColor: .selectedControlTextColor) : Color.primary)
+        .overlay {
+            if selected {
+                bubbleShape
+                    .stroke(Color.accentColor, lineWidth: 2)
+                    .padding(-2)
+            }
+        }
+        .contentShape(bubbleShape)
+        .onTapGesture(perform: select)
+        .focusEffectDisabled()
+    }
+
+    @ViewBuilder
+    private var replyControlSlot: some View {
+        if MessageReplyControlVisibility.isVisible(
+            canReply: canReply,
+            hovering: hovering,
+            selected: selected
+        ) {
+            Button(action: reply) {
+                Image(systemName: "arrowshape.turn.up.left")
+                    .frame(width: 28, height: 28)
+                    .background(Color(nsColor: .controlBackgroundColor), in: Circle())
+                    .overlay {
+                        Circle().stroke(Color(nsColor: .separatorColor))
+                    }
+            }
+            .frame(width: 44, height: 44)
+            .contentShape(Rectangle())
+            .buttonStyle(.plain)
+            .help("Reply")
+            .accessibilityLabel("Reply") // [VERIFY] Matches the visible tooltip.
+            .accessibilityInputLabels(["Reply", "Quote Message"])
+            .accessibilityIdentifier("message.\(message.id).reply")
+        } else {
+            Color.clear
+                .frame(width: 44, height: 44)
+                .accessibilityHidden(true)
+        }
     }
 
     private var bubbleBackground: Color {

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -214,6 +214,21 @@ struct ConversationView: View {
 
     private func composer(chat: NativeChat) -> some View {
         VStack(spacing: 0) {
+            if !model.selectedMessageIDs.isEmpty {
+                MessageSelectionBar(
+                    count: model.selectedMessageIDs.count,
+                    canReply: model.selectedMessagesInTranscriptOrder.count == 1
+                        && chat.kind.canReply
+                        && !model.isSending,
+                    canDelete: model.canDeleteSelectedMessages,
+                    reply: model.replyToSelectedMessage,
+                    copy: model.copySelectedMessages,
+                    delete: model.requestDeleteSelectedMessages,
+                    clear: model.clearMessageSelection
+                )
+                Divider()
+            }
+
             if let message = model.replyingTo {
                 ReplyContextBar(message: message, chat: chat, cancel: model.cancelReply)
                 Divider()
@@ -282,6 +297,48 @@ struct ConversationView: View {
             .padding(12)
         }
         .background(Color(nsColor: .windowBackgroundColor))
+    }
+}
+
+private struct MessageSelectionBar: View {
+    let count: Int
+    let canReply: Bool
+    let canDelete: Bool
+    let reply: () -> Void
+    let copy: () -> Void
+    let delete: () -> Void
+    let clear: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text("\(count) selected")
+                .font(.callout.weight(.medium))
+
+            Spacer(minLength: 8)
+
+            if canReply {
+                Button(action: reply) {
+                    Label("Reply", systemImage: "arrowshape.turn.up.left")
+                }
+            }
+
+            Button(action: copy) {
+                Label("Copy", systemImage: "doc.on.doc")
+            }
+
+            Button(role: .destructive, action: delete) {
+                Label("Delete", systemImage: "trash")
+            }
+            .disabled(!canDelete)
+
+            Button("Done", action: clear)
+        }
+        .buttonStyle(.borderless)
+        .controlSize(.small)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .accessibilityElement(children: .contain)
     }
 }
 

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -1,4 +1,5 @@
 import AppKit
+import QuickLook
 import SwiftUI
 
 struct ConversationView: View {
@@ -63,6 +64,7 @@ struct ConversationView: View {
         .onChange(of: model.composerFocusRequest) { _, _ in
             composerFocused = true
         }
+        .quickLookPreview($model.quickLookURL)
     }
 
     @ToolbarContentBuilder

--- a/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/ConversationView.swift
@@ -935,6 +935,12 @@ private struct MessageContentView: View {
             switch message.content {
             case .text:
                 messageText
+            case .link(let preview):
+                linkPreview(preview)
+                if message.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                    != preview.uri.trimmingCharacters(in: .whitespacesAndNewlines) {
+                    messageText
+                }
             case .image(let preview, let fileName):
                 mediaPreview(preview: preview, fileName: fileName ?? "Image", video: false)
                 if !message.text.isEmpty { messageText }
@@ -984,6 +990,69 @@ private struct MessageContentView: View {
 
     private var messageText: some View {
         MessageBodyText(text: message.text)
+    }
+
+    @ViewBuilder
+    private func linkPreview(_ preview: NativeLinkPreview) -> some View {
+        if let destination = preview.destination {
+            Link(destination: destination) {
+                linkPreviewContent(preview)
+            }
+            .buttonStyle(.plain)
+            .help("Open \(preview.uri)")
+            .accessibilityHint("Opens in your default browser")
+        } else {
+            linkPreviewContent(preview)
+        }
+    }
+
+    private func linkPreviewContent(_ preview: NativeLinkPreview) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let image = NativeChatParser.image(from: preview.image) {
+                ZStack(alignment: .bottomTrailing) {
+                    Image(nsImage: image)
+                        .resizable()
+                        .scaledToFit()
+                        .accessibilityHidden(true)
+                        .accessibilityIgnoresInvertColors()
+
+                    if let duration = preview.durationLabel {
+                        Text(duration)
+                            .font(.caption.monospacedDigit())
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(.black.opacity(0.72), in: Capsule())
+                            .foregroundStyle(.white)
+                            .padding(8)
+                    }
+                }
+                .frame(maxWidth: 420, maxHeight: 236)
+                .clipped()
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                if !preview.title.isEmpty {
+                    Text(preview.title)
+                        .font(.headline)
+                        .lineLimit(2)
+                }
+                if !preview.description.isEmpty {
+                    Text(preview.description)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(3)
+                }
+                Text(preview.displayHost)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .padding(12)
+        }
+        .frame(maxWidth: 420, alignment: .leading)
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: 10))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .accessibilityElement(children: .combine)
     }
 
     @ViewBuilder
@@ -1066,10 +1135,21 @@ struct MessageBodyText: View {
     let text: String
 
     var body: some View {
-        Text(text)
-            .lineLimit(nil)
-            .fixedSize(horizontal: false, vertical: true)
-            .textSelection(.enabled)
+        Group {
+            if let destination = NativeMessageLink.standaloneURL(in: text) {
+                Link(destination: destination) {
+                    Text(text)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.tint)
+                .help("Open \(destination.absoluteString)")
+            } else {
+                Text(text)
+            }
+        }
+        .lineLimit(nil)
+        .fixedSize(horizontal: false, vertical: true)
+        .textSelection(.enabled)
     }
 }
 

--- a/apps/macos-native/Sources/SimpleXNative/UI/InlineAudioPlayer.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/InlineAudioPlayer.swift
@@ -1,0 +1,197 @@
+import AVFoundation
+import AppKit
+import SwiftUI
+
+struct InlineAudioPlayer: View {
+    @StateObject private var controller: InlineAudioPlayerController
+
+    let title: String
+    let fallbackDuration: Int?
+    let close: () -> Void
+
+    init(url: URL, title: String, fallbackDuration: Int?, close: @escaping () -> Void) {
+        _controller = StateObject(wrappedValue: InlineAudioPlayerController(url: url))
+        self.title = title
+        self.fallbackDuration = fallbackDuration
+        self.close = close
+    }
+
+    var body: some View {
+        Group {
+            if let errorMessage = controller.errorMessage {
+                HStack(spacing: 12) {
+                    Label(errorMessage, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.secondary)
+                    Spacer(minLength: 0)
+                    openExternallyButton
+                    closeButton
+                }
+            } else {
+                TimelineView(.periodic(from: .now, by: 0.25)) { _ in
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack(spacing: 8) {
+                            playPauseButton
+                            Image(systemName: "waveform")
+                                .foregroundStyle(.secondary)
+                                .accessibilityHidden(true)
+                            Text(title)
+                                .font(.callout.weight(.medium))
+                                .lineLimit(1)
+                            Spacer(minLength: 8)
+                            openExternallyButton
+                            closeButton
+                        }
+
+                        Slider(value: playbackPosition, in: 0...maximumDuration) {
+                            Text("Playback Position")
+                        }
+                        .accessibilityValue("\(elapsedLabel) of \(durationLabel)")
+                        .accessibilityInputLabels(["Playback Position", "Seek"])
+
+                        HStack {
+                            Text(elapsedLabel)
+                            Spacer(minLength: 8)
+                            Text(durationLabel)
+                        }
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .frame(minWidth: 280, idealWidth: 360, maxWidth: 400)
+        .accessibilityElement(children: .contain)
+        .onAppear { controller.play() }
+        .onDisappear { controller.stop() }
+    }
+
+    private var playPauseButton: some View {
+        Button(action: controller.togglePlayback) {
+            Image(systemName: controller.isPlaying ? "pause.fill" : "play.fill")
+                .frame(width: 20, height: 20)
+        }
+        .buttonStyle(.borderless)
+        .frame(width: 44, height: 44)
+        .contentShape(Rectangle())
+        .help(controller.isPlaying ? "Pause" : "Play")
+        .accessibilityLabel(controller.isPlaying ? "Pause" : "Play") // [VERIFY] Matches the visible playback state.
+        .accessibilityInputLabels(controller.isPlaying ? ["Pause"] : ["Play"])
+    }
+
+    private var openExternallyButton: some View {
+        Button(action: controller.openExternally) {
+            Image(systemName: "arrow.up.forward.square")
+                .frame(width: 20, height: 20)
+        }
+        .buttonStyle(.borderless)
+        .frame(width: 44, height: 44)
+        .contentShape(Rectangle())
+        .help("Open Externally")
+        .accessibilityLabel("Open Externally") // [VERIFY] Matches the visible tooltip.
+        .accessibilityInputLabels(["Open Externally", "Open Audio"])
+    }
+
+    private var closeButton: some View {
+        Button(action: close) {
+            Image(systemName: "xmark")
+                .frame(width: 20, height: 20)
+        }
+        .buttonStyle(.borderless)
+        .frame(width: 44, height: 44)
+        .contentShape(Rectangle())
+        .help("Close Player")
+        .accessibilityLabel("Close Player") // [VERIFY] Matches the visible tooltip.
+        .accessibilityInputLabels(["Close Player", "Close Audio"])
+    }
+
+    private var playbackPosition: Binding<Double> {
+        Binding(
+            get: { min(controller.currentTime, maximumDuration) },
+            set: { value in controller.seek(to: value) }
+        )
+    }
+
+    private var maximumDuration: Double {
+        max(controller.duration, Double(fallbackDuration ?? 0), 1)
+    }
+
+    private var elapsedLabel: String {
+        AudioPlaybackTime.label(controller.currentTime)
+    }
+
+    private var durationLabel: String {
+        AudioPlaybackTime.label(max(controller.duration, Double(fallbackDuration ?? 0)))
+    }
+}
+
+@MainActor
+final class InlineAudioPlayerController: NSObject, ObservableObject, AVAudioPlayerDelegate {
+    @Published private(set) var isPlaying = false
+    @Published private(set) var errorMessage: String?
+
+    private let url: URL
+    private var player: AVAudioPlayer?
+
+    init(url: URL) {
+        self.url = url
+        do {
+            player = try AVAudioPlayer(contentsOf: url)
+        } catch {
+            player = nil
+            errorMessage = "This audio could not be played inline."
+        }
+        super.init()
+        player?.delegate = self
+        player?.prepareToPlay()
+    }
+
+    var currentTime: Double {
+        player?.currentTime ?? 0
+    }
+
+    var duration: Double {
+        player?.duration ?? 0
+    }
+
+    func play() {
+        guard let player else { return }
+        if player.currentTime >= player.duration { player.currentTime = 0 }
+        isPlaying = player.play()
+    }
+
+    func togglePlayback() {
+        isPlaying ? pause() : play()
+    }
+
+    func pause() {
+        player?.pause()
+        isPlaying = false
+    }
+
+    func stop() {
+        player?.stop()
+        isPlaying = false
+    }
+
+    func seek(to time: Double) {
+        player?.currentTime = min(max(time, 0), duration)
+    }
+
+    func openExternally() {
+        pause()
+        NSWorkspace.shared.open(url)
+    }
+
+    nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        Task { @MainActor [weak self] in
+            self?.isPlaying = false
+        }
+    }
+}
+
+enum AudioPlaybackTime {
+    static func label(_ seconds: Double) -> String {
+        let normalized = seconds.isFinite ? max(seconds, 0) : 0
+        return Duration.seconds(normalized).formatted(.time(pattern: .minuteSecond))
+    }
+}

--- a/apps/macos-native/Sources/SimpleXNative/UI/InlineAudioPlayer.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/InlineAudioPlayer.swift
@@ -61,8 +61,8 @@ struct InlineAudioPlayer: View {
         }
         .frame(minWidth: 280, idealWidth: 360, maxWidth: 400)
         .accessibilityElement(children: .contain)
-        .onAppear { controller.play() }
-        .onDisappear { controller.stop() }
+        .onAppear { controller.autoplayIfNeeded() }
+        .onDisappear { controller.pause() }
     }
 
     private var playPauseButton: some View {
@@ -131,6 +131,7 @@ final class InlineAudioPlayerController: NSObject, ObservableObject, AVAudioPlay
 
     private let url: URL
     private var player: AVAudioPlayer?
+    private var autoplayPolicy = AudioAutoplayPolicy()
 
     init(url: URL) {
         self.url = url
@@ -157,6 +158,11 @@ final class InlineAudioPlayerController: NSObject, ObservableObject, AVAudioPlay
         guard let player else { return }
         if player.currentTime >= player.duration { player.currentTime = 0 }
         isPlaying = player.play()
+    }
+
+    func autoplayIfNeeded() {
+        guard autoplayPolicy.shouldAutoplayOnAppear() else { return }
+        play()
     }
 
     func togglePlayback() {
@@ -193,5 +199,15 @@ enum AudioPlaybackTime {
     static func label(_ seconds: Double) -> String {
         let normalized = seconds.isFinite ? max(seconds, 0) : 0
         return Duration.seconds(normalized).formatted(.time(pattern: .minuteSecond))
+    }
+}
+
+struct AudioAutoplayPolicy {
+    private(set) var consumedInitialRequest = false
+
+    mutating func shouldAutoplayOnAppear() -> Bool {
+        guard !consumedInitialRequest else { return false }
+        consumedInitialRequest = true
+        return true
     }
 }

--- a/apps/macos-native/Sources/SimpleXNative/UI/InlineVideoPlayer.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/InlineVideoPlayer.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import WebKit
+
+struct InlineVideoPlayer: NSViewRepresentable {
+    let url: URL
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeNSView(context: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.allowsAirPlayForMediaPlayback = true
+        configuration.mediaTypesRequiringUserActionForPlayback = []
+
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.allowsBackForwardNavigationGestures = false
+        load(url, in: webView, coordinator: context.coordinator)
+        return webView
+    }
+
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        guard context.coordinator.loadedURL != url else { return }
+        load(url, in: webView, coordinator: context.coordinator)
+    }
+
+    static func dismantleNSView(_ webView: WKWebView, coordinator: Coordinator) {
+        webView.stopLoading()
+        webView.loadHTMLString("", baseURL: nil)
+        coordinator.loadedURL = nil
+    }
+
+    private func load(_ url: URL, in webView: WKWebView, coordinator: Coordinator) {
+        coordinator.loadedURL = url
+        webView.load(URLRequest(url: url, cachePolicy: .returnCacheDataElseLoad, timeoutInterval: 30))
+    }
+
+    final class Coordinator {
+        var loadedURL: URL?
+    }
+}

--- a/apps/macos-native/Sources/SimpleXNative/UI/RootView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/RootView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct RootView: View {
+    @ObservedObject var model: AppModel
+    @State private var columnVisibility: NavigationSplitViewVisibility = .all
+
+    var body: some View {
+        Group {
+            switch model.phase {
+            case .locked, .opening:
+                UnlockView(model: model)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(.background)
+            case .ready, .failed:
+                NavigationSplitView(columnVisibility: $columnVisibility) {
+                    SidebarView(model: model)
+                        .navigationSplitViewColumnWidth(min: 240, ideal: 320, max: 480)
+                } detail: {
+                    ConversationView(model: model)
+                }
+                .alert("SimpleX", isPresented: Binding(
+                    get: { if case .failed = model.phase { true } else { false } },
+                    set: { if !$0 { model.phase = .ready } }
+                )) {
+                    Button("OK") { model.phase = .ready }
+                } message: {
+                    if case let .failed(message) = model.phase { Text(message) }
+                }
+            }
+        }
+    }
+}

--- a/apps/macos-native/Sources/SimpleXNative/UI/RootView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/RootView.swift
@@ -25,6 +25,7 @@ struct RootView: View {
                         .navigationSplitViewColumnWidth(min: 240, ideal: 320, max: 480)
                 } detail: {
                     ConversationView(model: model)
+                        .navigationSplitViewColumnWidth(min: 520, ideal: 800)
                 }
                 .alert("SimpleX", isPresented: Binding(
                     get: { if case .failed = model.phase { true } else { false } },

--- a/apps/macos-native/Sources/SimpleXNative/UI/RootView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/RootView.swift
@@ -2,7 +2,15 @@ import SwiftUI
 
 struct RootView: View {
     @ObservedObject var model: AppModel
-    @State private var columnVisibility: NavigationSplitViewVisibility = .all
+    @ObservedObject var notifications: NativeNotificationManager
+    @AppStorage("desktopSidebarCollapsed") private var sidebarCollapsed = false
+
+    private var columnVisibility: Binding<NavigationSplitViewVisibility> {
+        Binding(
+            get: { sidebarCollapsed ? .detailOnly : .all },
+            set: { sidebarCollapsed = $0 == .detailOnly }
+        )
+    }
 
     var body: some View {
         Group {
@@ -12,7 +20,7 @@ struct RootView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(.background)
             case .ready, .failed:
-                NavigationSplitView(columnVisibility: $columnVisibility) {
+                NavigationSplitView(columnVisibility: columnVisibility) {
                     SidebarView(model: model)
                         .navigationSplitViewColumnWidth(min: 240, ideal: 320, max: 480)
                 } detail: {
@@ -27,6 +35,16 @@ struct RootView: View {
                     if case let .failed(message) = model.phase { Text(message) }
                 }
             }
+        }
+        .alert("Stay Updated?", isPresented: $notifications.showingPermissionExplanation) {
+            Button("Allow Notifications") {
+                notifications.respondToPermissionExplanation(requestPermission: true)
+            }
+            Button("Not Now", role: .cancel) {
+                notifications.respondToPermissionExplanation(requestPermission: false)
+            }
+        } message: {
+            Text("SimpleX can use native Mac notifications for messages, contact requests, and calls. You can choose how much message detail appears in Settings.")
         }
     }
 }

--- a/apps/macos-native/Sources/SimpleXNative/UI/SidebarView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/SidebarView.swift
@@ -9,7 +9,7 @@ struct SidebarView: View {
             set: model.selectChat
         )) {
             ForEach(model.filteredChats) { chat in
-                ChatSidebarRow(chat: chat)
+                ChatSidebarRow(chat: chat, density: model.density)
                     .tag(chat.id)
             }
         }
@@ -28,10 +28,11 @@ struct SidebarView: View {
 
 private struct ChatSidebarRow: View {
     let chat: NativeChat
+    let density: DesktopChatDensity
 
     var body: some View {
         HStack(spacing: 12) {
-            ProfileAvatar(image: chat.image, name: chat.displayName, size: 40)
+            ProfileAvatar(image: chat.image, name: chat.displayName, size: density.tokens.avatarSize)
                 .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 4) {
@@ -63,7 +64,7 @@ private struct ChatSidebarRow: View {
                 }
             }
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, density.tokens.chatRowPadding)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(chat.accessibilityDescription)
     }

--- a/apps/macos-native/Sources/SimpleXNative/UI/SidebarView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/SidebarView.swift
@@ -14,14 +14,41 @@ struct SidebarView: View {
             }
         }
         .listStyle(.sidebar)
+        .overlay {
+            if model.filteredChats.isEmpty {
+                if model.searchText.isEmpty {
+                    ContentUnavailableView("No Chats", systemImage: "bubble.left.and.bubble.right")
+                } else {
+                    ContentUnavailableView.search(text: model.searchText)
+                }
+            }
+        }
         .navigationTitle("Chats")
-        .searchable(text: $model.searchText, placement: .sidebar, prompt: "Search")
+        .searchable(
+            text: $model.searchText,
+            isPresented: $model.sidebarSearchPresented,
+            placement: .sidebar,
+            prompt: "Search"
+        )
         .toolbar {
             ToolbarItem(placement: .navigation) {
-                ProfileAvatar(image: model.profile?.image, name: model.profile?.displayName ?? "Profile", size: 24)
-                    .help(model.profile?.displayName ?? "Profile")
-                    .accessibilityLabel("Current profile, \(model.profile?.displayName ?? "Profile")")
+                Menu {
+                    if let name = model.profile?.displayName {
+                        Text(name)
+                    }
+                    SettingsLink {
+                        Label("Settings…", systemImage: "gear")
+                    }
+                } label: {
+                    ProfileAvatar(image: model.profile?.image, name: model.profile?.displayName ?? "Profile", size: 24)
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+                .help("Profile and Settings")
+                .accessibilityLabel("Profile and Settings")
+                .accessibilityInputLabels(["Profile and Settings", "Profile", "Settings"])
             }
+
         }
     }
 }
@@ -32,7 +59,7 @@ private struct ChatSidebarRow: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            ProfileAvatar(image: chat.image, name: chat.displayName, size: density.tokens.avatarSize)
+            ChatSidebarAvatar(chat: chat, size: density.tokens.avatarSize)
                 .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 4) {
@@ -42,9 +69,7 @@ private struct ChatSidebarRow: View {
                         .lineLimit(1)
                     Spacer(minLength: 8)
                     if let timestamp = chat.timestamp {
-                        Text(timestamp, format: .dateTime.hour().minute())
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                        ChatTimestamp(date: timestamp)
                     }
                 }
                 HStack(spacing: 8) {
@@ -67,6 +92,43 @@ private struct ChatSidebarRow: View {
         .padding(.vertical, density.tokens.chatRowPadding)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(chat.accessibilityDescription)
+    }
+}
+
+private struct ChatSidebarAvatar: View {
+    let chat: NativeChat
+    let size: CGFloat
+
+    var body: some View {
+        if chat.image != nil || chat.kind == .direct {
+            ProfileAvatar(image: chat.image, name: chat.displayName, size: size)
+        } else {
+            ZStack {
+                Circle().fill(.quaternary)
+                Image(systemName: chat.kind == .local ? "folder.fill" : "person.2.fill")
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(width: size, height: size)
+        }
+    }
+}
+
+private struct ChatTimestamp: View {
+    let date: Date
+
+    var body: some View {
+        Text(label)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+    }
+
+    private var label: String {
+        if Calendar.current.isDateInToday(date) {
+            return date.formatted(.dateTime.hour().minute())
+        }
+        if Calendar.current.isDateInYesterday(date) { return "Yesterday" }
+        return date.formatted(.dateTime.month(.abbreviated).day())
     }
 }
 

--- a/apps/macos-native/Sources/SimpleXNative/UI/SidebarView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/SidebarView.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+struct SidebarView: View {
+    @ObservedObject var model: AppModel
+
+    var body: some View {
+        List(selection: Binding(
+            get: { model.selectedChatID },
+            set: model.selectChat
+        )) {
+            ForEach(model.filteredChats) { chat in
+                ChatSidebarRow(chat: chat)
+                    .tag(chat.id)
+            }
+        }
+        .listStyle(.sidebar)
+        .navigationTitle("Chats")
+        .searchable(text: $model.searchText, placement: .sidebar, prompt: "Search")
+        .toolbar {
+            ToolbarItem(placement: .navigation) {
+                ProfileAvatar(image: model.profile?.image, name: model.profile?.displayName ?? "Profile", size: 24)
+                    .help(model.profile?.displayName ?? "Profile")
+                    .accessibilityLabel("Current profile, \(model.profile?.displayName ?? "Profile")")
+            }
+        }
+    }
+}
+
+private struct ChatSidebarRow: View {
+    let chat: NativeChat
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ProfileAvatar(image: chat.image, name: chat.displayName, size: 40)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 8) {
+                    Text(chat.displayName)
+                        .font(.headline)
+                        .lineLimit(1)
+                    Spacer(minLength: 8)
+                    if let timestamp = chat.timestamp {
+                        Text(timestamp, format: .dateTime.hour().minute())
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                HStack(spacing: 8) {
+                    Text(chat.preview.isEmpty ? "No messages yet" : chat.preview)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                    Spacer(minLength: 8)
+                    if chat.unreadCount > 0 {
+                        Text(chat.unreadCount, format: .number.grouping(.never))
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(.tint, in: Capsule())
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(chat.accessibilityDescription)
+    }
+}
+
+struct ProfileAvatar: View {
+    let image: String?
+    let name: String
+    let size: CGFloat
+
+    var body: some View {
+        Group {
+            if let nsImage = NativeChatParser.image(from: image) {
+                Image(nsImage: nsImage)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                ZStack {
+                    Circle().fill(.quaternary)
+                    Text(String(name.prefix(1)).uppercased())
+                        .font(.headline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .frame(width: size, height: size)
+        .clipShape(Circle())
+    }
+}

--- a/apps/macos-native/Sources/SimpleXNative/UI/SidebarView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/SidebarView.swift
@@ -6,7 +6,7 @@ struct SidebarView: View {
     var body: some View {
         List(selection: Binding(
             get: { model.selectedChatID },
-            set: model.selectChat
+            set: { model.selectChat($0) }
         )) {
             ForEach(model.filteredChats) { chat in
                 ChatSidebarRow(chat: chat, density: model.density)

--- a/apps/macos-native/Sources/SimpleXNative/UI/UnlockView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/UnlockView.swift
@@ -1,55 +1,73 @@
+import AppKit
 import SwiftUI
 
 struct UnlockView: View {
     @ObservedObject var model: AppModel
     @State private var passphrase = ""
+    @State private var rememberPassphrase = true
     @FocusState private var passphraseFocused: Bool
 
     var body: some View {
-        VStack(spacing: 24) {
-            Image(systemName: "lock.shield")
-                .font(.largeTitle)
-                .foregroundStyle(.secondary)
-                .accessibilityHidden(true)
+        VStack(spacing: 20) {
+            Image(nsImage: NSApp.applicationIconImage)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 64, height: 64)
+                .accessibilityLabel("SimpleX Chat")
 
             VStack(spacing: 8) {
-                Text("Encrypted database")
+                Text("Welcome back")
                     .font(.title2.weight(.semibold))
-                Text("Enter the passphrase for your existing SimpleX desktop profile.")
+                Text("Enter your database passphrase to unlock this SimpleX profile.")
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
             }
 
-            VStack(alignment: .leading, spacing: 8) {
-                SecureField("Database passphrase", text: $passphrase)
-                    .textFieldStyle(.roundedBorder)
-                    .focused($passphraseFocused)
-                    .onSubmit(open)
-
-                if case let .locked(message?) = model.phase {
-                    Label(message, systemImage: "exclamationmark.triangle.fill")
-                        .foregroundStyle(.red)
-                        .font(.callout)
-                }
-            }
-
-            Button("Open Chat", action: open)
-                .buttonStyle(.borderedProminent)
-                .controlSize(.large)
-                .disabled(passphrase.isEmpty || model.phase == .opening)
-
-            if model.phase == .opening {
-                ProgressView("Opening profile…")
+            if model.phase == .opening, passphrase.isEmpty {
+                ProgressView("Unlocking with Mac Keychain…")
                     .controlSize(.small)
+            } else {
+                VStack(alignment: .leading, spacing: 8) {
+                    SecureField("Database passphrase", text: $passphrase)
+                        .textFieldStyle(.roundedBorder)
+                        .focused($passphraseFocused)
+                        .onSubmit(open)
+
+                    if model.keychainPassphraseStorageAvailable {
+                        Toggle("Remember in Mac Keychain", isOn: $rememberPassphrase)
+                    }
+
+                    if case let .locked(message?) = model.phase {
+                        Label(message, systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.red)
+                            .font(.callout)
+                    }
+                }
+
+                Button("Open Chat", action: open)
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.regular)
+                    .disabled(passphrase.isEmpty || model.phase == .opening)
+
+                if model.phase == .opening {
+                    ProgressView("Opening profile…")
+                        .controlSize(.small)
+                }
             }
         }
         .padding(32)
-        .frame(maxWidth: 420)
-        .onAppear { passphraseFocused = true }
+        .frame(width: 380)
+        .onAppear {
+            rememberPassphrase = model.keychainPassphraseStorageAvailable
+            passphraseFocused = true
+        }
     }
 
     private func open() {
         guard !passphrase.isEmpty else { return }
-        model.unlock(passphrase: passphrase)
+        model.unlock(
+            passphrase: passphrase,
+            rememberPassphrase: rememberPassphrase && model.keychainPassphraseStorageAvailable
+        )
     }
 }

--- a/apps/macos-native/Sources/SimpleXNative/UI/UnlockView.swift
+++ b/apps/macos-native/Sources/SimpleXNative/UI/UnlockView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+struct UnlockView: View {
+    @ObservedObject var model: AppModel
+    @State private var passphrase = ""
+    @FocusState private var passphraseFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "lock.shield")
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+
+            VStack(spacing: 8) {
+                Text("Encrypted database")
+                    .font(.title2.weight(.semibold))
+                Text("Enter the passphrase for your existing SimpleX desktop profile.")
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                SecureField("Database passphrase", text: $passphrase)
+                    .textFieldStyle(.roundedBorder)
+                    .focused($passphraseFocused)
+                    .onSubmit(open)
+
+                if case let .locked(message?) = model.phase {
+                    Label(message, systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.red)
+                        .font(.callout)
+                }
+            }
+
+            Button("Open Chat", action: open)
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .disabled(passphrase.isEmpty || model.phase == .opening)
+
+            if model.phase == .opening {
+                ProgressView("Opening profile…")
+                    .controlSize(.small)
+            }
+        }
+        .padding(32)
+        .frame(maxWidth: 420)
+        .onAppear { passphraseFocused = true }
+    }
+
+    private func open() {
+        guard !passphrase.isEmpty else { return }
+        model.unlock(passphrase: passphrase)
+    }
+}

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -391,6 +391,10 @@ private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: Quot
         }
     )
     #expect(!model.messages.contains(where: { $0.id == target.id }))
+    model.beginConversationSearch()
+    model.conversationSearchText = "Hey"
+    model.updateConversationSearchSelection()
+    #expect(model.selectedMessageIDs == [1])
 
     // When
     let navigation = try #require(model.openQuotedMessage(quote, from: 901))
@@ -400,6 +404,9 @@ private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: Quot
     #expect(model.messages == [target])
     #expect(model.targetMessageID == target.id)
     #expect(model.quoteNavigationError == nil)
+    #expect(!model.conversationSearchPresented)
+    #expect(model.conversationSearchText.isEmpty)
+    #expect(model.selectedMessageIDs.isEmpty)
     #expect(model.phase == .ready)
 }
 
@@ -483,6 +490,11 @@ private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: Quot
         }
     )
     let originalMessages = model.messages
+    model.beginConversationSearch()
+    model.conversationSearchText = "Hey"
+    model.updateConversationSearchSelection()
+    model.targetMessageID = nil
+    #expect(model.selectedMessageIDs == [1])
 
     // When
     let navigation = try #require(model.openQuotedMessage(quote, from: 903))
@@ -492,6 +504,40 @@ private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: Quot
     #expect(model.messages == originalMessages)
     #expect(model.targetMessageID == nil)
     #expect(model.quoteNavigationError == "The original quoted message is no longer available in this conversation.")
+    #expect(model.conversationSearchPresented)
+    #expect(model.conversationSearchText == "Hey")
+    #expect(model.selectedMessageIDs == [1])
+    #expect(model.phase == .ready)
+}
+
+@MainActor
+@Test func offscreenQuoteMissingFromLoadedPagePreservesTranscriptAndSearch() async throws {
+    // Given
+    let quote = NativeQuote(messageID: 906, text: "Missing original", sent: false, author: "Maya")
+    let model = AppModel(
+        previewMode: true,
+        loadMessagesOperation: { _, aroundMessageID in
+            #expect(aroundMessageID == quote.messageID)
+            return []
+        }
+    )
+    let originalMessages = model.messages
+    model.beginConversationSearch()
+    model.conversationSearchText = "Hey"
+    model.updateConversationSearchSelection()
+    model.targetMessageID = nil
+
+    // When
+    let navigation = try #require(model.openQuotedMessage(quote, from: 907))
+    await navigation.value
+
+    // Then
+    #expect(model.messages == originalMessages)
+    #expect(model.targetMessageID == nil)
+    #expect(model.quoteNavigationError == "The original quoted message is no longer available in this conversation.")
+    #expect(model.conversationSearchPresented)
+    #expect(model.conversationSearchText == "Hey")
+    #expect(model.selectedMessageIDs == [1])
     #expect(model.phase == .ready)
 }
 

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -1868,13 +1868,17 @@ private actor DelayedTextSendProbe {
 private func makeSendTestModel(
     sendTextOperation: SendTextOperation? = nil,
     sendAttachmentOperation: SendAttachmentOperation? = nil,
-    loadMessageOperation: LoadMessageOperation? = nil
+    loadMessageOperation: LoadMessageOperation? = nil,
+    loadMessagesOperation: LoadMessagesOperation? = nil,
+    loadChatsOperation: LoadChatsOperation? = nil
 ) -> AppModel {
     let model = AppModel(
         previewMode: true,
         sendTextOperation: sendTextOperation,
         sendAttachmentOperation: sendAttachmentOperation,
-        loadMessageOperation: loadMessageOperation
+        loadMessageOperation: loadMessageOperation,
+        loadMessagesOperation: loadMessagesOperation,
+        loadChatsOperation: loadChatsOperation
     )
     return model
 }
@@ -1982,6 +1986,40 @@ private func unavailableVersion(of message: NativeMessage) -> NativeMessage {
     #expect(model.replyingTo == nil)
     #expect(model.replyContextError == "Your message was sent, but SimpleX could not link it to the original message.")
     #expect(model.phase == .ready)
+    #expect(!model.isSending)
+}
+
+@MainActor
+@Test func committedReplyIsNotRestoredWhenOnlyTheRefreshFails() async throws {
+    // Given
+    let refreshFailure = "The newest messages are temporarily unavailable."
+    let original = NativePreviewData.messages(for: "@1")[0]
+    let model = makeSendTestModel(
+        sendTextOperation: { _, quotedItemID, _ in
+            #expect(quotedItemID == original.id)
+            return .confirmed
+        },
+        loadMessagesOperation: { chatID, aroundMessageID in
+            #expect(chatID == "@1")
+            #expect(aroundMessageID == nil)
+            throw NativeChatError.unavailable(refreshFailure)
+        }
+    )
+    model.messages = [original]
+    model.draft = "Send this once"
+    model.beginReply(to: original)
+
+    // When
+    model.sendDraft()
+    let send = try #require(model.sendTask)
+    await send.value
+
+    // Then: the committed message is not restored for a duplicate retry.
+    #expect(model.draft.isEmpty)
+    #expect(model.replyingTo == nil)
+    #expect(model.phase == .failed(
+        "Your message was sent, but the conversation could not refresh. Use Refresh to load it. \(refreshFailure)"
+    ))
     #expect(!model.isSending)
 }
 
@@ -3120,7 +3158,7 @@ func databasePassphraseKeychainAddsUpdatesLoadsAndDeletes() async throws {
         let createdUser = try sendCoreCommand(
             #"/_create user {"profile":null,"pastTimestamp":false,"userChatRelay":false,"clientService":false}"#
         )
-        _ = try NativeChatParser.profile(from: createdUser)
+        let profile = try NativeChatParser.profile(from: createdUser)
         let started = try sendCoreCommand("/_start main=on snd_files=on")
         try NativeChatParser.validateCommandResponse(started)
         let localSend = try sendCoreCommand(
@@ -3131,6 +3169,55 @@ func databasePassphraseKeychainAddsUpdatesLoadsAndDeletes() async throws {
             expectedType: "newChatItems",
             requireChatItems: true
         )
+
+        let createdGroup = try sendCoreCommand(
+            #"/_group \#(profile.userID) {"displayName":"Native Reply Check","fullName":""}"#
+        )
+        let groupRoot = try #require(
+            JSONSerialization.jsonObject(with: createdGroup) as? [String: Any]
+        )
+        let groupResult = try #require(groupRoot["result"] as? [String: Any])
+        #expect(groupResult["type"] as? String == "groupCreated")
+        let groupInfo = try #require(groupResult["groupInfo"] as? [String: Any])
+        let groupID = try #require(groupInfo["groupId"] as? NSNumber).int64Value
+        let group = NativeChat(
+            id: "#\(groupID)",
+            apiID: groupID,
+            kind: .group,
+            displayName: "Native Reply Check",
+            image: nil,
+            preview: "",
+            timestamp: nil,
+            unreadCount: 0,
+            sendAsGroup: false
+        )
+        let firstMessage = SimpleXCore.composedMessage(
+            messageContent: ["type": "text", "text": "Original bundled-core message"],
+            quotedItemID: nil
+        )
+        let firstSend = try sendCoreCommand(SimpleXCore.sendCommand(message: firstMessage, to: group))
+        try NativeChatParser.validateCommandResponse(
+            firstSend,
+            expectedType: "newChatItems",
+            requireChatItems: true
+        )
+        let firstRoot = try #require(JSONSerialization.jsonObject(with: firstSend) as? [String: Any])
+        let firstResult = try #require(firstRoot["result"] as? [String: Any])
+        let firstItems = try #require(firstResult["chatItems"] as? [[String: Any]])
+        let firstItem = try #require(firstItems.first?["chatItem"] as? [String: Any])
+        let firstMeta = try #require(firstItem["meta"] as? [String: Any])
+        let firstItemID = try #require(firstMeta["itemId"] as? NSNumber).int64Value
+
+        let replyMessage = SimpleXCore.composedMessage(
+            messageContent: ["type": "text", "text": "Bundled-core reply"],
+            quotedItemID: firstItemID
+        )
+        let replySend = try sendCoreCommand(SimpleXCore.sendCommand(message: replyMessage, to: group))
+        let replyReceipt = try NativeChatParser.validateSendResponse(
+            replySend,
+            quotedItemID: firstItemID
+        )
+        #expect(replyReceipt.replyContextConfirmed)
 
         let originalURL = temporaryDirectory.appendingPathComponent("original.jpg")
         let encryptedURL = temporaryDirectory.appendingPathComponent("encrypted.jpg")

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -33,6 +33,70 @@ import Testing
     #expect(message.quotedItem == NativeQuote(messageID: 7, text: "Original message", sent: true, author: nil))
 }
 
+private struct QuotedAttachmentCase: Sendable, CustomTestStringConvertible {
+    let contentType: String
+    let expectedPreview: String
+
+    var testDescription: String { contentType }
+}
+
+private let quotedAttachmentCases = [
+    QuotedAttachmentCase(contentType: "image", expectedPreview: "Photo"),
+    QuotedAttachmentCase(contentType: "video", expectedPreview: "Video"),
+    QuotedAttachmentCase(contentType: "voice", expectedPreview: "Voice message"),
+    QuotedAttachmentCase(contentType: "file", expectedPreview: "File"),
+]
+
+@Test(arguments: quotedAttachmentCases)
+private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: QuotedAttachmentCase) throws {
+    // Given
+    let json = """
+        {"result":{"type":"apiChat","chat":{"chatItems":[{"chatDir":{"type":"directRcv"},"meta":{"itemId":9,"itemText":"Reply","itemTs":"2026-08-02T20:00:00Z"},"content":{"type":"rcvMsgContent","msgContent":{"type":"text","text":"Reply"}},"quotedItem":{"chatDir":{"type":"directSnd"},"itemId":7,"sentAt":"2026-08-02T19:59:00Z","content":{"type":"\(testCase.contentType)","text":"   "}}}]}}}
+        """
+
+    // When
+    let message = try #require(NativeChatParser.messages(from: Data(json.utf8)).first)
+
+    // Then
+    #expect(message.quotedItem?.text == testCase.expectedPreview)
+}
+
+@Test func replyPreviewNormalizesCaptionsAndFallsBackForAttachments() {
+    // Given
+    let captioned = NativeMessage(
+        id: 1,
+        text: "  Keep this caption  ",
+        timestamp: nil,
+        sent: false,
+        author: nil,
+        deletable: true,
+        content: .image(preview: nil, fileName: "photo.jpg")
+    )
+    let whitespaceOnly = NativeMessage(
+        id: 2,
+        text: " \n ",
+        timestamp: nil,
+        sent: false,
+        author: nil,
+        deletable: true,
+        content: .file(fileName: "document.pdf")
+    )
+    let unnamedPhoto = NativeMessage(
+        id: 3,
+        text: "",
+        timestamp: nil,
+        sent: false,
+        author: nil,
+        deletable: true,
+        content: .image(preview: nil, fileName: "   ")
+    )
+
+    // When / Then
+    #expect(captioned.replyPreview == "Keep this caption")
+    #expect(whitespaceOnly.replyPreview == "document.pdf")
+    #expect(unnamedPhoto.replyPreview == "Photo")
+}
+
 @Test func composedMessagesIncludeAQuoteOnlyWhenReplying() {
     let reply = SimpleXCore.composedMessage(
         messageContent: ["type": "text", "text": "Reply"],

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -33,6 +33,20 @@ import Testing
     #expect(message.quotedItem == NativeQuote(messageID: 7, text: "Original message", sent: true, author: nil))
 }
 
+@Test func groupMessagesAndQuotesPreferLocallyDisambiguatedMemberNames() throws {
+    // Given
+    let json = #"{"result":{"type":"apiChat","chat":{"chatItems":[{"chatDir":{"type":"groupRcv","groupMember":{"localDisplayName":"Maya (work)","memberProfile":{"displayName":"Maya"}}},"meta":{"itemId":9,"itemText":"Reply","itemTs":"2026-08-02T20:00:00Z"},"content":{"type":"rcvMsgContent","msgContent":{"type":"text","text":"Reply"}},"quotedItem":{"chatDir":{"type":"groupRcv","groupMember":{"localDisplayName":"Jordan (cycling)","memberProfile":{"displayName":"Jordan"}}},"itemId":7,"sentAt":"2026-08-02T19:59:00Z","content":{"type":"text","text":"Original message"}}}]}}}"#
+
+    // When
+    let message = try #require(NativeChatParser.messages(from: Data(json.utf8)).first)
+
+    // Then
+    #expect(message.author == "Maya (work)")
+    #expect(message.quotedItem?.author == "Jordan (cycling)")
+    #expect(message.quotedItem?.messageID == 7)
+    #expect(message.quotedItem?.text == "Original message")
+}
+
 private struct ReplyEligibilityCase: Sendable, CustomTestStringConvertible {
     let name: String
     let itemID: Int64

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -677,6 +677,65 @@ private func makeLiveRefreshModel(probe: ConversationRefreshProbe) -> AppModel {
 }
 
 @MainActor
+@Test func manualRefreshBlocksConflictingTranscriptActionsFromItsFirstPhase() async throws {
+    // Given
+    let chatsProbe = DelayedValue(NativePreviewData.chats)
+    let originalMessages = NativePreviewData.messages(for: "@1")
+    let model = AppModel(
+        previewMode: false,
+        loadMessagesOperation: { chatID, aroundMessageID in
+            #expect(chatID == "@1")
+            #expect(aroundMessageID == nil)
+            return originalMessages
+        },
+        loadChatsOperation: { _ in await chatsProbe.load() }
+    )
+    model.phase = .ready
+    model.profile = NativePreviewData.profile
+    model.chats = NativePreviewData.chats
+    model.selectedChatID = "@1"
+    model.messages = originalMessages
+    let target = try #require(originalMessages.first)
+    let quote = NativeQuote(messageID: target.id, text: target.text, sent: target.sent, author: target.author)
+    model.draft = "Wait for refresh"
+    model.selectMessage(target.id, modifiers: [])
+
+    // When: Refresh is still loading only the chat list.
+    model.refresh()
+    await chatsProbe.waitUntilRequested()
+
+    // Then: transcript mutations are already disabled before its transcript load begins.
+    #expect(model.isRefreshing)
+    #expect(!model.isLoadingConversation)
+    #expect(!model.canSendDraft)
+    #expect(!model.canDeleteSelectedMessages)
+    #expect(!model.canNavigateConversationHistory)
+    #expect(!model.canRefreshConversation)
+    model.sendDraft()
+    model.requestDeleteSelectedMessages()
+    #expect(model.sendTask == nil)
+    #expect(!model.showingDeleteConfirmation)
+    #expect(model.openQuotedMessage(quote, from: 912) == nil)
+    #expect(model.targetMessageID == nil)
+
+    // When: both refresh phases finish.
+    await chatsProbe.release()
+    for _ in 0..<1_000 {
+        if !model.isRefreshing { break }
+        await Task.yield()
+    }
+
+    // Then: the original controls recover against the refreshed transcript.
+    #expect(!model.isRefreshing)
+    #expect(!model.isLoadingConversation)
+    #expect(model.canSendDraft)
+    #expect(model.canDeleteSelectedMessages)
+    #expect(model.canNavigateConversationHistory)
+    #expect(model.canRefreshConversation)
+    #expect(model.messages == originalMessages)
+}
+
+@MainActor
 @Test func liveEventRefreshPreservesTheActiveQuoteNavigationAnchor() async throws {
     // Given
     let target = NativePreviewData.messages(for: "@1")[0]

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -65,6 +65,49 @@ import Testing
 }
 
 @MainActor
+@Test func selectionBarActionsWorkAfterTranscriptLosesFocus() throws {
+    let model = AppModel(previewMode: true)
+    let original = try #require(model.messages.first)
+
+    model.selectMessage(original.id, modifiers: [])
+    model.transcriptFocused = false
+    model.replyToSelectedMessage()
+
+    #expect(model.replyingTo?.id == original.id)
+    #expect(model.selectedMessageIDs.isEmpty)
+
+    model.cancelReply()
+    model.selectMessage(original.id, modifiers: [])
+    model.transcriptFocused = false
+    model.requestDeleteSelectedMessages()
+
+    #expect(model.showingDeleteConfirmation)
+}
+
+@MainActor
+@Test func cancellingReplyPreservesTheDraftAndAttachments() throws {
+    let model = AppModel(previewMode: true)
+    let original = try #require(model.messages.first)
+    let attachment = PendingAttachment(
+        id: UUID(),
+        url: URL(fileURLWithPath: "/tmp/reply-photo.jpg"),
+        fileName: "reply-photo.jpg",
+        kind: .image,
+        byteCount: 10,
+        previewImage: nil
+    )
+    model.draft = "Keep this draft"
+    model.pendingAttachments = [attachment]
+    model.beginReply(to: original)
+
+    model.cancelReply()
+
+    #expect(model.replyingTo == nil)
+    #expect(model.draft == "Keep this draft")
+    #expect(model.pendingAttachments == [attachment])
+}
+
+@MainActor
 @Test func notificationChatTransitionCannotLeakAReplyIntoAnotherConversation() throws {
     // Given
     let model = AppModel(previewMode: true)

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -108,6 +108,98 @@ import Testing
 }
 
 @MainActor
+@Test func deletionCompletionCannotReplaceAnotherChatsTranscript() async throws {
+    // Given
+    let deletedChatMessages = Array(NativePreviewData.messages(for: "@1").dropFirst())
+    let model = AppModel(
+        previewMode: true,
+        deleteMessagesOperation: { _, _ in deletedChatMessages }
+    )
+    let message = try #require(model.messages.first)
+    model.selectMessage(message.id, modifiers: [])
+
+    // When
+    let deletion = try #require(model.deleteSelectedMessages())
+    model.selectChat("#2")
+    let activeChatMessages = model.messages
+    await deletion.value
+
+    // Then
+    #expect(model.selectedChatID == "#2")
+    #expect(model.messages == activeChatMessages)
+    #expect(!model.isDeletingMessages)
+}
+
+@MainActor
+@Test func deletionCompletionRefreshesItsOriginatingTranscript() async throws {
+    // Given
+    let remainingMessages = Array(NativePreviewData.messages(for: "@1").dropFirst())
+    let model = AppModel(
+        previewMode: true,
+        deleteMessagesOperation: { _, _ in remainingMessages }
+    )
+    let message = try #require(model.messages.first)
+    model.selectMessage(message.id, modifiers: [])
+
+    // When
+    let deletion = try #require(model.deleteSelectedMessages())
+    await deletion.value
+
+    // Then
+    #expect(model.messages == remainingMessages)
+    #expect(model.selectedMessageIDs.isEmpty)
+    #expect(!model.isDeletingMessages)
+}
+
+@MainActor
+@Test func offscreenDeletionFailureWaitsForItsOriginatingChat() async throws {
+    // Given
+    let message = "The message could not be deleted."
+    let model = AppModel(
+        previewMode: true,
+        deleteMessagesOperation: { _, _ in throw NativeChatError.unavailable(message) }
+    )
+    let selected = try #require(model.messages.first)
+    model.selectMessage(selected.id, modifiers: [])
+
+    // When
+    let deletion = try #require(model.deleteSelectedMessages())
+    model.selectChat("#2")
+    await deletion.value
+
+    // Then
+    #expect(model.phase == .ready)
+    #expect(!model.isDeletingMessages)
+
+    model.selectChat("@1")
+    #expect(model.phase == .failed(message))
+}
+
+@MainActor
+@Test func cancelledDeletionDoesNotMutateTheTranscriptOrStayBusy() async throws {
+    // Given
+    let model = AppModel(
+        previewMode: true,
+        deleteMessagesOperation: { _, _ in
+            try Task.checkCancellation()
+            return []
+        }
+    )
+    let originalMessages = model.messages
+    let selected = try #require(model.messages.first)
+    model.selectMessage(selected.id, modifiers: [])
+
+    // When
+    let deletion = try #require(model.deleteSelectedMessages())
+    deletion.cancel()
+    await deletion.value
+
+    // Then
+    #expect(model.messages == originalMessages)
+    #expect(!model.isDeletingMessages)
+}
+
+@MainActor
 @Test func notificationChatTransitionCannotLeakAReplyIntoAnotherConversation() throws {
     // Given
     let model = AppModel(previewMode: true)

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -736,6 +736,97 @@ private func makeLiveRefreshModel(probe: ConversationRefreshProbe) -> AppModel {
 }
 
 @MainActor
+@Test func eventRefreshSkipsItsTranscriptWhenASendStartsDuringChatListLoading() async throws {
+    // Given
+    let chatsProbe = DelayedValue(NativePreviewData.chats)
+    let originalMessages = NativePreviewData.messages(for: "@1")
+    let transcriptProbe = ConversationRefreshProbe(messages: originalMessages)
+    let sendFailure = "The delayed send failed."
+    let sendProbe = DelayedTextSendProbe(failureMessage: sendFailure)
+    let model = AppModel(
+        previewMode: false,
+        sendTextOperation: { _, _, _ in try await sendProbe.send() },
+        loadMessagesOperation: { _, aroundMessageID in
+            await transcriptProbe.load(around: aroundMessageID)
+        },
+        loadChatsOperation: { _ in await chatsProbe.load() }
+    )
+    model.phase = .ready
+    model.profile = NativePreviewData.profile
+    model.chats = NativePreviewData.chats
+    model.selectedChatID = "@1"
+    model.messages = originalMessages
+    model.draft = "Send owns the transcript"
+
+    // When: an event is loading chats and a send starts before its transcript phase.
+    let eventRefresh = Task { await model.refreshAfterEvent() }
+    await chatsProbe.waitUntilRequested()
+    model.sendDraft()
+    let send = try #require(model.sendTask)
+    await sendProbe.waitUntilRequested()
+    await chatsProbe.release()
+    await eventRefresh.value
+
+    // Then: the event does not start a competing transcript reload.
+    #expect(await transcriptProbe.recordedRequests().isEmpty)
+    #expect(model.messages == originalMessages)
+    #expect(model.isSendingSelectedChat)
+
+    // Cleanup.
+    await sendProbe.release()
+    await send.value
+    #expect(model.phase == .failed(sendFailure))
+}
+
+@MainActor
+@Test func cancelledEventAnchorCannotEraseANewerLoadedQuote() async throws {
+    // Given
+    let originalMessages = NativePreviewData.messages(for: "@1")
+    let oldTarget = try #require(originalMessages.first)
+    let newerTarget = try #require(originalMessages.dropFirst().first)
+    let probe = ConversationRefreshProbe(messages: originalMessages, delayFirstRequest: true)
+    let model = AppModel(
+        previewMode: false,
+        loadMessagesOperation: { _, aroundMessageID in await probe.load(around: aroundMessageID) },
+        loadChatsOperation: { _ in NativePreviewData.chats }
+    )
+    model.phase = .ready
+    model.profile = NativePreviewData.profile
+    model.chats = NativePreviewData.chats
+    model.selectedChatID = "@1"
+    model.messages = originalMessages
+    let oldQuote = NativeQuote(
+        messageID: oldTarget.id,
+        text: oldTarget.text,
+        sent: oldTarget.sent,
+        author: oldTarget.author
+    )
+    #expect(model.openQuotedMessage(oldQuote, from: 913) == nil)
+    #expect(model.conversationAnchorMessageID == oldTarget.id)
+
+    // When: the anchored event load starts, then a newer loaded quote wins.
+    let eventRefresh = Task { await model.refreshAfterEvent() }
+    await probe.waitUntilFirstRequested()
+    let newerQuote = NativeQuote(
+        messageID: newerTarget.id,
+        text: newerTarget.text,
+        sent: newerTarget.sent,
+        author: newerTarget.author
+    )
+    #expect(model.openQuotedMessage(newerQuote, from: 914) == nil)
+    #expect(model.conversationAnchorMessageID == newerTarget.id)
+    await probe.releaseFirstRequest()
+    await eventRefresh.value
+
+    // Then: the failed old load cannot trigger a latest-page fallback over the newer intent.
+    #expect(await probe.recordedRequests() == [oldTarget.id])
+    #expect(model.messages == originalMessages)
+    #expect(model.conversationAnchorMessageID == newerTarget.id)
+    #expect(model.targetMessageID == newerTarget.id)
+    #expect(model.quoteNavigationError == nil)
+}
+
+@MainActor
 @Test func liveEventRefreshPreservesTheActiveQuoteNavigationAnchor() async throws {
     // Given
     let target = NativePreviewData.messages(for: "@1")[0]

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -3730,6 +3730,21 @@ private actor DelayedDeletionProbe {
     )
 }
 
+@Test func copyCommandPreservesNativeTextSelectionAndSelectedMessageCopying() {
+    #expect(
+        DesktopCopyCommandRoute.resolve(transcriptFocused: true, selectedMessageCount: 0)
+            == .firstResponder
+    )
+    #expect(
+        DesktopCopyCommandRoute.resolve(transcriptFocused: true, selectedMessageCount: 2)
+            == .selectedMessages
+    )
+    #expect(
+        DesktopCopyCommandRoute.resolve(transcriptFocused: false, selectedMessageCount: 2)
+            == .firstResponder
+    )
+}
+
 @Test func replyControlRemainsVisibleAcrossItsHoverRegion() {
     #expect(MessageReplyControlVisibility.isVisible(canReply: true, hovering: true, selected: false))
     #expect(MessageReplyControlVisibility.isVisible(canReply: true, hovering: false, selected: true))

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -230,6 +230,28 @@ private func messageBodyHeight(_ text: String) -> CGFloat {
     #expect(NativeMessageLink.standaloneURL(in: "file:///tmp/private") == nil)
 }
 
+@Test func youtubeLinksBecomePrivacyEnhancedInlinePlayersAtTheirTimestamp() throws {
+    let embed = try #require(NativeMessageLink.youtubeEmbedURL(for: "https://youtu.be/ishgn7-NLIU?t=24"))
+    let components = try #require(URLComponents(url: embed, resolvingAgainstBaseURL: false))
+    let query = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).compactMap { item in
+        item.value.map { (item.name, $0) }
+    })
+
+    #expect(components.host == "www.youtube-nocookie.com")
+    #expect(components.path == "/embed/ishgn7-NLIU")
+    #expect(query["start"] == "24")
+    #expect(query["autoplay"] == "1")
+    #expect(query["playsinline"] == "1")
+
+    let longOffset = try #require(NativeMessageLink.youtubeEmbedURL(
+        for: "https://www.youtube.com/watch?v=ishgn7-NLIU&t=1m5s"
+    ))
+    #expect(URLComponents(url: longOffset, resolvingAgainstBaseURL: false)?
+        .queryItems?.first(where: { $0.name == "start" })?.value == "65")
+    #expect(NativeMessageLink.youtubeEmbedURL(for: "https://example.com/watch?v=ishgn7-NLIU") == nil)
+    #expect(NativeMessageLink.youtubeEmbedURL(for: "https://youtu.be/not-safe") == nil)
+}
+
 @Test func groupMessagesAndQuotesPreferLocallyDisambiguatedMemberNames() throws {
     // Given
     let json = #"{"result":{"type":"apiChat","chat":{"chatItems":[{"chatDir":{"type":"groupRcv","groupMember":{"localDisplayName":"Maya (work)","memberProfile":{"displayName":"Maya"}}},"meta":{"itemId":9,"itemText":"Reply","itemTs":"2026-08-02T20:00:00Z"},"content":{"type":"rcvMsgContent","msgContent":{"type":"text","text":"Reply"}},"quotedItem":{"chatDir":{"type":"groupRcv","groupMember":{"localDisplayName":"Jordan (cycling)","memberProfile":{"displayName":"Jordan"}}},"itemId":7,"sentAt":"2026-08-02T19:59:00Z","content":{"type":"text","text":"Original message"}}}]}}}"#

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -66,11 +66,13 @@ import Testing
 
 @MainActor
 @Test func notificationChatTransitionCannotLeakAReplyIntoAnotherConversation() throws {
+    // Given
     let model = AppModel(previewMode: true)
     let original = try #require(model.messages.first)
     model.beginReply(to: original)
     #expect(model.replyingTo?.id == original.id)
 
+    // When
     model.openNotificationRoute(NotificationRoute(
         userID: NativePreviewData.profile.userID,
         remoteHostID: nil,
@@ -78,6 +80,7 @@ import Testing
         messageID: 20
     ))
 
+    // Then
     #expect(model.selectedChatID == "#2")
     #expect(model.replyingTo == nil)
     #expect(model.targetMessageID == 20)
@@ -86,6 +89,44 @@ import Testing
     model.selectChat("*3")
     model.beginReply(to: groupMessage)
     #expect(model.replyingTo == nil)
+
+    model.selectChat("@1")
+    #expect(model.replyingTo?.id == original.id)
+}
+
+@MainActor
+@Test func switchingChatsPreservesIndependentComposerStates() throws {
+    // Given
+    let model = AppModel(previewMode: true)
+    let directMessage = try #require(model.messages.first)
+    let attachment = PendingAttachment(
+        id: UUID(),
+        url: URL(fileURLWithPath: "/tmp/photo.jpg"),
+        fileName: "photo.jpg",
+        kind: .image,
+        byteCount: 10,
+        previewImage: nil
+    )
+    model.draft = "Direct draft"
+    model.pendingAttachments = [attachment]
+    model.beginReply(to: directMessage)
+
+    // When
+    model.selectChat("#2")
+    let groupMessage = try #require(model.messages.first)
+    model.draft = "Group draft"
+    model.beginReply(to: groupMessage)
+    model.selectChat("@1")
+
+    // Then
+    #expect(model.draft == "Direct draft")
+    #expect(model.pendingAttachments == [attachment])
+    #expect(model.replyingTo?.id == directMessage.id)
+
+    model.selectChat("#2")
+    #expect(model.draft == "Group draft")
+    #expect(model.pendingAttachments.isEmpty)
+    #expect(model.replyingTo?.id == groupMessage.id)
 }
 
 @Test func messageSelectionSupportsRangesAndCommandToggle() {
@@ -147,15 +188,27 @@ func databasePassphraseKeychainAddsUpdatesLoadsAndDeletes() async throws {
 }
 
 @Test func attachmentReorderingAndFailureRetentionPreserveOrder() {
+    // Given
     let urls = ["one.jpg", "two.mov", "three.pdf"].map { URL(fileURLWithPath: "/tmp/\($0)") }
     let attachments = [
         PendingAttachment(id: UUID(), url: urls[0], fileName: "one.jpg", kind: .image, byteCount: 1, previewImage: nil),
         PendingAttachment(id: UUID(), url: urls[1], fileName: "two.mov", kind: .video, byteCount: 2, previewImage: nil),
         PendingAttachment(id: UUID(), url: urls[2], fileName: "three.pdf", kind: .document, byteCount: 3, previewImage: nil),
     ]
+    // When
     let reordered = PendingAttachment.reordered(attachments, from: attachments[2].id, before: attachments[0].id)
+    let sendSteps = PendingAttachmentBatch.sendSteps(
+        attachments: reordered,
+        caption: "Batch caption",
+        quotedItemID: 42
+    )
+
+    // Then
     #expect(reordered.map(\.fileName) == ["three.pdf", "one.jpg", "two.mov"])
     #expect(PendingAttachment.remainingAfterFailure(reordered, at: 1).map(\.fileName) == ["one.jpg", "two.mov"])
+    #expect(sendSteps.map(\.attachment.fileName) == ["three.pdf", "one.jpg", "two.mov"])
+    #expect(sendSteps.map(\.quotedItemID) == [42, nil, nil])
+    #expect(sendSteps.map(\.caption) == ["", "", "Batch caption"])
 }
 
 @Test func parsesMessageNotificationRouteAndPrivacyModes() throws {

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -1047,6 +1047,28 @@ private actor AttachmentOpenProbe {
 }
 
 @MainActor
+@Test func replyingFromConversationSearchConsumesTheSelectedResult() throws {
+    // Given
+    let model = AppModel(previewMode: true)
+    let source = try #require(model.messages.first(where: { $0.text.contains("photos") }))
+    model.beginConversationSearch()
+    model.conversationSearchText = "photos"
+    model.updateConversationSearchSelection()
+    let previousFocusRequest = model.composerFocusRequest
+    #expect(model.selectedMessageIDs == [source.id])
+
+    // When
+    model.replyToSelectedMessage()
+
+    // Then
+    #expect(model.replyingTo?.id == source.id)
+    #expect(!model.conversationSearchPresented)
+    #expect(model.conversationSearchText.isEmpty)
+    #expect(model.selectedMessageIDs.isEmpty)
+    #expect(model.composerFocusRequest == previousFocusRequest + 1)
+}
+
+@MainActor
 @Test func replyControlsRejectUnavailableItems() throws {
     // Given
     let source = try #require(NativePreviewData.messages(for: "@1").first)

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -205,6 +205,31 @@ private func messageBodyHeight(_ text: String) -> CGFloat {
     #expect(message.quotedItem == NativeQuote(messageID: 7, text: "Original message", sent: true, author: nil))
 }
 
+@Test func parsesLinkPreviewAsOneClickableVideoCard() throws {
+    let url = "https://youtu.be/ishgn7-NLIU?t=24"
+    let json = #"{"result":{"type":"apiChat","chat":{"chatItems":[{"chatDir":{"type":"directRcv"},"meta":{"itemId":24,"itemText":"https://youtu.be/ishgn7-NLIU?t=24"},"content":{"type":"rcvMsgContent","msgContent":{"type":"link","text":"https://youtu.be/ishgn7-NLIU?t=24","preview":{"uri":"https://youtu.be/ishgn7-NLIU?t=24","title":"Video title","description":"Video description","image":"data:image/jpeg;base64,AA==","content":{"type":"video","duration":24}}}}}]}}}"#
+    let message = try #require(NativeChatParser.messages(from: Data(json.utf8)).first)
+    let preview = try #require({
+        if case let .link(preview) = message.content { return preview }
+        return nil
+    }())
+
+    #expect(message.text == url)
+    #expect(preview.uri == url)
+    #expect(preview.title == "Video title")
+    #expect(preview.description == "Video description")
+    #expect(preview.videoDuration == 24)
+    #expect(preview.durationLabel == "0:24")
+    #expect(preview.destination?.absoluteString == url)
+}
+
+@Test func standaloneMessageLinksRequireOneCompleteWebURL() {
+    #expect(NativeMessageLink.standaloneURL(in: " https://youtu.be/ishgn7-NLIU?t=24 \n") != nil)
+    #expect(NativeMessageLink.standaloneURL(in: "See https://simplex.chat") == nil)
+    #expect(NativeMessageLink.standaloneURL(in: "simplex.chat") == nil)
+    #expect(NativeMessageLink.standaloneURL(in: "file:///tmp/private") == nil)
+}
+
 @Test func groupMessagesAndQuotesPreferLocallyDisambiguatedMemberNames() throws {
     // Given
     let json = #"{"result":{"type":"apiChat","chat":{"chatItems":[{"chatDir":{"type":"groupRcv","groupMember":{"localDisplayName":"Maya (work)","memberProfile":{"displayName":"Maya"}}},"meta":{"itemId":9,"itemText":"Reply","itemTs":"2026-08-02T20:00:00Z"},"content":{"type":"rcvMsgContent","msgContent":{"type":"text","text":"Reply"}},"quotedItem":{"chatDir":{"type":"groupRcv","groupMember":{"localDisplayName":"Jordan (cycling)","memberProfile":{"displayName":"Jordan"}}},"itemId":7,"sentAt":"2026-08-02T19:59:00Z","content":{"type":"text","text":"Original message"}}}]}}}"#

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import CoreBridge
 import Foundation
 import Testing
@@ -299,6 +300,13 @@ private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: Quot
         duration: 5
     ).replyContextVisual == .voice)
     #expect(NativeMessageContent.file(fileName: "notes.pdf").replyContextVisual == .file)
+}
+
+@Test func fullResolutionMediaUsesNativeQuickLook() {
+    #expect(NativeMessageContent.image(preview: nil, fileName: nil).opensInQuickLook)
+    #expect(NativeMessageContent.video(preview: nil, fileName: nil).opensInQuickLook)
+    #expect(!NativeMessageContent.voice(fileName: nil, duration: nil).opensInQuickLook)
+    #expect(!NativeMessageContent.file(fileName: nil).opensInQuickLook)
 }
 
 @Test func parsesVoiceMessageForPlaybackAndReplyContext() throws {
@@ -1651,6 +1659,19 @@ private actor DelayedAttachmentOpenFailure {
 }
 
 @MainActor
+private func writeTestJPEG(to url: URL) throws {
+    let image = NSImage(size: NSSize(width: 32, height: 24))
+    image.lockFocus()
+    NSColor.systemBlue.setFill()
+    NSRect(x: 0, y: 0, width: 32, height: 24).fill()
+    image.unlockFocus()
+    let tiff = try #require(image.tiffRepresentation)
+    let bitmap = try #require(NSBitmapImageRep(data: tiff))
+    let jpeg = try #require(bitmap.representation(using: .jpeg, properties: [:]))
+    try jpeg.write(to: url)
+}
+
+@MainActor
 @Test func attachmentOpenRefreshesMissingEncryptionMetadata() async throws {
     // Given
     let plainSource = NativeCryptoFile(filePath: "photo.jpg", cryptoArgs: nil)
@@ -1764,6 +1785,78 @@ private actor DelayedAttachmentOpenFailure {
     model.selectChat("@1")
     #expect(model.attachmentOpenError == failure)
     #expect(!model.isOpeningAttachment(first.id))
+}
+
+@MainActor
+@Test func openingAnImagePresentsTheOriginalFileInQuickLook() async throws {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let sourceURL = directory.appendingPathComponent("full-size.jpg")
+    try writeTestJPEG(to: sourceURL)
+
+    let source = NativeCryptoFile(filePath: sourceURL.path, cryptoArgs: nil)
+    let message = NativeMessage(
+        id: 93,
+        text: "Original photo",
+        timestamp: nil,
+        sent: false,
+        author: "Maya",
+        deletable: true,
+        content: .image(preview: "compressed-thumbnail", fileName: sourceURL.lastPathComponent),
+        fileSource: source
+    )
+    let model = AppModel(
+        previewMode: true,
+        loadMessageOperation: { _, _ in message }
+    )
+    model.messages = [message]
+
+    let opening = try #require(model.openAttachment(message))
+    await opening.value
+
+    #expect(model.quickLookURL?.standardizedFileURL == sourceURL.standardizedFileURL)
+    #expect(model.attachmentOpenError == nil)
+    #expect(!model.isOpeningAttachment(message.id))
+}
+
+@MainActor
+@Test func delayedImageOpenCannotAppearInAnotherConversation() async throws {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let sourceURL = directory.appendingPathComponent("delayed-full-size.jpg")
+    try writeTestJPEG(to: sourceURL)
+
+    let source = NativeCryptoFile(filePath: sourceURL.path, cryptoArgs: nil)
+    let message = NativeMessage(
+        id: 94,
+        text: "Slow original photo",
+        timestamp: nil,
+        sent: false,
+        author: "Maya",
+        deletable: true,
+        content: .image(preview: "compressed-thumbnail", fileName: sourceURL.lastPathComponent),
+        fileSource: source
+    )
+    let probe = DelayedValue<NativeMessage?>(message)
+    let model = AppModel(
+        previewMode: true,
+        loadMessageOperation: { _, _ in await probe.load() }
+    )
+    model.messages = [message]
+
+    let opening = try #require(model.openAttachment(message))
+    await probe.waitUntilRequested()
+    model.selectChat("#2")
+    await probe.release()
+    await opening.value
+
+    #expect(model.selectedChatID == "#2")
+    #expect(model.quickLookURL == nil)
+    #expect(model.attachmentOpenError == nil)
 }
 
 @MainActor

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -352,6 +352,10 @@ private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: Quot
         loadMessageOperation: { _, _ in containingMessage }
     )
     model.messages = [containingMessage]
+    model.beginConversationSearch()
+    model.conversationSearchText = "Reply"
+    model.updateConversationSearchSelection()
+    model.targetMessageID = nil
 
     // When
     let navigation = try #require(model.openQuotedMessage(unresolvedQuote, from: containingMessage.id))
@@ -360,6 +364,9 @@ private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: Quot
     // Then
     #expect(model.targetMessageID == nil)
     #expect(model.quoteNavigationError == "The original quoted message is no longer available in this conversation.")
+    #expect(model.conversationSearchPresented)
+    #expect(model.conversationSearchText == "Reply")
+    #expect(model.selectedMessageIDs == [containingMessage.id])
 }
 
 @MainActor
@@ -411,6 +418,30 @@ private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: Quot
     #expect(navigation == nil)
     #expect(model.targetMessageID == original.id)
     #expect(model.replyingTo?.id == original.id)
+}
+
+@MainActor
+@Test func quotedMessageNavigationConsumesSearchAndContainingSelection() throws {
+    // Given
+    let model = AppModel(previewMode: true)
+    let containingMessage = try #require(model.messages.first(where: { $0.quotedItem != nil }))
+    let quote = try #require(containingMessage.quotedItem)
+    let sourceID = try #require(quote.messageID)
+    model.beginConversationSearch()
+    model.conversationSearchText = "native"
+    model.updateConversationSearchSelection()
+    #expect(model.selectedMessageIDs == [containingMessage.id])
+
+    // When
+    let navigation = model.openQuotedMessage(quote, from: containingMessage.id)
+
+    // Then
+    #expect(navigation == nil)
+    #expect(!model.conversationSearchPresented)
+    #expect(model.conversationSearchText.isEmpty)
+    #expect(model.selectedMessageIDs.isEmpty)
+    #expect(model.targetMessageID == sourceID)
+    #expect(model.conversationAnchorMessageID == sourceID)
 }
 
 @MainActor

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -341,6 +341,7 @@ private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: Quot
 @Test func sendResponseValidationRequiresTheCommittedMessage() throws {
     // Given
     let committed = Data(#"{"result":{"type":"newChatItems","chatItems":[{"chatItem":{"meta":{"itemId":9}}}]}}"#.utf8)
+    let committedReply = Data(#"{"result":{"type":"newChatItems","chatItems":[{"chatItem":{"meta":{"itemId":9},"quotedItem":{"itemId":42}}}]}}"#.utf8)
     let missingItem = Data(#"{"result":{"type":"newChatItems","chatItems":[]}}"#.utf8)
     let wrongResult = Data(#"{"result":{"type":"cmdOk"}}"#.utf8)
 
@@ -350,6 +351,18 @@ private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: Quot
         expectedType: "newChatItems",
         requireChatItems: true
     )
+    #expect(try NativeChatParser.validateSendResponse(
+        committedReply,
+        quotedItemID: 42
+    ).replyContextConfirmed)
+    #expect(try !NativeChatParser.validateSendResponse(
+        committed,
+        quotedItemID: 42
+    ).replyContextConfirmed)
+    #expect(try NativeChatParser.validateSendResponse(
+        committed,
+        quotedItemID: nil
+    ).replyContextConfirmed)
     #expect(throws: NativeChatError.self) {
         try NativeChatParser.validateCommandResponse(
             missingItem,
@@ -1769,7 +1782,11 @@ private actor AttachmentSendProbe {
         self.failingRequest = failingRequest
     }
 
-    func send(_ attachment: PendingAttachment, caption: String, quotedItemID: Int64?) throws {
+    func send(
+        _ attachment: PendingAttachment,
+        caption: String,
+        quotedItemID: Int64?
+    ) throws -> NativeSendReceipt {
         requests.append(Request(
             attachmentID: attachment.id,
             caption: caption,
@@ -1778,6 +1795,7 @@ private actor AttachmentSendProbe {
         if requests.count == failingRequest {
             throw NativeChatError.unavailable("The attachment could not be sent.")
         }
+        return .confirmed
     }
 
     func recordedRequests() -> [Request] {
@@ -1804,8 +1822,9 @@ private actor ReplyValidationProbe {
         released = true
     }
 
-    func recordSend() {
+    func recordSend() -> NativeSendReceipt {
         sendCount += 1
+        return .confirmed
     }
 
     func recordedSendCount() -> Int {
@@ -1824,7 +1843,7 @@ private actor DelayedTextSendProbe {
         self.cancelAfterSuccess = cancelAfterSuccess
     }
 
-    func send() async throws {
+    func send() async throws -> NativeSendReceipt {
         requested = true
         while !released { await Task.yield() }
         if let failureMessage {
@@ -1833,6 +1852,7 @@ private actor DelayedTextSendProbe {
         if cancelAfterSuccess {
             withUnsafeCurrentTask { $0?.cancel() }
         }
+        return .confirmed
     }
 
     func waitUntilRequested() async {
@@ -1935,6 +1955,32 @@ private func unavailableVersion(of message: NativeMessage) -> NativeMessage {
     #expect(model.draft.isEmpty)
     #expect(model.replyingTo == nil)
     #expect(model.replyContextError == nil)
+    #expect(model.phase == .ready)
+    #expect(!model.isSending)
+}
+
+@MainActor
+@Test func committedMessageWithoutTheRequestedQuoteIsNotRetried() async throws {
+    // Given
+    let original = NativePreviewData.messages(for: "@1")[0]
+    let model = makeSendTestModel(sendTextOperation: { _, quotedItemID, _ in
+        #expect(quotedItemID == original.id)
+        withUnsafeCurrentTask { $0?.cancel() }
+        return NativeSendReceipt(replyContextConfirmed: false)
+    })
+    model.messages = [original]
+    model.draft = "Send this once"
+    model.beginReply(to: original)
+
+    // When
+    model.sendDraft()
+    let send = try #require(model.sendTask)
+    await send.value
+
+    // Then: the committed message stays committed, while the UI reports the missing link.
+    #expect(model.draft.isEmpty)
+    #expect(model.replyingTo == nil)
+    #expect(model.replyContextError == "Your message was sent, but SimpleX could not link it to the original message.")
     #expect(model.phase == .ready)
     #expect(!model.isSending)
 }
@@ -2058,6 +2104,7 @@ private func unavailableVersion(of message: NativeMessage) -> NativeMessage {
     // Given
     let model = makeSendTestModel(sendAttachmentOperation: { _, _, _, _ in
         withUnsafeCurrentTask { $0?.cancel() }
+        return .confirmed
     })
     let original = try #require(model.messages.first)
     let attachments = ["sent.jpg", "unsent.jpg"].map {
@@ -2083,6 +2130,41 @@ private func unavailableVersion(of message: NativeMessage) -> NativeMessage {
     #expect(model.pendingAttachments == [attachments[1]])
     #expect(model.draft == "Keep for the unsent item")
     #expect(model.replyingTo == nil)
+    #expect(model.phase == .ready)
+    #expect(!model.isSending)
+}
+
+@MainActor
+@Test func committedAttachmentWithoutTheRequestedQuoteIsRemovedFromTheTray() async throws {
+    // Given
+    let attachment = PendingAttachment(
+        id: UUID(),
+        url: URL(fileURLWithPath: "/tmp/committed-photo.jpg"),
+        fileName: "committed-photo.jpg",
+        kind: .image,
+        byteCount: 10,
+        previewImage: nil
+    )
+    let model = makeSendTestModel(sendAttachmentOperation: { _, _, quotedItemID, _ in
+        #expect(quotedItemID != nil)
+        withUnsafeCurrentTask { $0?.cancel() }
+        return NativeSendReceipt(replyContextConfirmed: false)
+    })
+    let original = try #require(model.messages.first)
+    model.pendingAttachments = [attachment]
+    model.draft = "Committed caption"
+    model.beginReply(to: original)
+
+    // When
+    model.sendDraft()
+    let send = try #require(model.sendTask)
+    await send.value
+
+    // Then: neither the file nor its caption can be sent a second time.
+    #expect(model.pendingAttachments.isEmpty)
+    #expect(model.draft.isEmpty)
+    #expect(model.replyingTo == nil)
+    #expect(model.replyContextError == "Your message was sent, but SimpleX could not link it to the original message.")
     #expect(model.phase == .ready)
     #expect(!model.isSending)
 }
@@ -2121,6 +2203,7 @@ private func unavailableVersion(of message: NativeMessage) -> NativeMessage {
     // Given
     let model = makeSendTestModel(sendAttachmentOperation: { _, _, _, _ in
         try Task.checkCancellation()
+        return .confirmed
     })
     let original = try #require(model.messages.first)
     let originAttachments = ["one.jpg", "two.jpg"].map {
@@ -2187,6 +2270,7 @@ private func unavailableVersion(of message: NativeMessage) -> NativeMessage {
     // Given
     let model = makeSendTestModel(sendTextOperation: { _, _, _ in
         try Task.checkCancellation()
+        return .confirmed
     })
     let replyTarget = try #require(model.messages.first)
     let unrelatedMessage = try #require(model.messages.dropFirst().first)

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -107,6 +107,150 @@ import Testing
     #expect(model.pendingAttachments == [attachment])
 }
 
+private actor AttachmentSendProbe {
+    struct Request: Sendable {
+        let attachmentID: PendingAttachment.ID
+        let caption: String
+        let quotedItemID: Int64?
+    }
+
+    private let failingRequest: Int?
+    private var requests: [Request] = []
+
+    init(failingRequest: Int? = nil) {
+        self.failingRequest = failingRequest
+    }
+
+    func send(_ attachment: PendingAttachment, caption: String, quotedItemID: Int64?) throws {
+        requests.append(Request(
+            attachmentID: attachment.id,
+            caption: caption,
+            quotedItemID: quotedItemID
+        ))
+        if requests.count == failingRequest {
+            throw NativeChatError.unavailable("The attachment could not be sent.")
+        }
+    }
+
+    func recordedRequests() -> [Request] {
+        requests
+    }
+}
+
+@MainActor
+private func makeSendTestModel(
+    sendTextOperation: SendTextOperation? = nil,
+    sendAttachmentOperation: SendAttachmentOperation? = nil
+) -> AppModel {
+    let model = AppModel(
+        previewMode: true,
+        sendTextOperation: sendTextOperation,
+        sendAttachmentOperation: sendAttachmentOperation
+    )
+    return model
+}
+
+@MainActor
+@Test func partialAttachmentFailureKeepsOnlyUnsentItemsAndDoesNotRepeatTheQuote() async throws {
+    // Given
+    let probe = AttachmentSendProbe(failingRequest: 2)
+    let model = makeSendTestModel(sendAttachmentOperation: { attachment, caption, quotedItemID, _ in
+        try await probe.send(attachment, caption: caption, quotedItemID: quotedItemID)
+    })
+    let original = try #require(model.messages.first)
+    let attachments = ["one.jpg", "two.jpg"].map {
+        PendingAttachment(
+            id: UUID(),
+            url: URL(fileURLWithPath: "/tmp/\($0)"),
+            fileName: $0,
+            kind: .image,
+            byteCount: 10,
+            previewImage: nil
+        )
+    }
+    model.pendingAttachments = attachments
+    model.draft = "Batch caption"
+    model.beginReply(to: original)
+
+    // When
+    model.sendDraft()
+    let send = try #require(model.sendTask)
+    await send.value
+
+    // Then
+    let requests = await probe.recordedRequests()
+    #expect(requests.map(\.attachmentID) == attachments.map(\.id))
+    #expect(requests.map(\.quotedItemID) == [original.id, nil])
+    #expect(requests.map(\.caption) == ["", "Batch caption"])
+    #expect(model.pendingAttachments == [attachments[1]])
+    #expect(model.draft == "Batch caption")
+    #expect(model.replyingTo == nil)
+    #expect(!model.isSending)
+}
+
+@MainActor
+@Test func cancellationAfterCoreSuccessCommitsTheSentAttachmentBeforeStopping() async throws {
+    // Given
+    let model = makeSendTestModel(sendAttachmentOperation: { _, _, _, _ in
+        withUnsafeCurrentTask { $0?.cancel() }
+    })
+    let original = try #require(model.messages.first)
+    let attachments = ["sent.jpg", "unsent.jpg"].map {
+        PendingAttachment(
+            id: UUID(),
+            url: URL(fileURLWithPath: "/tmp/\($0)"),
+            fileName: $0,
+            kind: .image,
+            byteCount: 10,
+            previewImage: nil
+        )
+    }
+    model.pendingAttachments = attachments
+    model.draft = "Keep for the unsent item"
+    model.beginReply(to: original)
+
+    // When
+    model.sendDraft()
+    let send = try #require(model.sendTask)
+    await send.value
+
+    // Then
+    #expect(model.pendingAttachments == [attachments[1]])
+    #expect(model.draft == "Keep for the unsent item")
+    #expect(model.replyingTo == nil)
+    #expect(model.phase == .ready)
+    #expect(!model.isSending)
+}
+
+@MainActor
+@Test func offscreenSendFailureRestoresItsComposerAndWaitsToShowTheError() async throws {
+    // Given
+    let failure = "The reply could not be sent."
+    let model = makeSendTestModel(sendTextOperation: { _, _, _ in
+        throw NativeChatError.unavailable(failure)
+    })
+    let original = try #require(model.messages.first)
+    model.draft = "Retry this reply"
+    model.beginReply(to: original)
+
+    // When
+    model.sendDraft()
+    let send = try #require(model.sendTask)
+    model.selectChat("#2")
+    await send.value
+
+    // Then
+    #expect(model.phase == .ready)
+    #expect(model.draft.isEmpty)
+    #expect(model.replyingTo == nil)
+    #expect(!model.isSending)
+
+    model.selectChat("@1")
+    #expect(model.phase == .failed(failure))
+    #expect(model.draft == "Retry this reply")
+    #expect(model.replyingTo?.id == original.id)
+}
+
 @MainActor
 @Test func deletionCompletionCannotReplaceAnotherChatsTranscript() async throws {
     // Given

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -334,6 +334,55 @@ private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: Quot
     }
 }
 
+@Test func replyAndQuoteAuthorsRespectGroupSendingIdentity() {
+    // Given
+    let direct = NativeChat(
+        id: "@7",
+        apiID: 7,
+        kind: .direct,
+        displayName: "Maya",
+        image: nil,
+        preview: "",
+        timestamp: nil,
+        unreadCount: 0,
+        sendAsGroup: false
+    )
+    let ordinaryGroup = NativeChat(
+        id: "#8",
+        apiID: 8,
+        kind: .group,
+        displayName: "Friends",
+        image: nil,
+        preview: "",
+        timestamp: nil,
+        unreadCount: 0,
+        sendAsGroup: false
+    )
+    let channel = NativeChat(
+        id: "#9",
+        apiID: 9,
+        kind: .group,
+        displayName: "Announcements",
+        image: nil,
+        preview: "",
+        timestamp: nil,
+        unreadCount: 0,
+        sendAsGroup: true
+    )
+
+    // When / Then: outgoing direct and ordinary group messages belong to the user.
+    #expect(direct.displayedMessageAuthor(sent: true, author: "Local profile") == "You")
+    #expect(ordinaryGroup.displayedMessageAuthor(sent: true, author: "Local profile") == "You")
+
+    // Channel-owner messages use the public group identity in both reply surfaces.
+    #expect(channel.displayedMessageAuthor(sent: true, author: "Local profile") == "Announcements")
+
+    // Incoming group authors remain specific, with the conversation name as a safe fallback.
+    #expect(ordinaryGroup.displayedMessageAuthor(sent: false, author: "Jordan") == "Jordan")
+    #expect(direct.displayedMessageAuthor(sent: false, author: nil) == "Maya")
+    #expect(direct.displayedMessageAuthor(sent: false, author: "  ") == "Maya")
+}
+
 @Test func coreRejectsQuotedMessagesInNonReplyableConversations() {
     // Given
     let message = SimpleXCore.composedMessage(

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -196,23 +196,45 @@ private func parserLimitsRepliesToAvailableMessages(testCase: ReplyEligibilityCa
 
 private struct QuotedAttachmentCase: Sendable, CustomTestStringConvertible {
     let contentType: String
+    let additionalContent: String
     let expectedPreview: String
+    let expectedVisual: NativeReplyContextVisual
 
     var testDescription: String { contentType }
 }
 
 private let quotedAttachmentCases = [
-    QuotedAttachmentCase(contentType: "image", expectedPreview: "Photo"),
-    QuotedAttachmentCase(contentType: "video", expectedPreview: "Video"),
-    QuotedAttachmentCase(contentType: "voice", expectedPreview: "Voice message"),
-    QuotedAttachmentCase(contentType: "file", expectedPreview: "File"),
+    QuotedAttachmentCase(
+        contentType: "image",
+        additionalContent: ",\"image\":\"quoted-photo-preview\"",
+        expectedPreview: "Photo",
+        expectedVisual: .image("quoted-photo-preview")
+    ),
+    QuotedAttachmentCase(
+        contentType: "video",
+        additionalContent: ",\"image\":\"quoted-video-preview\"",
+        expectedPreview: "Video",
+        expectedVisual: .video("quoted-video-preview")
+    ),
+    QuotedAttachmentCase(
+        contentType: "voice",
+        additionalContent: "",
+        expectedPreview: "Voice message",
+        expectedVisual: .voice
+    ),
+    QuotedAttachmentCase(
+        contentType: "file",
+        additionalContent: "",
+        expectedPreview: "File",
+        expectedVisual: .file
+    ),
 ]
 
 @Test(arguments: quotedAttachmentCases)
 private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: QuotedAttachmentCase) throws {
     // Given
     let json = """
-        {"result":{"type":"apiChat","chat":{"chatItems":[{"chatDir":{"type":"directRcv"},"meta":{"itemId":9,"itemText":"Reply","itemTs":"2026-08-02T20:00:00Z"},"content":{"type":"rcvMsgContent","msgContent":{"type":"text","text":"Reply"}},"quotedItem":{"chatDir":{"type":"directSnd"},"itemId":7,"sentAt":"2026-08-02T19:59:00Z","content":{"type":"\(testCase.contentType)","text":"   "}}}]}}}
+        {"result":{"type":"apiChat","chat":{"chatItems":[{"chatDir":{"type":"directRcv"},"meta":{"itemId":9,"itemText":"Reply","itemTs":"2026-08-02T20:00:00Z"},"content":{"type":"rcvMsgContent","msgContent":{"type":"text","text":"Reply"}},"quotedItem":{"chatDir":{"type":"directSnd"},"itemId":7,"sentAt":"2026-08-02T19:59:00Z","content":{"type":"\(testCase.contentType)","text":"   "\(testCase.additionalContent)}}}]}}}
         """
 
     // When
@@ -220,6 +242,7 @@ private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: Quot
 
     // Then
     #expect(message.quotedItem?.text == testCase.expectedPreview)
+    #expect(message.quotedItem?.visual == testCase.expectedVisual)
 }
 
 @Test func replyPreviewNormalizesCaptionsAndFallsBackForAttachments() {
@@ -1758,6 +1781,21 @@ private actor DelayedAttachmentOpenFailure {
     #expect(sent.quotedItem?.text == original.text)
     #expect(model.replyingTo == nil)
     #expect(model.draft.isEmpty)
+}
+
+@MainActor
+@Test func previewMediaReplyKeepsItsQuoteVisual() throws {
+    let model = AppModel(previewMode: true)
+    let original = try #require(model.messages.first { $0.content.replyContextVisual != nil })
+
+    model.beginReply(to: original)
+    model.draft = "Replying to the photo"
+    model.sendDraft()
+
+    let sent = try #require(model.messages.last)
+    #expect(sent.quotedItem?.messageID == original.id)
+    #expect(sent.quotedItem?.text == original.replyPreview)
+    #expect(sent.quotedItem?.visual == original.content.replyContextVisual)
 }
 
 @MainActor

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -709,6 +709,63 @@ private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: Quot
 }
 
 @MainActor
+@Test func missingOffscreenReplyTargetRetiresOnlyTheQuoteAndKeepsTheDraft() async throws {
+    // Given: the active reply points to an older message outside the visible page.
+    let original = NativePreviewData.messages(for: "@1")[0]
+    let visibleMessages = Array(NativePreviewData.messages(for: "@1").dropFirst())
+    let model = AppModel(
+        previewMode: true,
+        loadMessagesOperation: { chatID, aroundMessageID in
+            #expect(chatID == "@1")
+            #expect(aroundMessageID == original.id)
+            return visibleMessages
+        }
+    )
+    model.draft = "Keep this reply draft"
+    model.beginReply(to: original)
+    model.messages = visibleMessages
+
+    // When: Show Original confirms that the requested target is absent.
+    let navigation = try #require(model.openReplyTarget())
+    await navigation.value
+
+    // Then: only the invalid quote is retired; user content and transcript survive.
+    #expect(model.replyingTo == nil)
+    #expect(model.draft == "Keep this reply draft")
+    #expect(model.messages == visibleMessages)
+    #expect(model.targetMessageID == nil)
+    #expect(model.quoteNavigationError == nil)
+    #expect(model.replyContextError == "The message you were replying to is no longer available. Your draft was kept.")
+}
+
+@MainActor
+@Test func transientReplyTargetLoadFailureKeepsTheQuoteForRetry() async throws {
+    // Given
+    let original = NativePreviewData.messages(for: "@1")[0]
+    let visibleMessages = Array(NativePreviewData.messages(for: "@1").dropFirst())
+    let model = AppModel(
+        previewMode: true,
+        loadMessagesOperation: { _, _ in
+            throw NativeChatError.unavailable("Temporary history failure")
+        }
+    )
+    model.draft = "Do not lose this"
+    model.beginReply(to: original)
+    model.messages = visibleMessages
+
+    // When
+    let navigation = try #require(model.openReplyTarget())
+    await navigation.value
+
+    // Then: an inconclusive load does not claim the original was deleted.
+    #expect(model.replyingTo?.id == original.id)
+    #expect(model.draft == "Do not lose this")
+    #expect(model.messages == visibleMessages)
+    #expect(model.replyContextError == nil)
+    #expect(model.quoteNavigationError == "Temporary history failure")
+}
+
+@MainActor
 @Test func cancellingReplyRetiresItsPendingOriginalMessageNavigation() async throws {
     // Given
     let original = NativePreviewData.messages(for: "@1")[0]

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -252,6 +252,72 @@ private func makeSendTestModel(
 }
 
 @MainActor
+@Test func inFlightSendLocksOnlyItsOriginatingComposer() async throws {
+    // Given
+    let model = makeSendTestModel(sendAttachmentOperation: { _, _, _, _ in
+        try Task.checkCancellation()
+    })
+    let original = try #require(model.messages.first)
+    let originAttachments = ["one.jpg", "two.jpg"].map {
+        PendingAttachment(
+            id: UUID(),
+            url: URL(fileURLWithPath: "/tmp/\($0)"),
+            fileName: $0,
+            kind: .image,
+            byteCount: 10,
+            previewImage: nil
+        )
+    }
+    model.pendingAttachments = originAttachments
+    model.draft = "Origin caption"
+    model.beginReply(to: original)
+
+    // When
+    model.sendDraft()
+    let send = try #require(model.sendTask)
+
+    // Then: the originating composer cannot discard in-flight state.
+    #expect(model.isSendingSelectedChat)
+    #expect(model.sendingChatID == "@1")
+    model.cancelReply()
+    model.removeAttachment(originAttachments[0].id)
+    model.dismissNearestState()
+    #expect(model.replyingTo?.id == original.id)
+    #expect(model.pendingAttachments == originAttachments)
+
+    // When: another conversation becomes active.
+    model.selectChat("#2")
+    let groupMessage = try #require(model.messages.first)
+    let otherAttachment = PendingAttachment(
+        id: UUID(),
+        url: URL(fileURLWithPath: "/tmp/other.jpg"),
+        fileName: "other.jpg",
+        kind: .image,
+        byteCount: 10,
+        previewImage: nil
+    )
+
+    // Then: its reply and attachment controls remain available.
+    #expect(!model.isSendingSelectedChat)
+    model.beginReply(to: groupMessage)
+    #expect(model.replyingTo?.id == groupMessage.id)
+    model.pendingAttachments = [otherAttachment]
+    model.removeAttachment(otherAttachment.id)
+    #expect(model.pendingAttachments.isEmpty)
+
+    // Cleanup and verify the originating composer survives cancellation.
+    send.cancel()
+    await send.value
+    #expect(!model.isSending)
+    #expect(model.sendingChatID == nil)
+
+    model.selectChat("@1")
+    #expect(model.draft == "Origin caption")
+    #expect(model.pendingAttachments == originAttachments)
+    #expect(model.replyingTo?.id == original.id)
+}
+
+@MainActor
 @Test func deletionCompletionCannotReplaceAnotherChatsTranscript() async throws {
     // Given
     let deletedChatMessages = Array(NativePreviewData.messages(for: "@1").dropFirst())

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -111,6 +111,199 @@ private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: Quot
     #expect(ordinary["quotedItemId"] == nil)
 }
 
+@Test func singleMessageReloadUsesTheCoreQuoteResolutionPagination() {
+    // Given / When
+    let command = SimpleXCore.chatPageCommand(chatID: "@42", around: 91, count: 0)
+
+    // Then
+    #expect(command == "/_get chat @42 around=91 count=0")
+}
+
+@Test func encryptedBytesAreNotMistakenForAPlainJPEG() {
+    // Given
+    let encryptedHeader = Data([0x6a, 0xbd, 0xf4, 0x48, 0x36, 0x31, 0xf0, 0x54])
+    let jpegHeader = Data([0xff, 0xd8, 0xff, 0xe0])
+
+    // When / Then
+    #expect(!SimpleXCore.imageHeaderIsReadable(encryptedHeader, fileName: "photo.jpg"))
+    #expect(SimpleXCore.imageHeaderIsReadable(jpegHeader, fileName: "photo.jpg"))
+}
+
+@Test func attachmentFallbackNamesKeepTheStoredFileExtension() {
+    // Given / When / Then
+    #expect(SimpleXCore.openedFileName(
+        preferredName: "Photo",
+        sourcePath: "IMG_20260802_145258.jpg"
+    ) == "IMG_20260802_145258.jpg")
+    #expect(SimpleXCore.openedFileName(
+        preferredName: "holiday.jpg",
+        sourcePath: "encrypted.bin"
+    ) == "holiday.jpg")
+}
+
+@Test func encryptedJPEGWithoutMetadataIsRejectedBeforeOpeningPreview() async throws {
+    // Given
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let sourceURL = directory.appendingPathComponent("photo.jpg")
+    try Data([0x6a, 0xbd, 0xf4, 0x48, 0x36, 0x31, 0xf0, 0x54]).write(to: sourceURL)
+    let source = NativeCryptoFile(filePath: sourceURL.path, cryptoArgs: nil)
+
+    // When / Then
+    do {
+        _ = try await SimpleXCore().openableURL(for: source, fileName: "photo.jpg")
+        Issue.record("Ciphertext should not be handed to Preview as a JPEG.")
+    } catch let error as NativeChatError {
+        #expect(error.localizedDescription.contains("still be encrypted or incomplete"))
+    }
+}
+
+@MainActor
+@Test func unresolvedQuoteReloadsItsContainingMessageBeforeNavigating() async throws {
+    // Given
+    let target = NativePreviewData.messages(for: "@1")[0]
+    let unresolvedQuote = NativeQuote(messageID: nil, text: target.text, sent: target.sent, author: target.author)
+    let containingMessage = NativeMessage(
+        id: 90,
+        text: "Reply",
+        timestamp: nil,
+        sent: true,
+        author: nil,
+        deletable: true,
+        content: .text,
+        quotedItem: unresolvedQuote
+    )
+    let refreshedMessage = NativeMessage(
+        id: containingMessage.id,
+        text: containingMessage.text,
+        timestamp: containingMessage.timestamp,
+        sent: containingMessage.sent,
+        author: containingMessage.author,
+        deletable: containingMessage.deletable,
+        content: containingMessage.content,
+        quotedItem: NativeQuote(
+            messageID: target.id,
+            text: target.text,
+            sent: target.sent,
+            author: target.author
+        )
+    )
+    let model = AppModel(
+        previewMode: true,
+        loadMessageOperation: { chatID, itemID in
+            #expect(chatID == "@1")
+            #expect(itemID == containingMessage.id)
+            return refreshedMessage
+        }
+    )
+    model.messages = [target, containingMessage]
+
+    // When
+    let navigation = try #require(model.openQuotedMessage(unresolvedQuote, from: containingMessage.id))
+    await navigation.value
+
+    // Then
+    #expect(model.messages.last?.quotedItem?.messageID == target.id)
+    #expect(model.targetMessageID == target.id)
+    #expect(model.quoteNavigationError == nil)
+}
+
+@MainActor
+@Test func missingQuotedMessageShowsAUsefulError() async throws {
+    // Given
+    let unresolvedQuote = NativeQuote(messageID: nil, text: "Gone", sent: false, author: "Maya")
+    let containingMessage = NativeMessage(
+        id: 91,
+        text: "Reply",
+        timestamp: nil,
+        sent: true,
+        author: nil,
+        deletable: true,
+        content: .text,
+        quotedItem: unresolvedQuote
+    )
+    let model = AppModel(
+        previewMode: true,
+        loadMessageOperation: { _, _ in containingMessage }
+    )
+    model.messages = [containingMessage]
+
+    // When
+    let navigation = try #require(model.openQuotedMessage(unresolvedQuote, from: containingMessage.id))
+    await navigation.value
+
+    // Then
+    #expect(model.targetMessageID == nil)
+    #expect(model.quoteNavigationError == "The original quoted message is no longer available in this conversation.")
+}
+
+private actor AttachmentOpenProbe {
+    private var openedSource: NativeCryptoFile?
+
+    func open(_ source: NativeCryptoFile) {
+        openedSource = source
+    }
+
+    func source() -> NativeCryptoFile? {
+        openedSource
+    }
+}
+
+@MainActor
+@Test func attachmentOpenRefreshesMissingEncryptionMetadata() async throws {
+    // Given
+    let plainSource = NativeCryptoFile(filePath: "photo.jpg", cryptoArgs: nil)
+    let encryptedSource = NativeCryptoFile(
+        filePath: "photo.jpg",
+        cryptoArgs: NativeCryptoFileArgs(fileKey: "key", fileNonce: "nonce")
+    )
+    let original = NativeMessage(
+        id: 92,
+        text: "Photo",
+        timestamp: nil,
+        sent: false,
+        author: "Maya",
+        deletable: true,
+        content: .image(preview: nil, fileName: "photo.jpg"),
+        fileSource: plainSource
+    )
+    let refreshed = NativeMessage(
+        id: original.id,
+        text: original.text,
+        timestamp: original.timestamp,
+        sent: original.sent,
+        author: original.author,
+        deletable: original.deletable,
+        content: original.content,
+        fileSource: encryptedSource
+    )
+    let probe = AttachmentOpenProbe()
+    let model = AppModel(
+        previewMode: true,
+        loadMessageOperation: { chatID, itemID in
+            #expect(chatID == "@1")
+            #expect(itemID == original.id)
+            return refreshed
+        },
+        openAttachmentOperation: { source, _ in
+            await probe.open(source)
+        }
+    )
+    model.messages = [original]
+
+    // When
+    let opening = try #require(model.openAttachment(original))
+    await opening.value
+
+    // Then
+    #expect(await probe.source() == encryptedSource)
+    #expect(model.messages.first?.fileSource == encryptedSource)
+    #expect(model.attachmentOpenError == nil)
+    #expect(model.openingAttachmentIDs.isEmpty)
+}
+
 @MainActor
 @Test func replyComposerSendsAndClearsQuotedContext() throws {
     let model = AppModel(previewMode: true)

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -18,6 +18,26 @@ import Testing
     #expect(SingleInstanceGuard(lockURL: lockURL) != nil)
 }
 
+@Test func processLockYieldsToALegacyFrontendThatDoesNotOwnTheLock() throws {
+    // Given: an older build is already registered with macOS but predates the lock file.
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let lockURL = directory.appendingPathComponent("simplex-native.lock")
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    // When / Then: the new process releases the lock and yields to the legacy process.
+    #expect(SingleInstanceGuard(
+        lockURL: lockURL,
+        otherApplicationRunning: { true }
+    ) == nil)
+
+    // And: the rejected launch did not strand the lock for the next clean launch.
+    #expect(SingleInstanceGuard(
+        lockURL: lockURL,
+        otherApplicationRunning: { false }
+    ) != nil)
+}
+
 @Test func parsesDesktopChatListResponse() throws {
     let json = #"{"result":{"type":"apiChats","user":{"userId":7},"chats":[{"chatInfo":{"type":"direct","contact":{"contactId":42,"localDisplayName":"Alice","profile":{"displayName":"Alice"}}},"chatItems":[{"meta":{"itemText":"Hello","itemTs":"2026-08-02T20:00:00Z"}}],"chatStats":{"unreadCount":2}}]}}"#
     let chats = try NativeChatParser.chats(from: Data(json.utf8))

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -715,6 +715,9 @@ private func makeLiveRefreshModel(probe: ConversationRefreshProbe) -> AppModel {
     #expect(!model.canDeleteSelectedMessages)
     #expect(!model.canNavigateConversationHistory)
     #expect(!model.canRefreshConversation)
+    #expect(!model.canReply(to: target))
+    model.beginReply(to: target)
+    #expect(model.replyingTo == nil)
     model.sendDraft()
     model.requestDeleteSelectedMessages()
     #expect(model.sendTask == nil)
@@ -736,6 +739,7 @@ private func makeLiveRefreshModel(probe: ConversationRefreshProbe) -> AppModel {
     #expect(model.canDeleteSelectedMessages)
     #expect(model.canNavigateConversationHistory)
     #expect(model.canRefreshConversation)
+    #expect(model.canReply(to: target))
     #expect(model.messages == originalMessages)
 }
 
@@ -1992,6 +1996,118 @@ private func unavailableVersion(of message: NativeMessage) -> NativeMessage {
 }
 
 @MainActor
+@Test func newerReplyCancelsAnOlderOffscreenQuotePageLoad() async throws {
+    // Given
+    let originalMessages = NativePreviewData.messages(for: "@1")
+    let replyTarget = try #require(originalMessages.first)
+    let offscreenTarget = NativeMessage(
+        id: 9_701,
+        text: "Older offscreen quote destination",
+        timestamp: nil,
+        sent: false,
+        author: "Maya",
+        deletable: true,
+        content: .text
+    )
+    let probe = DelayedValue([offscreenTarget])
+    let model = AppModel(
+        previewMode: true,
+        loadMessagesOperation: { chatID, aroundMessageID in
+            #expect(chatID == "@1")
+            #expect(aroundMessageID == offscreenTarget.id)
+            return await probe.load()
+        }
+    )
+    model.messages = originalMessages
+    let quote = NativeQuote(
+        messageID: offscreenTarget.id,
+        text: offscreenTarget.text,
+        sent: offscreenTarget.sent,
+        author: offscreenTarget.author
+    )
+
+    // When: an offscreen quote page is loading, then Reply becomes the newer intent.
+    let navigation = try #require(model.openQuotedMessage(quote, from: 9_702))
+    await probe.waitUntilRequested()
+    #expect(model.isLoadingConversation)
+    model.beginReply(to: replyTarget)
+
+    // Then: Reply immediately keeps the visible transcript and owns the composer.
+    #expect(model.replyingTo?.id == replyTarget.id)
+    #expect(model.messages == originalMessages)
+    #expect(!model.isLoadingConversation)
+
+    // When: the cancelled page loader eventually returns.
+    await probe.release()
+    await navigation.value
+
+    // Then: it cannot replace the transcript or steal scroll focus.
+    #expect(model.replyingTo?.id == replyTarget.id)
+    #expect(model.messages == originalMessages)
+    #expect(model.targetMessageID == nil)
+    #expect(model.conversationAnchorMessageID == nil)
+}
+
+@MainActor
+@Test func newerReplyCancelsOlderUnresolvedQuoteMetadata() async throws {
+    // Given
+    let replyTarget = NativePreviewData.messages(for: "@1")[0]
+    let unresolvedQuote = NativeQuote(messageID: nil, text: "Older unresolved quote", sent: false, author: "Maya")
+    let containingMessage = NativeMessage(
+        id: 9_703,
+        text: "Reply with delayed metadata",
+        timestamp: nil,
+        sent: true,
+        author: nil,
+        deletable: true,
+        content: .text,
+        quotedItem: unresolvedQuote
+    )
+    let refreshedMessage = NativeMessage(
+        id: containingMessage.id,
+        text: containingMessage.text,
+        timestamp: containingMessage.timestamp,
+        sent: containingMessage.sent,
+        author: containingMessage.author,
+        deletable: containingMessage.deletable,
+        content: containingMessage.content,
+        quotedItem: NativeQuote(
+            messageID: replyTarget.id,
+            text: replyTarget.text,
+            sent: replyTarget.sent,
+            author: replyTarget.author
+        )
+    )
+    let probe = DelayedValue<NativeMessage?>(refreshedMessage)
+    let model = AppModel(
+        previewMode: true,
+        loadMessageOperation: { _, _ in await probe.load() }
+    )
+    let originalMessages = [replyTarget, containingMessage]
+    model.messages = originalMessages
+
+    // When: metadata resolution is pending, then the user chooses a visible reply target.
+    let navigation = try #require(model.openQuotedMessage(unresolvedQuote, from: containingMessage.id))
+    await probe.waitUntilRequested()
+    #expect(model.quoteNavigationTask != nil)
+    model.beginReply(to: replyTarget)
+
+    // Then: the newer reply retires the unresolved navigation immediately.
+    #expect(model.replyingTo?.id == replyTarget.id)
+    #expect(model.quoteNavigationTask == nil)
+
+    // When: the cancelled metadata request returns.
+    await probe.release()
+    await navigation.value
+
+    // Then: it cannot update the old row or jump the transcript.
+    #expect(model.replyingTo?.id == replyTarget.id)
+    #expect(model.messages == originalMessages)
+    #expect(model.targetMessageID == nil)
+    #expect(model.quoteNavigationError == nil)
+}
+
+@MainActor
 @Test func inFlightSendBlocksQuotedHistoryNavigation() async throws {
     // Given
     let failure = "The delayed send failed."
@@ -2059,6 +2175,7 @@ private actor DelayedDeletionProbe {
         deleteMessagesOperation: { _, _ in try await probe.delete() }
     )
     let target = try #require(model.messages.first)
+    let unrelatedMessage = try #require(model.messages.dropFirst().first)
     model.draft = "Keep this reply"
     model.beginReply(to: target)
     model.selectMessage(target.id, modifiers: [])
@@ -2072,6 +2189,9 @@ private actor DelayedDeletionProbe {
     #expect(!model.canSendDraft)
     #expect(!model.canNavigateConversationHistory)
     #expect(!model.canRefreshConversation)
+    #expect(!model.canReply(to: unrelatedMessage))
+    model.beginReply(to: unrelatedMessage)
+    #expect(model.replyingTo?.id == target.id)
     let quote = NativeQuote(messageID: target.id, text: target.text, sent: target.sent, author: target.author)
     #expect(model.openQuotedMessage(quote, from: 910) == nil)
     #expect(model.targetMessageID == nil)
@@ -2086,6 +2206,7 @@ private actor DelayedDeletionProbe {
     #expect(model.replyingTo?.id == target.id)
     #expect(model.draft == "Keep this reply")
     #expect(model.canSendDraft)
+    #expect(model.canReply(to: unrelatedMessage))
     #expect(model.phase == .failed(failure))
 }
 

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -318,6 +318,41 @@ private func makeSendTestModel(
 }
 
 @MainActor
+@Test func inFlightReplyTargetCannotBeDeletedUntilTheSendResolves() async throws {
+    // Given
+    let model = makeSendTestModel(sendTextOperation: { _, _, _ in
+        try Task.checkCancellation()
+    })
+    let replyTarget = try #require(model.messages.first)
+    let unrelatedMessage = try #require(model.messages.dropFirst().first)
+    model.draft = "Reply in progress"
+    model.beginReply(to: replyTarget)
+
+    // When
+    model.sendDraft()
+    let send = try #require(model.sendTask)
+    model.selectMessage(replyTarget.id, modifiers: [])
+    model.requestDeleteSelectedMessages()
+
+    // Then: deleting the quoted source cannot strand a failed reply.
+    #expect(!model.canDeleteSelectedMessages)
+    #expect(!model.showingDeleteConfirmation)
+
+    // When: an unrelated message is selected instead.
+    model.selectMessage(unrelatedMessage.id, modifiers: [])
+
+    // Then: unrelated deletion remains available.
+    #expect(model.canDeleteSelectedMessages)
+
+    // Cleanup.
+    send.cancel()
+    await send.value
+    #expect(!model.isSending)
+    model.selectMessage(replyTarget.id, modifiers: [])
+    #expect(model.canDeleteSelectedMessages)
+}
+
+@MainActor
 @Test func deletionCompletionCannotReplaceAnotherChatsTranscript() async throws {
     // Given
     let deletedChatMessages = Array(NativePreviewData.messages(for: "@1").dropFirst())

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -315,6 +315,105 @@ private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: Quot
     #expect(model.quoteNavigationError == "The original quoted message is no longer available in this conversation.")
 }
 
+@MainActor
+@Test func offscreenQuotedMessageLoadsItsPageBeforeScrolling() async throws {
+    // Given
+    let target = NativeMessage(
+        id: 900,
+        text: "Original offscreen message",
+        timestamp: nil,
+        sent: false,
+        author: "Maya",
+        deletable: true,
+        content: .text
+    )
+    let quote = NativeQuote(messageID: target.id, text: target.text, sent: target.sent, author: target.author)
+    let model = AppModel(
+        previewMode: true,
+        loadMessagesOperation: { chatID, aroundMessageID in
+            #expect(chatID == "@1")
+            #expect(aroundMessageID == target.id)
+            return [target]
+        }
+    )
+    #expect(!model.messages.contains(where: { $0.id == target.id }))
+
+    // When
+    let navigation = try #require(model.openQuotedMessage(quote, from: 901))
+    await navigation.value
+
+    // Then
+    #expect(model.messages == [target])
+    #expect(model.targetMessageID == target.id)
+    #expect(model.quoteNavigationError == nil)
+    #expect(model.phase == .ready)
+}
+
+@MainActor
+@Test func deletedOffscreenQuoteShowsLocalErrorWithoutBreakingConversation() async throws {
+    // Given
+    let quote = NativeQuote(messageID: 902, text: "Deleted original", sent: false, author: "Maya")
+    let model = AppModel(
+        previewMode: true,
+        loadMessagesOperation: { _, _ in
+            throw NativeChatError.unavailable("The core no longer has this item.")
+        }
+    )
+    let originalMessages = model.messages
+
+    // When
+    let navigation = try #require(model.openQuotedMessage(quote, from: 903))
+    await navigation.value
+
+    // Then
+    #expect(model.messages == originalMessages)
+    #expect(model.targetMessageID == nil)
+    #expect(model.quoteNavigationError == "The original quoted message is no longer available in this conversation.")
+    #expect(model.phase == .ready)
+}
+
+private actor DelayedConversationLoadFailure {
+    private var requested = false
+    private var released = false
+
+    func load() async throws -> [NativeMessage] {
+        requested = true
+        while !released { await Task.yield() }
+        throw NativeChatError.unavailable("The old conversation load failed late.")
+    }
+
+    func waitUntilRequested() async {
+        while !requested { await Task.yield() }
+    }
+
+    func release() {
+        released = true
+    }
+}
+
+@MainActor
+@Test func offscreenQuoteFailureCannotLeakIntoANewConversation() async throws {
+    // Given
+    let probe = DelayedConversationLoadFailure()
+    let quote = NativeQuote(messageID: 904, text: "Old conversation", sent: false, author: "Maya")
+    let model = AppModel(
+        previewMode: true,
+        loadMessagesOperation: { _, _ in try await probe.load() }
+    )
+
+    // When: quote loading begins, then the user switches chats before it fails.
+    let navigation = try #require(model.openQuotedMessage(quote, from: 905))
+    await probe.waitUntilRequested()
+    model.selectChat("#2")
+    await probe.release()
+    await navigation.value
+
+    // Then: the stale failure is ignored in the newly selected conversation.
+    #expect(model.selectedChatID == "#2")
+    #expect(model.quoteNavigationError == nil)
+    #expect(model.phase == .ready)
+}
+
 private actor AttachmentOpenProbe {
     private var openedSource: NativeCryptoFile?
 

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -514,6 +514,24 @@ private actor FallbackRefreshProbe {
     }
 }
 
+private actor LatestNavigationProbe {
+    private let latestMessages: [NativeMessage]
+    private var requests: [Int64?] = []
+
+    init(latestMessages: [NativeMessage]) {
+        self.latestMessages = latestMessages
+    }
+
+    func load(around messageID: Int64?) -> [NativeMessage] {
+        requests.append(messageID)
+        return latestMessages
+    }
+
+    func recordedRequests() -> [Int64?] {
+        requests
+    }
+}
+
 @MainActor
 private func makeLiveRefreshModel(probe: ConversationRefreshProbe) -> AppModel {
     let model = AppModel(
@@ -634,6 +652,72 @@ private func makeLiveRefreshModel(probe: ConversationRefreshProbe) -> AppModel {
     #expect(model.messages == latestMessages)
     #expect(model.quoteNavigationError == nil)
     #expect(model.phase == .ready)
+}
+
+@MainActor
+@Test func jumpToLatestLeavesQuotedHistoryAndScrollsToTheNewestMessage() async throws {
+    // Given
+    let target = NativePreviewData.messages(for: "@1")[0]
+    let latestMessages = Array(NativePreviewData.messages(for: "@1").dropFirst())
+    let probe = LatestNavigationProbe(latestMessages: latestMessages)
+    let model = AppModel(
+        previewMode: true,
+        loadMessagesOperation: { _, aroundMessageID in
+            await probe.load(around: aroundMessageID)
+        }
+    )
+    model.messages = [target]
+    let quote = NativeQuote(
+        messageID: target.id,
+        text: target.text,
+        sent: target.sent,
+        author: target.author
+    )
+    #expect(model.openQuotedMessage(quote, from: 915) == nil)
+    #expect(model.isViewingConversationHistory)
+
+    // When
+    let navigation = try #require(model.jumpToLatest())
+    await navigation.value
+
+    // Then
+    let requests = await probe.recordedRequests()
+    #expect(requests == [nil])
+    #expect(!model.isViewingConversationHistory)
+    #expect(model.conversationAnchorMessageID == nil)
+    #expect(model.messages == latestMessages)
+    #expect(model.targetMessageID == latestMessages.last?.id)
+    #expect(model.phase == .ready)
+}
+
+@MainActor
+@Test func failedJumpToLatestKeepsTheCurrentQuotedHistoryPage() async throws {
+    // Given
+    let target = NativePreviewData.messages(for: "@1")[0]
+    let model = AppModel(
+        previewMode: true,
+        loadMessagesOperation: { _, _ in
+            throw NativeChatError.unavailable("The newest messages could not be loaded.")
+        }
+    )
+    model.messages = [target]
+    let quote = NativeQuote(
+        messageID: target.id,
+        text: target.text,
+        sent: target.sent,
+        author: target.author
+    )
+    #expect(model.openQuotedMessage(quote, from: 916) == nil)
+
+    // When
+    let navigation = try #require(model.jumpToLatest())
+    await navigation.value
+
+    // Then
+    #expect(model.isViewingConversationHistory)
+    #expect(model.conversationAnchorMessageID == target.id)
+    #expect(model.messages == [target])
+    #expect(model.phase == .failed("The newest messages could not be loaded."))
 }
 
 @MainActor

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -608,6 +608,10 @@ private actor ConversationRefreshProbe {
         while requests.isEmpty { await Task.yield() }
     }
 
+    func waitUntilRequestCount(_ count: Int) async {
+        while requests.count < count { await Task.yield() }
+    }
+
     func releaseFirstRequest() {
         firstRequestReleased = true
     }
@@ -2268,6 +2272,128 @@ private actor DelayedDeletionProbe {
 
     model.selectChat("@1")
     #expect(model.replyingTo?.id == original.id)
+}
+
+@MainActor
+@Test func sameChatNotificationWaitsForAFailedSendToReleaseTheTranscript() async throws {
+    // Given
+    let failure = "The delayed send failed."
+    let probe = DelayedTextSendProbe(failureMessage: failure)
+    let model = makeSendTestModel(sendTextOperation: { _, _, _ in try await probe.send() })
+    let target = try #require(model.messages.last)
+    model.draft = "Keep this draft if sending fails"
+
+    // When: a notification for the selected chat arrives during the send.
+    model.sendDraft()
+    let send = try #require(model.sendTask)
+    await probe.waitUntilRequested()
+    model.openNotificationRoute(NotificationRoute(
+        userID: NativePreviewData.profile.userID,
+        remoteHostID: nil,
+        chatID: "@1",
+        messageID: target.id
+    ))
+
+    // Then: the route cannot replace the transcript owned by the send.
+    #expect(model.isSendingSelectedChat)
+    #expect(model.targetMessageID == nil)
+
+    // When: the send resolves with an error.
+    await probe.release()
+    await send.value
+
+    // Then: the draft is restored and the queued click reaches its exact message.
+    #expect(model.phase == .failed(failure))
+    #expect(model.draft == "Keep this draft if sending fails")
+    #expect(!model.isSending)
+    #expect(model.targetMessageID == target.id)
+}
+
+@MainActor
+@Test func sameChatNotificationWaitsForAFailedDeletionToReleaseTheTranscript() async throws {
+    // Given
+    let failure = "The delayed deletion failed."
+    let probe = DelayedDeletionProbe(failureMessage: failure)
+    let model = AppModel(
+        previewMode: true,
+        deleteMessagesOperation: { _, _ in try await probe.delete() }
+    )
+    let deletionTarget = try #require(model.messages.first)
+    let routeTarget = try #require(model.messages.last)
+    model.selectMessage(deletionTarget.id, modifiers: [])
+
+    // When: a notification for the selected chat arrives during deletion.
+    let deletion = try #require(model.deleteSelectedMessages())
+    await probe.waitUntilRequested()
+    model.openNotificationRoute(NotificationRoute(
+        userID: NativePreviewData.profile.userID,
+        remoteHostID: nil,
+        chatID: "@1",
+        messageID: routeTarget.id
+    ))
+
+    // Then: the in-flight deletion keeps ownership of the transcript.
+    #expect(model.isDeletingSelectedChat)
+    #expect(model.targetMessageID == nil)
+
+    // When: deletion resolves with an error.
+    await probe.release()
+    await deletion.value
+
+    // Then: the queued click is consumed without losing the failure state.
+    #expect(model.phase == .failed(failure))
+    #expect(!model.isDeletingMessages)
+    #expect(model.targetMessageID == routeTarget.id)
+}
+
+@MainActor
+@Test func notificationRouteWaitsForBothPhasesOfManualRefresh() async throws {
+    // Given
+    let chatsProbe = DelayedValue(NativePreviewData.chats)
+    let originalMessages = NativePreviewData.messages(for: "@1")
+    let transcriptProbe = ConversationRefreshProbe(messages: originalMessages)
+    let model = AppModel(
+        previewMode: false,
+        loadMessagesOperation: { chatID, aroundMessageID in
+            #expect(chatID == "@1")
+            return await transcriptProbe.load(around: aroundMessageID)
+        },
+        loadChatsOperation: { _ in await chatsProbe.load() }
+    )
+    model.phase = .ready
+    model.profile = NativePreviewData.profile
+    model.chats = NativePreviewData.chats
+    model.selectedChatID = "@1"
+    model.messages = originalMessages
+    let target = try #require(originalMessages.last)
+
+    // When: the route arrives while refresh is still loading the chat list.
+    model.refresh()
+    await chatsProbe.waitUntilRequested()
+    model.openNotificationRoute(NotificationRoute(
+        userID: NativePreviewData.profile.userID,
+        remoteHostID: nil,
+        chatID: "@1",
+        messageID: target.id
+    ))
+
+    // Then: it cannot bypass the pending transcript refresh.
+    #expect(model.isRefreshing)
+    #expect(model.targetMessageID == nil)
+    #expect(await transcriptProbe.recordedRequests().isEmpty)
+
+    // When: refresh completes, its queued route loads the exact message afterward.
+    await chatsProbe.release()
+    await transcriptProbe.waitUntilRequestCount(2)
+    for _ in 0..<1_000 {
+        if model.targetMessageID == target.id { break }
+        await Task.yield()
+    }
+
+    // Then
+    #expect(!model.isRefreshing)
+    #expect(await transcriptProbe.recordedRequests() == [nil, target.id])
+    #expect(model.targetMessageID == target.id)
 }
 
 @MainActor

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -480,6 +480,101 @@ private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: Quot
 }
 
 @MainActor
+@Test func cancellingReplyRetiresItsPendingOriginalMessageNavigation() async throws {
+    // Given
+    let original = NativePreviewData.messages(for: "@1")[0]
+    let visibleMessages = Array(NativePreviewData.messages(for: "@1").dropFirst())
+    let probe = DelayedValue([original])
+    let model = AppModel(
+        previewMode: true,
+        loadMessagesOperation: { chatID, aroundMessageID in
+            #expect(chatID == "@1")
+            #expect(aroundMessageID == original.id)
+            return await probe.load()
+        }
+    )
+    model.draft = "Keep this draft"
+    model.beginReply(to: original)
+    model.messages = visibleMessages
+
+    // When: Show Original is loading and Escape cancels the reply context.
+    let navigation = try #require(model.openReplyTarget())
+    await probe.waitUntilRequested()
+    #expect(model.isLoadingConversation)
+    model.dismissNearestState()
+
+    // Then: the composer exits reply mode without losing the draft.
+    #expect(model.replyingTo == nil)
+    #expect(model.draft == "Keep this draft")
+
+    // When: the cancelled backend request eventually returns.
+    await probe.release()
+    await navigation.value
+
+    // Then: it cannot replace or jump the visible transcript.
+    #expect(model.messages == visibleMessages)
+    #expect(model.targetMessageID == nil)
+    #expect(model.conversationAnchorMessageID == nil)
+    #expect(!model.isLoadingConversation)
+    #expect(model.quoteNavigationError == nil)
+}
+
+@MainActor
+@Test func cancellingReplyDoesNotCancelANewerInlineQuoteNavigation() async throws {
+    // Given
+    let replyTarget = NativePreviewData.messages(for: "@1")[0]
+    let inlineTarget = NativeMessage(
+        id: 9_704,
+        text: "Newer inline quote destination",
+        timestamp: nil,
+        sent: false,
+        author: "Maya",
+        deletable: true,
+        content: .text
+    )
+    let replyProbe = DelayedValue([replyTarget])
+    let inlineProbe = DelayedValue([inlineTarget])
+    let model = AppModel(
+        previewMode: true,
+        loadMessagesOperation: { _, aroundMessageID in
+            if aroundMessageID == replyTarget.id {
+                return await replyProbe.load()
+            }
+            #expect(aroundMessageID == inlineTarget.id)
+            return await inlineProbe.load()
+        }
+    )
+    model.beginReply(to: replyTarget)
+    model.messages = Array(NativePreviewData.messages(for: "@1").dropFirst())
+
+    // When: a newer inline quote navigation supersedes Show Original.
+    let replyNavigation = try #require(model.openReplyTarget())
+    await replyProbe.waitUntilRequested()
+    let quote = NativeQuote(
+        messageID: inlineTarget.id,
+        text: inlineTarget.text,
+        sent: inlineTarget.sent,
+        author: inlineTarget.author
+    )
+    let inlineNavigation = try #require(model.openQuotedMessage(quote, from: 9_705))
+    await inlineProbe.waitUntilRequested()
+    model.cancelReply()
+
+    // Then: cancelling the old reply context leaves the newer user navigation alive.
+    #expect(model.replyingTo == nil)
+    await inlineProbe.release()
+    await inlineNavigation.value
+    #expect(model.messages == [inlineTarget])
+    #expect(model.targetMessageID == inlineTarget.id)
+
+    // Cleanup: the cancelled older request cannot overwrite the result when it returns.
+    await replyProbe.release()
+    await replyNavigation.value
+    #expect(model.messages == [inlineTarget])
+    #expect(model.targetMessageID == inlineTarget.id)
+}
+
+@MainActor
 @Test func deletedOffscreenQuoteShowsLocalErrorWithoutBreakingConversation() async throws {
     // Given
     let quote = NativeQuote(messageID: 902, text: "Deleted original", sent: false, author: "Maya")

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -230,6 +230,15 @@ private func messageBodyHeight(_ text: String) -> CGFloat {
     #expect(NativeMessageLink.standaloneURL(in: "file:///tmp/private") == nil)
 }
 
+@Test func nativeAudioFilesUseInlinePlaybackWithoutClaimingDocuments() {
+    #expect(NativeAudioFile.supports("03 – Yön Sylössä On Polkumme.flac"))
+    #expect(NativeAudioFile.supports("VOICE.M4A"))
+    #expect(NativeAudioFile.supports("recording.wav"))
+    #expect(!NativeAudioFile.supports("report.pdf"))
+    #expect(!NativeAudioFile.supports(nil))
+    #expect(AudioPlaybackTime.label(65) == "1:05")
+}
+
 @Test func youtubeLinksBecomePrivacyEnhancedInlinePlayersAtTheirTimestamp() throws {
     let embed = try #require(NativeMessageLink.youtubeEmbedURL(for: "https://youtu.be/ishgn7-NLIU?t=24"))
     let components = try #require(URLComponents(url: embed, resolvingAgainstBaseURL: false))
@@ -1886,6 +1895,56 @@ private func writeTestJPEG(to url: URL) throws {
     // Then
     #expect(await probe.source() == encryptedSource)
     #expect(model.messages.first?.fileSource == encryptedSource)
+    #expect(model.attachmentOpenError == nil)
+    #expect(!model.isOpeningAttachment(original.id))
+}
+
+@MainActor
+@Test func inlineAudioPreparationRefreshesEncryptionMetadataAndCachesThePlayableURL() async throws {
+    let plainSource = NativeCryptoFile(filePath: "track.flac", cryptoArgs: nil)
+    let encryptedSource = NativeCryptoFile(
+        filePath: "track.flac",
+        cryptoArgs: NativeCryptoFileArgs(fileKey: "key", fileNonce: "nonce")
+    )
+    let original = NativeMessage(
+        id: 93,
+        text: "",
+        timestamp: nil,
+        sent: false,
+        author: "Maya",
+        deletable: true,
+        content: .file(fileName: "track.flac"),
+        fileSource: plainSource
+    )
+    let refreshed = NativeMessage(
+        id: original.id,
+        text: original.text,
+        timestamp: original.timestamp,
+        sent: original.sent,
+        author: original.author,
+        deletable: original.deletable,
+        content: original.content,
+        fileSource: encryptedSource
+    )
+    let playableURL = URL(fileURLWithPath: "/tmp/playable-track.flac")
+    let probe = AttachmentOpenProbe()
+    let model = AppModel(
+        previewMode: true,
+        loadMessageOperation: { _, _ in refreshed },
+        prepareAttachmentOperation: { source, fileName in
+            #expect(fileName == "track.flac")
+            await probe.open(source)
+            return playableURL
+        }
+    )
+    model.messages = [original]
+
+    let preparation = try #require(model.prepareInlineAudio(original))
+    await preparation.value
+
+    #expect(await probe.source() == encryptedSource)
+    #expect(model.messages.first?.fileSource == encryptedSource)
+    #expect(model.inlineAudioURL(original.id) == playableURL)
     #expect(model.attachmentOpenError == nil)
     #expect(!model.isOpeningAttachment(original.id))
 }

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -1557,7 +1557,7 @@ private actor AttachmentOpenProbe {
     #expect(model.canReplyToSelectedMessage)
 
     // When: Reply is invoked, composed, and sent.
-    model.replyToSelectedMessage()
+    #expect(model.replyToSelectedMessage())
     #expect(model.replyingTo?.id == original.id)
     #expect(model.selectedMessageIDs.isEmpty)
     model.draft = "Reply from the selected message"
@@ -1590,7 +1590,7 @@ private actor AttachmentOpenProbe {
     #expect(model.selectedMessageIDs == [source.id])
 
     // When
-    model.replyToSelectedMessage()
+    #expect(model.replyToSelectedMessage())
 
     // Then
     #expect(model.replyingTo?.id == source.id)
@@ -1619,7 +1619,7 @@ private actor AttachmentOpenProbe {
     model.selectMessage(unavailable.id, modifiers: [])
 
     // When
-    model.replyToSelectedMessage()
+    #expect(!model.replyToSelectedMessage())
 
     // Then
     #expect(!model.canReplyToSelectedMessage)

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -3456,6 +3456,13 @@ private actor DelayedDeletionProbe {
     #expect(toggled.selection == [20, 40])
 }
 
+@Test func replyControlRemainsVisibleAcrossItsHoverRegion() {
+    #expect(MessageReplyControlVisibility.isVisible(canReply: true, hovering: true, selected: false))
+    #expect(MessageReplyControlVisibility.isVisible(canReply: true, hovering: false, selected: true))
+    #expect(!MessageReplyControlVisibility.isVisible(canReply: true, hovering: false, selected: false))
+    #expect(!MessageReplyControlVisibility.isVisible(canReply: false, hovering: true, selected: true))
+}
+
 @Test func densityTokensStayOnTheMacSpacingGrid() {
     #expect(DesktopChatDensity.compact.tokens.chatRowPadding == 4)
     #expect(DesktopChatDensity.comfortable.tokens.transcriptGap == 12)

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -1099,6 +1099,98 @@ private func makeSendTestModel(
     #expect(model.canDeleteSelectedMessages)
 }
 
+private actor DelayedDeletionProbe {
+    private let messages: [NativeMessage]?
+    private let failureMessage: String
+    private var requested = false
+    private var released = false
+
+    init(messages: [NativeMessage]? = nil, failureMessage: String = "Deletion failed") {
+        self.messages = messages
+        self.failureMessage = failureMessage
+    }
+
+    func delete() async throws -> [NativeMessage] {
+        requested = true
+        while !released { await Task.yield() }
+        if let messages { return messages }
+        throw NativeChatError.unavailable(failureMessage)
+    }
+
+    func waitUntilRequested() async {
+        while !requested { await Task.yield() }
+    }
+
+    func release() {
+        released = true
+    }
+}
+
+@MainActor
+@Test func failedDeletionPreservesReplyAndBlocksRacingSend() async throws {
+    // Given
+    let failure = "The reply target could not be deleted."
+    let probe = DelayedDeletionProbe(failureMessage: failure)
+    let model = AppModel(
+        previewMode: true,
+        deleteMessagesOperation: { _, _ in try await probe.delete() }
+    )
+    let target = try #require(model.messages.first)
+    model.draft = "Keep this reply"
+    model.beginReply(to: target)
+    model.selectMessage(target.id, modifiers: [])
+
+    // When: deletion is pending.
+    let deletion = try #require(model.deleteSelectedMessages())
+    await probe.waitUntilRequested()
+
+    // Then: the reply stays visible, but cannot be sent into the deletion race.
+    #expect(model.replyingTo?.id == target.id)
+    #expect(!model.canSendDraft)
+    model.sendDraft()
+    #expect(model.sendTask == nil)
+
+    // When: deletion fails.
+    await probe.release()
+    await deletion.value
+
+    // Then: the complete composer is restored and can be retried.
+    #expect(model.replyingTo?.id == target.id)
+    #expect(model.draft == "Keep this reply")
+    #expect(model.canSendDraft)
+    #expect(model.phase == .failed(failure))
+}
+
+@MainActor
+@Test func successfulDeletionClearsOnlyItsReplyContextAcrossChatSwitch() async throws {
+    // Given
+    let remainingMessages = Array(NativePreviewData.messages(for: "@1").dropFirst())
+    let probe = DelayedDeletionProbe(messages: remainingMessages)
+    let model = AppModel(
+        previewMode: true,
+        deleteMessagesOperation: { _, _ in try await probe.delete() }
+    )
+    let target = try #require(model.messages.first)
+    model.draft = "Keep as an ordinary draft"
+    model.beginReply(to: target)
+    model.selectMessage(target.id, modifiers: [])
+
+    // When: deletion starts and the user switches conversations.
+    let deletion = try #require(model.deleteSelectedMessages())
+    await probe.waitUntilRequested()
+    #expect(model.replyingTo?.id == target.id)
+    #expect(!model.canSendDraft)
+    model.selectChat("#2")
+    await probe.release()
+    await deletion.value
+
+    // Then: returning restores the draft, but not a quote to the deleted item.
+    model.selectChat("@1")
+    #expect(model.replyingTo == nil)
+    #expect(model.draft == "Keep as an ordinary draft")
+    #expect(model.canSendDraft)
+}
+
 @MainActor
 @Test func deletionCompletionCannotReplaceAnotherChatsTranscript() async throws {
     // Given
@@ -1179,6 +1271,8 @@ private func makeSendTestModel(
     )
     let originalMessages = model.messages
     let selected = try #require(model.messages.first)
+    model.draft = "Keep this reply"
+    model.beginReply(to: selected)
     model.selectMessage(selected.id, modifiers: [])
 
     // When
@@ -1188,7 +1282,38 @@ private func makeSendTestModel(
 
     // Then
     #expect(model.messages == originalMessages)
+    #expect(model.replyingTo?.id == selected.id)
+    #expect(model.draft == "Keep this reply")
     #expect(!model.isDeletingMessages)
+}
+
+@MainActor
+@Test func cancellationAfterDeletionCommitClearsReplyAndRemovesTarget() async throws {
+    // Given
+    let remainingMessages = Array(NativePreviewData.messages(for: "@1").dropFirst())
+    let model = AppModel(
+        previewMode: true,
+        deleteMessagesOperation: { _, _ in
+            withUnsafeCurrentTask { $0?.cancel() }
+            return remainingMessages
+        }
+    )
+    let target = try #require(model.messages.first)
+    model.draft = "Keep as an ordinary draft"
+    model.beginReply(to: target)
+    model.selectMessage(target.id, modifiers: [])
+
+    // When: the delete operation commits, then observes cancellation.
+    let deletion = try #require(model.deleteSelectedMessages())
+    await deletion.value
+
+    // Then: committed state wins over cancellation.
+    #expect(!model.messages.contains(where: { $0.id == target.id }))
+    #expect(model.replyingTo == nil)
+    #expect(model.draft == "Keep as an ordinary draft")
+    #expect(model.canSendDraft)
+    #expect(!model.isDeletingMessages)
+    #expect(model.phase == .ready)
 }
 
 @MainActor

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -1,6 +1,7 @@
 import AppKit
 import CoreBridge
 import Foundation
+import SwiftUI
 import Testing
 @testable import SimpleXNative
 
@@ -83,6 +84,31 @@ import Testing
     let messages = try NativeChatParser.messages(from: Data(json.utf8))
     #expect(messages.map(\.sent) == [false, true])
     #expect(messages.map(\.text) == ["Hi", "Hey"])
+}
+
+@MainActor
+@Test func longMessageBodyUsesItsFullWrappedHeight() {
+    let shortHeight = messageBodyHeight("Short message")
+    let longHeight = messageBodyHeight(
+        String(repeating: "Unlimited browser profiles keep every profile isolated. ", count: 8)
+    )
+
+    #expect(longHeight > 100)
+    #expect(longHeight > shortHeight * 2)
+}
+
+@MainActor
+private func messageBodyHeight(_ text: String) -> CGFloat {
+    let view = HStack(alignment: .center, spacing: 4) {
+        Color.clear.frame(width: 44, height: 44)
+        MessageBodyText(text: text)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(Color.accentColor, in: RoundedRectangle(cornerRadius: 16))
+    }
+    .frame(width: 520, alignment: .trailing)
+
+    return NSHostingView(rootView: view).fittingSize.height
 }
 
 @Test func parsesImageMessagePreviewAndFile() throws {

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -2443,6 +2443,35 @@ private func unavailableVersion(of message: NativeMessage) -> NativeMessage {
     #expect(model.phase == .failed(failure))
     #expect(model.draft == "Retry this reply")
     #expect(model.replyingTo?.id == original.id)
+
+    // When: a notification opens another chat before the send error is dismissed.
+    model.openNotificationRoute(NotificationRoute(
+        userID: NativePreviewData.profile.userID,
+        remoteHostID: nil,
+        chatID: "#2",
+        messageID: nil
+    ))
+
+    // Then: the reply failure leaves with its draft and does not leak into the new chat.
+    #expect(model.selectedChatID == "#2")
+    #expect(model.phase == .ready)
+    model.selectChat("@1")
+    #expect(model.phase == .failed(failure))
+    #expect(model.draft == "Retry this reply")
+    #expect(model.replyingTo?.id == original.id)
+}
+
+@MainActor
+@Test func globalFailureRemainsVisibleAcrossChatTransitions() {
+    // Given
+    let model = AppModel(previewMode: true)
+    model.phase = .failed("The profile connection is unavailable.")
+
+    // When
+    model.selectChat("#2")
+
+    // Then: failures without a chat owner stay global.
+    #expect(model.phase == .failed("The profile connection is unavailable."))
 }
 
 @MainActor

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -57,6 +57,39 @@ import Testing
     #expect(DesktopChatDensity.compact.tokens.avatarSize < DesktopChatDensity.spacious.tokens.avatarSize)
 }
 
+@Test func conversationSearchFindsCaseInsensitiveTextAndWrapsResults() {
+    let messages = [
+        NativeMessage(id: 1, text: "First PHOTO", timestamp: nil, sent: false, author: nil, deletable: true, content: .text),
+        NativeMessage(id: 2, text: "No match", timestamp: nil, sent: true, author: nil, deletable: true, content: .text),
+        NativeMessage(id: 3, text: "Another photo", timestamp: nil, sent: false, author: nil, deletable: true, content: .text),
+    ]
+    let matches = ConversationSearch.matches(messages, query: "photo")
+    #expect(matches.map(\.id) == [1, 3])
+    #expect(ConversationSearch.nextID(in: matches, currentID: 3, offset: 1) == 1)
+    #expect(ConversationSearch.nextID(in: matches, currentID: 1, offset: -1) == 3)
+    #expect(ConversationSearch.resultDescription(matches: matches, selectedID: 3, queryIsEmpty: false) == "2 of 2")
+}
+
+@Test(.disabled("Requires an Apple-provisioned application identifier; SwiftPM test hosts have none"))
+func databasePassphraseKeychainAddsUpdatesLoadsAndDeletes() async throws {
+    let service = "chat.simplex.native.tests.\(UUID().uuidString)"
+    let store = DatabasePassphraseKeychain(service: service, account: "test-database")
+    try await store.delete()
+
+    do {
+        #expect(try await store.load() == nil)
+        try await store.save("first-passphrase")
+        #expect(try await store.load() == "first-passphrase")
+        try await store.save("updated-passphrase")
+        #expect(try await store.load() == "updated-passphrase")
+        try await store.delete()
+        #expect(try await store.load() == nil)
+    } catch {
+        try? await store.delete()
+        throw error
+    }
+}
+
 @Test func attachmentReorderingAndFailureRetentionPreserveOrder() {
     let urls = ["one.jpg", "two.mov", "three.pdf"].map { URL(fileURLWithPath: "/tmp/\($0)") }
     let attachments = [

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -258,6 +258,26 @@ private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: Quot
     #expect(unnamedPhoto.replyPreview == "Photo")
 }
 
+@Test func replyContextVisualsMatchAttachmentTypes() {
+    let imagePreview = "data:image/jpeg;base64,AA=="
+    let videoPreview = "data:image/jpeg;base64,AQ=="
+
+    #expect(NativeMessageContent.text.replyContextVisual == nil)
+    #expect(NativeMessageContent.image(
+        preview: imagePreview,
+        fileName: "photo.jpg"
+    ).replyContextVisual == .image(imagePreview))
+    #expect(NativeMessageContent.video(
+        preview: videoPreview,
+        fileName: "clip.mp4"
+    ).replyContextVisual == .video(videoPreview))
+    #expect(NativeMessageContent.voice(
+        fileName: "voice.m4a",
+        duration: 5
+    ).replyContextVisual == .voice)
+    #expect(NativeMessageContent.file(fileName: "notes.pdf").replyContextVisual == .file)
+}
+
 @Test func parsesVoiceMessageForPlaybackAndReplyContext() throws {
     // Given
     let json = #"{"result":{"type":"apiChat","chat":{"chatItems":[{"chatDir":{"type":"directRcv"},"meta":{"itemId":12,"itemText":"","itemTs":"2026-08-02T20:00:00Z"},"content":{"type":"rcvMsgContent","msgContent":{"type":"voice","text":"","duration":65}},"file":{"fileName":"voice.m4a","fileSource":{"filePath":"voice.m4a","cryptoArgs":{"fileKey":"key","fileNonce":"nonce"}}}}]}}}"#

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -20,9 +20,125 @@ import Testing
     #expect(messages.map(\.text) == ["Hi", "Hey"])
 }
 
+@Test func parsesImageMessagePreviewAndFile() throws {
+    let json = #"{"result":{"type":"apiChat","chat":{"chatItems":[{"chatDir":{"type":"directRcv"},"meta":{"itemId":9,"itemText":"A photo","itemTs":"2026-08-02T20:00:00Z","deletable":true},"content":{"type":"rcvMsgContent","msgContent":{"type":"image","text":"A photo","image":"data:image/jpeg;base64,AA=="}},"file":{"fileName":"photo.jpg","fileSource":{"filePath":"photo.jpg","cryptoArgs":null}}}]}}}"#
+    let message = try #require(NativeChatParser.messages(from: Data(json.utf8)).first)
+    #expect(message.deletable)
+    #expect(message.content == .image(
+        preview: "data:image/jpeg;base64,AA==",
+        fileName: "photo.jpg",
+        filePath: "photo.jpg"
+    ))
+    #expect(message.content.fileURL?.lastPathComponent == "photo.jpg")
+}
+
+@Test func messageSelectionSupportsRangesAndCommandToggle() {
+    let ordered: [Int64] = [10, 20, 30, 40]
+    let first = MessageSelection.updated(
+        current: [], anchor: nil, clicked: 20, orderedIDs: ordered, command: false, shift: false
+    )
+    #expect(first.selection == [20])
+
+    let range = MessageSelection.updated(
+        current: first.selection, anchor: first.anchor, clicked: 40, orderedIDs: ordered, command: false, shift: true
+    )
+    #expect(range.selection == [20, 30, 40])
+
+    let toggled = MessageSelection.updated(
+        current: range.selection, anchor: range.anchor, clicked: 30, orderedIDs: ordered, command: true, shift: false
+    )
+    #expect(toggled.selection == [20, 40])
+}
+
+@Test func densityTokensStayOnTheMacSpacingGrid() {
+    #expect(DesktopChatDensity.compact.tokens.chatRowPadding == 4)
+    #expect(DesktopChatDensity.comfortable.tokens.transcriptGap == 12)
+    #expect(DesktopChatDensity.spacious.tokens.composerPadding == 16)
+    #expect(DesktopChatDensity.compact.tokens.avatarSize < DesktopChatDensity.spacious.tokens.avatarSize)
+}
+
+@Test func attachmentReorderingAndFailureRetentionPreserveOrder() {
+    let urls = ["one.jpg", "two.mov", "three.pdf"].map { URL(fileURLWithPath: "/tmp/\($0)") }
+    let attachments = [
+        PendingAttachment(id: UUID(), url: urls[0], fileName: "one.jpg", kind: .image, byteCount: 1, previewImage: nil),
+        PendingAttachment(id: UUID(), url: urls[1], fileName: "two.mov", kind: .video, byteCount: 2, previewImage: nil),
+        PendingAttachment(id: UUID(), url: urls[2], fileName: "three.pdf", kind: .document, byteCount: 3, previewImage: nil),
+    ]
+    let reordered = PendingAttachment.reordered(attachments, from: attachments[2].id, before: attachments[0].id)
+    #expect(reordered.map(\.fileName) == ["three.pdf", "one.jpg", "two.mov"])
+    #expect(PendingAttachment.remainingAfterFailure(reordered, at: 1).map(\.fileName) == ["one.jpg", "two.mov"])
+}
+
+@Test func parsesMessageNotificationRouteAndPrivacyModes() throws {
+    let json = #"{"remoteHostId":null,"result":{"type":"newChatItems","user":{"userId":7,"localDisplayName":"Me"},"chatItems":[{"chatInfo":{"type":"direct","contact":{"contactId":42,"localDisplayName":"Alice","profile":{"displayName":"Alice"}}},"chatItem":{"chatDir":{"type":"directRcv"},"meta":{"itemId":99,"itemText":"Secret hello"}}}]}}"#
+    let payload = try #require(NativeNotificationParser.payload(from: Data(json.utf8)))
+    #expect(payload.route.userID == 7)
+    #expect(payload.route.chatID == "@42")
+    #expect(payload.route.messageID == 99)
+    #expect(payload.route.identifier == "simplex.7.-1._42.99")
+    #expect(NativeNotificationParser.preview(for: payload, mode: .message) == .init(
+        title: "Alice", body: "Secret hello"
+    ))
+    #expect(NativeNotificationParser.preview(for: payload, mode: .contact) == .init(
+        title: "Alice", body: "New message"
+    ))
+    #expect(NativeNotificationParser.preview(for: payload, mode: .hidden) == .init(
+        title: "SimpleX Chat", body: "New message"
+    ))
+}
+
+@Test func notificationSuppressionRequiresTheExactFocusedConversation() {
+    let route = NotificationRoute(userID: 7, remoteHostID: nil, chatID: "@42", messageID: 99)
+    #expect(NativeNotificationParser.shouldSuppress(
+        windowFocused: true,
+        activeUserID: 7,
+        activeRemoteHostID: nil,
+        activeChatID: "@42",
+        route: route
+    ))
+    #expect(!NativeNotificationParser.shouldSuppress(
+        windowFocused: true,
+        activeUserID: 7,
+        activeRemoteHostID: nil,
+        activeChatID: "@43",
+        route: route
+    ))
+    #expect(!NativeNotificationParser.shouldSuppress(
+        windowFocused: false,
+        activeUserID: 7,
+        activeRemoteHostID: nil,
+        activeChatID: "@42",
+        route: route
+    ))
+}
+
+@Test func notificationRoutesQueueUntilTheInterfaceIsReady() {
+    var queue = NotificationRouteQueue()
+    let first = NotificationRoute(userID: 7, remoteHostID: nil, chatID: "@42", messageID: 1)
+    let second = NotificationRoute(userID: 7, remoteHostID: nil, chatID: "#9", messageID: 2)
+    queue.enqueue(first)
+    queue.enqueue(first)
+    queue.enqueue(second)
+    #expect(queue.consumeIfReady(false).isEmpty)
+    #expect(queue.consumeIfReady(true) == [first, second])
+    #expect(queue.consumeIfReady(true).isEmpty)
+}
+
 @Test func recognizesMigrationSuccess() {
     #expect(NativeChatParser.migrationSucceeded(Data(#"{"type":"ok"}"#.utf8)))
     #expect(NativeChatParser.migrationSucceeded(Data(#""ok""#.utf8)))
+}
+
+@Test func decodesDataURIImagePreview() {
+    let onePixelPNG = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    #expect(NativeChatParser.image(from: onePixelPNG) != nil)
+}
+
+@Test func recognizesCoreCommandFailure() {
+    let error = Data(#"{"remoteHostId":null,"error":{"type":"chatError","errorType":{"type":"fileSize","filePath":"huge.mov"}}}"#.utf8)
+    #expect(NativeChatParser.commandError(from: error) == "SimpleX could not complete the action (fileSize).")
+    let success = Data(#"{"remoteHostId":null,"result":{"type":"cmdOk"}}"#.utf8)
+    #expect(NativeChatParser.commandError(from: success) == nil)
 }
 
 @Test func opensTemporaryDatabaseWithBundledCore() throws {

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -47,6 +47,47 @@ import Testing
     #expect(ordinary["quotedItemId"] == nil)
 }
 
+@MainActor
+@Test func replyComposerSendsAndClearsQuotedContext() throws {
+    let model = AppModel(previewMode: true)
+    let original = try #require(model.messages.first)
+
+    model.beginReply(to: original)
+    model.draft = "This is a reply"
+    model.sendDraft()
+
+    let sent = try #require(model.messages.last)
+    #expect(sent.text == "This is a reply")
+    #expect(sent.quotedItem?.messageID == original.id)
+    #expect(sent.quotedItem?.text == original.text)
+    #expect(model.replyingTo == nil)
+    #expect(model.draft.isEmpty)
+}
+
+@MainActor
+@Test func notificationChatTransitionCannotLeakAReplyIntoAnotherConversation() throws {
+    let model = AppModel(previewMode: true)
+    let original = try #require(model.messages.first)
+    model.beginReply(to: original)
+    #expect(model.replyingTo?.id == original.id)
+
+    model.openNotificationRoute(NotificationRoute(
+        userID: NativePreviewData.profile.userID,
+        remoteHostID: nil,
+        chatID: "#2",
+        messageID: 20
+    ))
+
+    #expect(model.selectedChatID == "#2")
+    #expect(model.replyingTo == nil)
+    #expect(model.targetMessageID == 20)
+
+    let groupMessage = try #require(model.messages.first)
+    model.selectChat("*3")
+    model.beginReply(to: groupMessage)
+    #expect(model.replyingTo == nil)
+}
+
 @Test func messageSelectionSupportsRangesAndCommandToggle() {
     let ordered: [Int64] = [10, 20, 30, 40]
     let first = MessageSelection.updated(

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -365,14 +365,18 @@ private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: Quot
     }
 }
 
-@Test func nestedStoreErrorsIdentifyAnInvalidReplyTarget() {
+@Test func nestedStoreErrorsIdentifyEveryUnavailableReplyTarget() {
     // Given
     let invalidQuote = Data(#"{"error":{"type":"errorStore","storeError":{"type":"invalidQuote"}}}"#.utf8)
-    let unrelated = Data(#"{"error":{"type":"errorStore","storeError":{"type":"chatItemNotFound","itemId":9}}}"#.utf8)
+    let missingItem = Data(#"{"error":{"type":"errorStore","storeError":{"type":"chatItemNotFound","itemId":9}}}"#.utf8)
+    let badItem = Data(#"{"error":{"type":"errorStore","storeError":{"type":"badChatItem","itemId":9,"itemTs":null}}}"#.utf8)
+    let unrelated = Data(#"{"error":{"type":"errorStore","storeError":{"type":"fileNotFound","fileId":3}}}"#.utf8)
 
     // When / Then
-    #expect(NativeChatParser.commandErrorIsInvalidQuote(invalidQuote))
-    #expect(!NativeChatParser.commandErrorIsInvalidQuote(unrelated))
+    #expect(NativeChatParser.commandErrorMakesReplyTargetUnavailable(invalidQuote))
+    #expect(NativeChatParser.commandErrorMakesReplyTargetUnavailable(missingItem))
+    #expect(NativeChatParser.commandErrorMakesReplyTargetUnavailable(badItem))
+    #expect(!NativeChatParser.commandErrorMakesReplyTargetUnavailable(unrelated))
 }
 
 @Test func singleMessageReloadUsesTheCoreQuoteResolutionPagination() {

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -1742,7 +1742,7 @@ private func unavailableVersion(of message: NativeMessage) -> NativeMessage {
 }
 
 @MainActor
-@Test func inFlightReplyTargetCannotBeDeletedUntilTheSendResolves() async throws {
+@Test func inFlightSendBlocksTranscriptDeletionUntilItResolves() async throws {
     // Given
     let model = makeSendTestModel(sendTextOperation: { _, _, _ in
         try Task.checkCancellation()
@@ -1765,8 +1765,8 @@ private func unavailableVersion(of message: NativeMessage) -> NativeMessage {
     // When: an unrelated message is selected instead.
     model.selectMessage(unrelatedMessage.id, modifiers: [])
 
-    // Then: unrelated deletion remains available.
-    #expect(model.canDeleteSelectedMessages)
+    // Then: even unrelated deletion waits so its transcript reload cannot race the send reload.
+    #expect(!model.canDeleteSelectedMessages)
 
     // Cleanup.
     send.cancel()
@@ -1774,6 +1774,90 @@ private func unavailableVersion(of message: NativeMessage) -> NativeMessage {
     #expect(!model.isSending)
     model.selectMessage(replyTarget.id, modifiers: [])
     #expect(model.canDeleteSelectedMessages)
+}
+
+@MainActor
+@Test func unresolvedQuoteNavigationBlocksSendUntilItsDestinationSettles() async throws {
+    // Given
+    let target = NativePreviewData.messages(for: "@1")[0]
+    let unresolvedQuote = NativeQuote(messageID: nil, text: target.text, sent: target.sent, author: target.author)
+    let containingMessage = NativeMessage(
+        id: 908,
+        text: "Reply with delayed quote metadata",
+        timestamp: nil,
+        sent: true,
+        author: nil,
+        deletable: true,
+        content: .text,
+        quotedItem: unresolvedQuote
+    )
+    let refreshedMessage = NativeMessage(
+        id: containingMessage.id,
+        text: containingMessage.text,
+        timestamp: containingMessage.timestamp,
+        sent: containingMessage.sent,
+        author: containingMessage.author,
+        deletable: containingMessage.deletable,
+        content: containingMessage.content,
+        quotedItem: NativeQuote(messageID: target.id, text: target.text, sent: target.sent, author: target.author)
+    )
+    let probe = DelayedValue<NativeMessage?>(refreshedMessage)
+    let model = AppModel(
+        previewMode: true,
+        loadMessageOperation: { _, _ in await probe.load() }
+    )
+    model.messages = [target, containingMessage]
+
+    // When: resolving the quote metadata is still in flight.
+    let navigation = try #require(model.openQuotedMessage(unresolvedQuote, from: containingMessage.id))
+    await probe.waitUntilRequested()
+    model.draft = "Do not race this send"
+
+    // Then: Send remains disabled even before the transcript page loader begins.
+    #expect(!model.isLoadingConversation)
+    #expect(!model.canSendDraft)
+    model.sendDraft()
+    #expect(model.sendTask == nil)
+    #expect(model.draft == "Do not race this send")
+
+    // When: the destination resolves.
+    await probe.release()
+    await navigation.value
+
+    // Then
+    #expect(model.targetMessageID == target.id)
+    #expect(model.canSendDraft)
+}
+
+@MainActor
+@Test func inFlightSendBlocksQuotedHistoryNavigation() async throws {
+    // Given
+    let failure = "The delayed send failed."
+    let probe = DelayedTextSendProbe(failureMessage: failure)
+    let model = makeSendTestModel(sendTextOperation: { _, _, _ in try await probe.send() })
+    let target = try #require(model.messages.first)
+    let quote = NativeQuote(messageID: target.id, text: target.text, sent: target.sent, author: target.author)
+    model.draft = "Sending now"
+
+    // When: a send is in flight.
+    model.sendDraft()
+    let send = try #require(model.sendTask)
+    await probe.waitUntilRequested()
+
+    // Then: quote navigation and transcript deletion are both rejected consistently.
+    #expect(!model.canNavigateConversationHistory)
+    #expect(!model.canRefreshConversation)
+    #expect(model.openQuotedMessage(quote, from: 909) == nil)
+    #expect(model.targetMessageID == nil)
+    #expect(model.conversationAnchorMessageID == nil)
+    model.selectMessage(target.id, modifiers: [])
+    #expect(!model.canDeleteSelectedMessages)
+
+    // Cleanup.
+    await probe.release()
+    await send.value
+    #expect(model.phase == .failed(failure))
+    #expect(model.canNavigateConversationHistory)
 }
 
 private actor DelayedDeletionProbe {
@@ -1824,6 +1908,11 @@ private actor DelayedDeletionProbe {
     // Then: the reply stays visible, but cannot be sent into the deletion race.
     #expect(model.replyingTo?.id == target.id)
     #expect(!model.canSendDraft)
+    #expect(!model.canNavigateConversationHistory)
+    #expect(!model.canRefreshConversation)
+    let quote = NativeQuote(messageID: target.id, text: target.text, sent: target.sent, author: target.author)
+    #expect(model.openQuotedMessage(quote, from: 910) == nil)
+    #expect(model.targetMessageID == nil)
     model.sendDraft()
     #expect(model.sendTask == nil)
 

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -2848,6 +2848,11 @@ private actor DelayedDeletionProbe {
     #expect(DesktopChatDensity.compact.tokens.avatarSize < DesktopChatDensity.spacious.tokens.avatarSize)
 }
 
+@Test func composerReturnSendsWhileShiftReturnInsertsANewline() {
+    #expect(ComposerKeyboard.returnAction(shiftPressed: false) == .send)
+    #expect(ComposerKeyboard.returnAction(shiftPressed: true) == .insertNewline)
+}
+
 @Test func conversationSearchFindsCaseInsensitiveTextAndWrapsResults() {
     let messages = [
         NativeMessage(id: 1, text: "First PHOTO", timestamp: nil, sent: false, author: nil, deletable: true, content: .text),

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -33,6 +33,75 @@ import Testing
     #expect(message.quotedItem == NativeQuote(messageID: 7, text: "Original message", sent: true, author: nil))
 }
 
+private struct ReplyEligibilityCase: Sendable, CustomTestStringConvertible {
+    let name: String
+    let itemID: Int64
+    let metaFields: String
+    let content: String
+    let expected: Bool
+
+    var testDescription: String { name }
+}
+
+private let replyEligibilityCases = [
+    ReplyEligibilityCase(
+        name: "ordinary message",
+        itemID: 1,
+        metaFields: "",
+        content: #"{"type":"rcvMsgContent","msgContent":{"type":"text","text":"Hello"}}"#,
+        expected: true
+    ),
+    ReplyEligibilityCase(
+        name: "system event",
+        itemID: 2,
+        metaFields: "",
+        content: #"{"type":"rcvGroupEvent"}"#,
+        expected: false
+    ),
+    ReplyEligibilityCase(
+        name: "deleted message",
+        itemID: 3,
+        metaFields: #", "itemDeleted":{"type":"deleted"}"#,
+        content: #"{"type":"rcvMsgContent","msgContent":{"type":"text","text":"Gone"}}"#,
+        expected: false
+    ),
+    ReplyEligibilityCase(
+        name: "live message",
+        itemID: 4,
+        metaFields: #", "isLive":true"#,
+        content: #"{"type":"rcvMsgContent","msgContent":{"type":"text","text":"Typing"}}"#,
+        expected: false
+    ),
+    ReplyEligibilityCase(
+        name: "report message",
+        itemID: 5,
+        metaFields: "",
+        content: #"{"type":"rcvMsgContent","msgContent":{"type":"report","text":"Report"}}"#,
+        expected: false
+    ),
+    ReplyEligibilityCase(
+        name: "temporary live placeholder",
+        itemID: -2,
+        metaFields: "",
+        content: #"{"type":"rcvMsgContent","msgContent":{"type":"text","text":"Typing"}}"#,
+        expected: false
+    ),
+]
+
+@Test(arguments: replyEligibilityCases)
+private func parserLimitsRepliesToAvailableMessages(testCase: ReplyEligibilityCase) throws {
+    // Given
+    let json = """
+        {"result":{"type":"apiChat","chat":{"chatItems":[{"chatDir":{"type":"directRcv"},"meta":{"itemId":\(testCase.itemID),"itemText":"Item","itemTs":"2026-08-02T20:00:00Z"\(testCase.metaFields)},"content":\(testCase.content)}]}}}
+        """
+
+    // When
+    let message = try #require(NativeChatParser.messages(from: Data(json.utf8)).first)
+
+    // Then
+    #expect(message.replyable == testCase.expected)
+}
+
 private struct QuotedAttachmentCase: Sendable, CustomTestStringConvertible {
     let contentType: String
     let expectedPreview: String
@@ -319,6 +388,77 @@ private actor AttachmentOpenProbe {
     #expect(sent.quotedItem?.text == original.text)
     #expect(model.replyingTo == nil)
     #expect(model.draft.isEmpty)
+}
+
+@MainActor
+@Test func replyControlsRejectUnavailableItems() throws {
+    // Given
+    let source = try #require(NativePreviewData.messages(for: "@1").first)
+    let unavailable = NativeMessage(
+        id: source.id,
+        text: source.text,
+        timestamp: source.timestamp,
+        sent: source.sent,
+        author: source.author,
+        deletable: source.deletable,
+        content: source.content,
+        replyable: false
+    )
+    let model = AppModel(previewMode: true)
+    model.messages = [unavailable]
+    model.selectMessage(unavailable.id, modifiers: [])
+
+    // When
+    model.replyToSelectedMessage()
+
+    // Then
+    #expect(!model.canReplyToSelectedMessage)
+    #expect(model.replyingTo == nil)
+    #expect(model.selectedMessageIDs == [unavailable.id])
+}
+
+@MainActor
+@Test func liveRefreshUpdatesOrInvalidatesReplyContextWithoutLosingDraft() throws {
+    // Given
+    let original = try #require(NativePreviewData.messages(for: "@1").first)
+    let edited = NativeMessage(
+        id: original.id,
+        text: "Edited source message",
+        timestamp: original.timestamp,
+        sent: original.sent,
+        author: original.author,
+        deletable: original.deletable,
+        content: original.content
+    )
+    let unavailable = NativeMessage(
+        id: edited.id,
+        text: "Message deleted",
+        timestamp: edited.timestamp,
+        sent: edited.sent,
+        author: edited.author,
+        deletable: false,
+        content: edited.content,
+        replyable: false
+    )
+    let model = AppModel(previewMode: true)
+    model.messages = [original]
+    model.draft = "Keep this draft"
+    model.beginReply(to: original)
+
+    // When: the quoted source is edited by a live refresh.
+    model.applyLoadedMessages([edited], to: "@1")
+
+    // Then: the composer shows the current source text.
+    #expect(model.replyingTo?.text == "Edited source message")
+    #expect(model.replyContextError == nil)
+
+    // When: a later refresh marks the source unavailable.
+    model.applyLoadedMessages([unavailable], to: "@1")
+
+    // Then: only the invalid quote is removed; the user's work survives.
+    #expect(model.replyingTo == nil)
+    #expect(model.draft == "Keep this draft")
+    #expect(model.replyContextError == "The message you were replying to is no longer available. Your draft was kept.")
 }
 
 @MainActor

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -1195,6 +1195,37 @@ private actor ReplyValidationProbe {
     }
 }
 
+private actor DelayedTextSendProbe {
+    private let failureMessage: String?
+    private let cancelAfterSuccess: Bool
+    private var requested = false
+    private var released = false
+
+    init(failureMessage: String? = nil, cancelAfterSuccess: Bool = false) {
+        self.failureMessage = failureMessage
+        self.cancelAfterSuccess = cancelAfterSuccess
+    }
+
+    func send() async throws {
+        requested = true
+        while !released { await Task.yield() }
+        if let failureMessage {
+            throw NativeChatError.unavailable(failureMessage)
+        }
+        if cancelAfterSuccess {
+            withUnsafeCurrentTask { $0?.cancel() }
+        }
+    }
+
+    func waitUntilRequested() async {
+        while !requested { await Task.yield() }
+    }
+
+    func release() {
+        released = true
+    }
+}
+
 @MainActor
 private func makeSendTestModel(
     sendTextOperation: SendTextOperation? = nil,
@@ -1208,6 +1239,126 @@ private func makeSendTestModel(
         loadMessageOperation: loadMessageOperation
     )
     return model
+}
+
+@MainActor
+private func unavailableVersion(of message: NativeMessage) -> NativeMessage {
+    NativeMessage(
+        id: message.id,
+        text: "Message deleted",
+        timestamp: message.timestamp,
+        sent: message.sent,
+        author: message.author,
+        deletable: false,
+        content: message.content,
+        replyable: false
+    )
+}
+
+@MainActor
+@Test func failedSendClearsAReplyTargetDeletedWhileTheSendWasInFlight() async throws {
+    // Given
+    let failure = "The reply could not be sent."
+    let original = NativePreviewData.messages(for: "@1")[0]
+    let probe = DelayedTextSendProbe(failureMessage: failure)
+    let model = makeSendTestModel(
+        sendTextOperation: { _, _, _ in try await probe.send() },
+        loadMessageOperation: { _, _ in original }
+    )
+    model.messages = [original]
+    model.draft = "Keep this reply text"
+    model.beginReply(to: original)
+
+    // When: the source is deleted after validation but before the send fails.
+    model.sendDraft()
+    let send = try #require(model.sendTask)
+    await probe.waitUntilRequested()
+    model.applyLoadedMessages([unavailableVersion(of: original)], to: "@1")
+
+    // Then: the in-flight composer remains stable until the operation resolves.
+    #expect(model.replyingTo?.id == original.id)
+    #expect(model.replyContextError == nil)
+    #expect(model.isSendingSelectedChat)
+
+    // When
+    await probe.release()
+    await send.value
+
+    // Then: the text is restored without retaining an invalid quote.
+    #expect(model.draft == "Keep this reply text")
+    #expect(model.replyingTo == nil)
+    #expect(model.replyContextError == "The message you were replying to is no longer available. Your draft was kept.")
+    #expect(model.phase == .failed(failure))
+    #expect(!model.isSending)
+}
+
+@MainActor
+@Test func committedReplyDoesNotReportADeferredTargetInvalidation() async throws {
+    // Given
+    let original = NativePreviewData.messages(for: "@1")[0]
+    let probe = DelayedTextSendProbe(cancelAfterSuccess: true)
+    let model = makeSendTestModel(
+        sendTextOperation: { _, _, _ in try await probe.send() },
+        loadMessageOperation: { _, _ in original }
+    )
+    model.messages = [original]
+    model.draft = "This reply commits"
+    model.beginReply(to: original)
+
+    // When: the source is deleted while the core is committing the reply.
+    model.sendDraft()
+    let send = try #require(model.sendTask)
+    await probe.waitUntilRequested()
+    model.applyLoadedMessages([unavailableVersion(of: original)], to: "@1")
+    await probe.release()
+    await send.value
+
+    // Then: the committed quote stays sent and no stale composer warning appears.
+    #expect(model.draft.isEmpty)
+    #expect(model.replyingTo == nil)
+    #expect(model.replyContextError == nil)
+    #expect(model.phase == .ready)
+    #expect(!model.isSending)
+}
+
+@MainActor
+@Test func transientReplyInvalidationCanRecoverBeforeAFailedSendReturns() async throws {
+    // Given
+    let failure = "The reply could not be sent."
+    let original = NativePreviewData.messages(for: "@1")[0]
+    let recovered = NativeMessage(
+        id: original.id,
+        text: "Edited but available again",
+        timestamp: original.timestamp,
+        sent: original.sent,
+        author: original.author,
+        deletable: original.deletable,
+        content: original.content
+    )
+    let probe = DelayedTextSendProbe(failureMessage: failure)
+    let model = makeSendTestModel(
+        sendTextOperation: { _, _, _ in try await probe.send() },
+        loadMessageOperation: { _, _ in original }
+    )
+    model.messages = [original]
+    model.draft = "Retry against the recovered target"
+    model.beginReply(to: original)
+
+    // When: a transient unavailable state is followed by a valid refresh.
+    model.sendDraft()
+    let send = try #require(model.sendTask)
+    await probe.waitUntilRequested()
+    model.applyLoadedMessages([unavailableVersion(of: original)], to: "@1")
+    model.applyLoadedMessages([recovered], to: "@1")
+    await probe.release()
+    await send.value
+
+    // Then: the failed send restores a valid, current reply context.
+    #expect(model.draft == "Retry against the recovered target")
+    #expect(model.replyingTo == recovered)
+    #expect(model.replyContextError == nil)
+    #expect(model.phase == .failed(failure))
+    #expect(!model.isSending)
 }
 
 @MainActor

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -983,6 +983,37 @@ private actor AttachmentOpenProbe {
 }
 
 @MainActor
+@Test func selectedMessageReplyCanReturnToItsSource() throws {
+    // Given: a transcript message is selected through the same model path as the UI.
+    let model = AppModel(previewMode: true)
+    let original = try #require(model.messages.first)
+    model.transcriptFocused = true
+    model.selectMessage(original.id, modifiers: [])
+    #expect(model.canReplyToSelectedMessage)
+
+    // When: Reply is invoked, composed, and sent.
+    model.replyToSelectedMessage()
+    #expect(model.replyingTo?.id == original.id)
+    #expect(model.selectedMessageIDs.isEmpty)
+    model.draft = "Reply from the selected message"
+    model.sendDraft()
+
+    // Then: the new quote preserves the source identity and can navigate back to it.
+    let sent = try #require(model.messages.last)
+    let quote = try #require(sent.quotedItem)
+    #expect(quote.messageID == original.id)
+    #expect(quote.text == original.text)
+    #expect(model.replyingTo == nil)
+    #expect(model.draft.isEmpty)
+
+    let navigation = model.openQuotedMessage(quote, from: sent.id)
+    #expect(navigation == nil)
+    #expect(model.targetMessageID == original.id)
+    #expect(model.conversationAnchorMessageID == original.id)
+    #expect(model.isViewingConversationHistory)
+}
+
+@MainActor
 @Test func replyControlsRejectUnavailableItems() throws {
     // Given
     let source = try #require(NativePreviewData.messages(for: "@1").first)

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -536,6 +536,36 @@ private actor AttachmentOpenProbe {
     #expect(model.pendingAttachments == [attachment])
 }
 
+@MainActor
+@Test func escapeDismissesSearchBeforeReplyContext() throws {
+    // Given
+    let model = AppModel(previewMode: true)
+    let original = try #require(model.messages.first)
+    model.draft = "Keep this draft"
+    model.beginReply(to: original)
+    model.sidebarSearchPresented = true
+    model.searchText = "maya"
+
+    // When: sidebar search is the nearest temporary state.
+    #expect(model.canDismissNearestState)
+    model.dismissNearestState()
+
+    // Then: only search closes; the reply and draft survive.
+    #expect(!model.sidebarSearchPresented)
+    #expect(model.searchText.isEmpty)
+    #expect(model.replyingTo?.id == original.id)
+    #expect(model.draft == "Keep this draft")
+    #expect(model.canDismissNearestState)
+
+    // When: Escape is invoked again.
+    model.dismissNearestState()
+
+    // Then: the reply context closes without discarding the draft.
+    #expect(model.replyingTo == nil)
+    #expect(model.draft == "Keep this draft")
+    #expect(!model.canDismissNearestState)
+}
+
 private actor AttachmentSendProbe {
     struct Request: Sendable {
         let attachmentID: PendingAttachment.ID

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -338,6 +338,43 @@ private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: Quot
     }
 }
 
+@Test func sendResponseValidationRequiresTheCommittedMessage() throws {
+    // Given
+    let committed = Data(#"{"result":{"type":"newChatItems","chatItems":[{"chatItem":{"meta":{"itemId":9}}}]}}"#.utf8)
+    let missingItem = Data(#"{"result":{"type":"newChatItems","chatItems":[]}}"#.utf8)
+    let wrongResult = Data(#"{"result":{"type":"cmdOk"}}"#.utf8)
+
+    // When / Then
+    try NativeChatParser.validateCommandResponse(
+        committed,
+        expectedType: "newChatItems",
+        requireChatItems: true
+    )
+    #expect(throws: NativeChatError.self) {
+        try NativeChatParser.validateCommandResponse(
+            missingItem,
+            expectedType: "newChatItems",
+            requireChatItems: true
+        )
+    }
+    #expect(throws: NativeChatError.self) {
+        try NativeChatParser.validateCommandResponse(
+            wrongResult,
+            expectedType: "newChatItems"
+        )
+    }
+}
+
+@Test func nestedStoreErrorsIdentifyAnInvalidReplyTarget() {
+    // Given
+    let invalidQuote = Data(#"{"error":{"type":"errorStore","storeError":{"type":"invalidQuote"}}}"#.utf8)
+    let unrelated = Data(#"{"error":{"type":"errorStore","storeError":{"type":"chatItemNotFound","itemId":9}}}"#.utf8)
+
+    // When / Then
+    #expect(NativeChatParser.commandErrorIsInvalidQuote(invalidQuote))
+    #expect(!NativeChatParser.commandErrorIsInvalidQuote(unrelated))
+}
+
 @Test func singleMessageReloadUsesTheCoreQuoteResolutionPagination() {
     // Given / When
     let command = SimpleXCore.chatPageCommand(chatID: "@42", around: 91, count: 0)
@@ -1650,6 +1687,41 @@ private actor AttachmentOpenProbe {
 }
 
 @MainActor
+@Test func invalidQuoteRaceKeepsTheDraftAndAttachmentsButRetiresTheReply() async throws {
+    // Given
+    let attachment = PendingAttachment(
+        id: UUID(),
+        url: URL(fileURLWithPath: "/tmp/reply-race-photo.jpg"),
+        fileName: "reply-race-photo.jpg",
+        kind: .image,
+        byteCount: 10,
+        previewImage: nil
+    )
+    let model = makeSendTestModel(
+        sendAttachmentOperation: { _, _, _, _ in
+            throw NativeChatError.replyTargetUnavailable
+        }
+    )
+    let original = try #require(model.messages.first)
+    model.draft = "Keep this caption"
+    model.pendingAttachments = [attachment]
+    model.beginReply(to: original)
+
+    // When
+    model.sendDraft()
+    let task = try #require(model.sendTask)
+    await task.value
+
+    // Then
+    #expect(model.replyingTo == nil)
+    #expect(model.draft == "Keep this caption")
+    #expect(model.pendingAttachments == [attachment])
+    #expect(model.replyContextError == "The message you were replying to is no longer available. Your draft was kept.")
+    #expect(model.phase == .ready)
+    #expect(!model.isSending)
+}
+
+@MainActor
 @Test func escapeDismissesSearchBeforeReplyContext() throws {
     // Given
     let model = AppModel(previewMode: true)
@@ -2940,6 +3012,33 @@ func databasePassphraseKeychainAddsUpdatesLoadsAndDeletes() async throws {
                 sx_core_free(closeResult)
             }
         }
+        func sendCoreCommand(_ command: String) throws -> Data {
+            let result = command.withCString { sx_core_send_cmd(controller, $0, 0) }
+            guard let result else {
+                throw NativeChatError.unavailable("The bundled core returned no command response.")
+            }
+            defer { sx_core_free(result) }
+            guard let response = String(validatingUTF8: result) else {
+                throw NativeChatError.invalidResponse("The bundled core returned invalid UTF-8.")
+            }
+            return Data(response.utf8)
+        }
+
+        let createdUser = try sendCoreCommand(
+            #"/_create user {"profile":null,"pastTimestamp":false,"userChatRelay":false,"clientService":false}"#
+        )
+        _ = try NativeChatParser.profile(from: createdUser)
+        let started = try sendCoreCommand("/_start main=on snd_files=on")
+        try NativeChatParser.validateCommandResponse(started)
+        let localSend = try sendCoreCommand(
+            #"/_create *1 json [{"msgContent":{"type":"text","text":"Native response check"},"mentions":{}}]"#
+        )
+        try NativeChatParser.validateCommandResponse(
+            localSend,
+            expectedType: "newChatItems",
+            requireChatItems: true
+        )
+
         let originalURL = temporaryDirectory.appendingPathComponent("original.jpg")
         let encryptedURL = temporaryDirectory.appendingPathComponent("encrypted.jpg")
         try original.write(to: originalURL)

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -1000,7 +1000,15 @@ private func makeLiveRefreshModel(probe: ConversationRefreshProbe) -> AppModel {
         sent: newerTarget.sent,
         author: newerTarget.author
     )
+    model.draft = "Ready after cancellation"
     #expect(model.openQuotedMessage(newerQuote, from: 911) == nil)
+
+    // Then: the obsolete loader no longer keeps the winning transcript artificially busy.
+    #expect(!model.isLoadingConversation)
+    #expect(model.canSendDraft)
+    #expect(model.canRefreshConversation)
+
+    // When: the cancelled operation eventually cooperates and returns.
     await probe.release()
     await olderNavigation.value
 

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -3,6 +3,21 @@ import Foundation
 import Testing
 @testable import SimpleXNative
 
+@Test func processLockAllowsOnlyOneNativeFrontend() throws {
+    // Given
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let lockURL = directory.appendingPathComponent("simplex-native.lock")
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    // When / Then
+    var firstGuard = SingleInstanceGuard(lockURL: lockURL)
+    #expect(firstGuard != nil)
+    #expect(SingleInstanceGuard(lockURL: lockURL) == nil)
+    firstGuard = nil
+    #expect(SingleInstanceGuard(lockURL: lockURL) != nil)
+}
+
 @Test func parsesDesktopChatListResponse() throws {
     let json = #"{"result":{"type":"apiChats","user":{"userId":7},"chats":[{"chatInfo":{"type":"direct","contact":{"contactId":42,"localDisplayName":"Alice","profile":{"displayName":"Alice"}}},"chatItems":[{"meta":{"itemText":"Hello","itemTs":"2026-08-02T20:00:00Z"}}],"chatStats":{"unreadCount":2}}]}}"#
     let chats = try NativeChatParser.chats(from: Data(json.utf8))

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -86,6 +86,87 @@ import Testing
     #expect(messages.map(\.text) == ["Hi", "Hey"])
 }
 
+@Test func markChatReadUsesTheExistingCoreCommand() {
+    #expect(SimpleXCore.markChatReadCommand(chatID: "@42") == "/_read chat @42")
+    #expect(SimpleXCore.markChatReadCommand(chatID: "#9") == "/_read chat #9")
+}
+
+@MainActor
+@Test func openingTheLatestMessagesClearsUnreadOnlyAfterCoreConfirmation() async throws {
+    let unreadChat = NativeChat(
+        id: "@88",
+        apiID: 88,
+        kind: .direct,
+        displayName: "Unread chat",
+        image: nil,
+        preview: "New message",
+        timestamp: nil,
+        unreadCount: 3,
+        sendAsGroup: false
+    )
+    let readProbe = MarkReadProbe()
+    let model = AppModel(
+        previewMode: false,
+        loadMessagesOperation: { chatID, aroundMessageID in
+            #expect(chatID == unreadChat.id)
+            #expect(aroundMessageID == nil)
+            return [NativeMessage(
+                id: 880,
+                text: "New message",
+                timestamp: nil,
+                sent: false,
+                author: nil,
+                deletable: true,
+                content: .text
+            )]
+        },
+        markChatReadOperation: { chatID in
+            await readProbe.mark(chatID)
+        },
+        windowFocusedOperation: { true }
+    )
+    model.chats = [unreadChat]
+
+    let load = try #require(model.selectChat(unreadChat.id))
+    await load.value
+
+    let recordedChatIDs = await readProbe.recordedChatIDs()
+    #expect(recordedChatIDs == [unreadChat.id])
+    #expect(model.chats.first(where: { $0.id == unreadChat.id })?.unreadCount == 0)
+}
+
+@MainActor
+@Test func backgroundConversationRefreshDoesNotClearUnreadMessages() async throws {
+    let unreadChat = NativeChat(
+        id: "@89",
+        apiID: 89,
+        kind: .direct,
+        displayName: "Background chat",
+        image: nil,
+        preview: "Keep this unread",
+        timestamp: nil,
+        unreadCount: 1,
+        sendAsGroup: false
+    )
+    let readProbe = MarkReadProbe()
+    let model = AppModel(
+        previewMode: false,
+        loadMessagesOperation: { _, _ in [] },
+        markChatReadOperation: { chatID in
+            await readProbe.mark(chatID)
+        },
+        windowFocusedOperation: { false }
+    )
+    model.chats = [unreadChat]
+
+    let load = try #require(model.selectChat(unreadChat.id))
+    await load.value
+
+    let recordedChatIDs = await readProbe.recordedChatIDs()
+    #expect(recordedChatIDs.isEmpty)
+    #expect(model.chats.first?.unreadCount == 1)
+}
+
 @MainActor
 @Test func longMessageBodyUsesItsFullWrappedHeight() {
     let shortHeight = messageBodyHeight("Short message")
@@ -1053,6 +1134,18 @@ private actor DelayedValue<Value: Sendable> {
 
     func release() {
         released = true
+    }
+}
+
+private actor MarkReadProbe {
+    private var chatIDs: [NativeChat.ID] = []
+
+    func mark(_ chatID: NativeChat.ID) {
+        chatIDs.append(chatID)
+    }
+
+    func recordedChatIDs() -> [NativeChat.ID] {
+        chatIDs
     }
 }
 

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -21,15 +21,30 @@ import Testing
 }
 
 @Test func parsesImageMessagePreviewAndFile() throws {
-    let json = #"{"result":{"type":"apiChat","chat":{"chatItems":[{"chatDir":{"type":"directRcv"},"meta":{"itemId":9,"itemText":"A photo","itemTs":"2026-08-02T20:00:00Z","deletable":true},"content":{"type":"rcvMsgContent","msgContent":{"type":"image","text":"A photo","image":"data:image/jpeg;base64,AA=="}},"file":{"fileName":"photo.jpg","fileSource":{"filePath":"photo.jpg","cryptoArgs":null}}}]}}}"#
+    let json = #"{"result":{"type":"apiChat","chat":{"chatItems":[{"chatDir":{"type":"directRcv"},"meta":{"itemId":9,"itemText":"A photo","itemTs":"2026-08-02T20:00:00Z","deletable":true},"content":{"type":"rcvMsgContent","msgContent":{"type":"image","text":"A photo","image":"data:image/jpeg;base64,AA=="}},"quotedItem":{"chatDir":{"type":"directSnd"},"itemId":7,"sentAt":"2026-08-02T19:59:00Z","content":{"type":"text","text":"Original message"}},"file":{"fileName":"photo.jpg","fileSource":{"filePath":"photo.jpg","cryptoArgs":{"fileKey":"test-key","fileNonce":"test-nonce"}}}}]}}}"#
     let message = try #require(NativeChatParser.messages(from: Data(json.utf8)).first)
     #expect(message.deletable)
     #expect(message.content == .image(
         preview: "data:image/jpeg;base64,AA==",
-        fileName: "photo.jpg",
-        filePath: "photo.jpg"
+        fileName: "photo.jpg"
     ))
-    #expect(message.content.fileURL?.lastPathComponent == "photo.jpg")
+    #expect(message.fileSource?.sourceURL.lastPathComponent == "photo.jpg")
+    #expect(message.fileSource?.cryptoArgs == NativeCryptoFileArgs(fileKey: "test-key", fileNonce: "test-nonce"))
+    #expect(message.quotedItem == NativeQuote(messageID: 7, text: "Original message", sent: true, author: nil))
+}
+
+@Test func composedMessagesIncludeAQuoteOnlyWhenReplying() {
+    let reply = SimpleXCore.composedMessage(
+        messageContent: ["type": "text", "text": "Reply"],
+        quotedItemID: 42
+    )
+    #expect(reply["quotedItemId"] as? Int64 == 42)
+
+    let ordinary = SimpleXCore.composedMessage(
+        messageContent: ["type": "text", "text": "Ordinary"],
+        quotedItemID: nil
+    )
+    #expect(ordinary["quotedItemId"] == nil)
 }
 
 @Test func messageSelectionSupportsRangesAndCommandToggle() {
@@ -174,7 +189,7 @@ func databasePassphraseKeychainAddsUpdatesLoadsAndDeletes() async throws {
     #expect(NativeChatParser.commandError(from: success) == nil)
 }
 
-@Test func opensTemporaryDatabaseWithBundledCore() throws {
+@Test func opensTemporaryDatabaseAndDecryptsAttachmentWithBundledCore() async throws {
     guard let libraryDirectory = ProcessInfo.processInfo.environment["SIMPLEX_CORE_LIB_DIR"] else {
         return
     }
@@ -201,9 +216,43 @@ func databasePassphraseKeychainAddsUpdatesLoadsAndDeletes() async throws {
     let response = try #require(result.flatMap(String.init(validatingUTF8:)))
     #expect(NativeChatParser.migrationSucceeded(Data(response.utf8)))
     if let result { sx_core_free(result) }
+    var encryptedSource: NativeCryptoFile?
+    let original = Data([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0xff, 0xd9])
     if let controller {
-        if let closeResult = sx_core_close_store(controller) {
-            sx_core_free(closeResult)
+        defer {
+            if let closeResult = sx_core_close_store(controller) {
+                sx_core_free(closeResult)
+            }
         }
+        let originalURL = temporaryDirectory.appendingPathComponent("original.jpg")
+        let encryptedURL = temporaryDirectory.appendingPathComponent("encrypted.jpg")
+        try original.write(to: originalURL)
+
+        let encryptResult = originalURL.path.withCString { fromPath in
+            encryptedURL.path.withCString { toPath in
+                sx_core_encrypt_file(controller, fromPath, toPath)
+            }
+        }
+        let encryptJSON = try #require(encryptResult.flatMap(String.init(validatingUTF8:)))
+        if let encryptResult { sx_core_free(encryptResult) }
+        let encryptObject = try #require(
+            JSONSerialization.jsonObject(with: Data(encryptJSON.utf8)) as? [String: Any]
+        )
+        let cryptoArgs = try #require(encryptObject["cryptoArgs"] as? [String: Any])
+        let key = try #require(cryptoArgs["fileKey"] as? String)
+        let nonce = try #require(cryptoArgs["fileNonce"] as? String)
+        encryptedSource = NativeCryptoFile(
+            filePath: encryptedURL.path,
+            cryptoArgs: NativeCryptoFileArgs(fileKey: key, fileNonce: nonce)
+        )
     }
+
+    let attachmentCore = SimpleXCore()
+    let source = try #require(encryptedSource)
+    let decryptedURL = try await attachmentCore.openableURL(
+        for: source,
+        fileName: "photo.jpg"
+    )
+    #expect(decryptedURL.lastPathComponent == "photo.jpg")
+    #expect(try Data(contentsOf: decryptedURL) == original)
 }

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -28,6 +28,35 @@ import Testing
     #expect(chats[0].unreadCount == 2)
 }
 
+@Test func channelOwnersSendGroupRepliesWithTheGroupIdentity() throws {
+    // Given
+    let json = #"{"result":{"type":"apiChats","user":{"userId":7},"chats":[{"chatInfo":{"type":"group","groupInfo":{"groupId":9,"localDisplayName":"News","useRelays":true,"membership":{"memberRole":"owner"},"groupProfile":{"displayName":"News"}}},"chatItems":[],"chatStats":{}}]}}"#
+
+    // When
+    let chat = try #require(NativeChatParser.chats(from: Data(json.utf8)).first)
+    let reply = SimpleXCore.composedMessage(
+        messageContent: ["type": "text", "text": "Reply"],
+        quotedItemID: 42
+    )
+    let command = try SimpleXCore.sendCommand(message: reply, to: chat)
+
+    // Then
+    #expect(chat.sendAsGroup)
+    #expect(command.hasPrefix("/_send #9(as_group=on) "))
+}
+
+@Test func ordinaryGroupsAndScopedSupportChatsDoNotImpersonateTheGroup() throws {
+    // Given
+    let json = #"{"result":{"type":"apiChats","user":{"userId":7},"chats":[{"chatInfo":{"type":"group","groupInfo":{"groupId":9,"localDisplayName":"Friends","useRelays":false,"membership":{"memberRole":"owner"},"groupProfile":{"displayName":"Friends"}}},"chatItems":[],"chatStats":{}},{"chatInfo":{"type":"group","groupChatScope":{"type":"memberSupport","groupMember_":null},"groupInfo":{"groupId":10,"localDisplayName":"Support","useRelays":true,"membership":{"memberRole":"owner"},"groupProfile":{"displayName":"Support"}}},"chatItems":[],"chatStats":{}}]}}"#
+
+    // When
+    let chats = try NativeChatParser.chats(from: Data(json.utf8))
+
+    // Then
+    #expect(chats.count == 2)
+    #expect(chats.allSatisfy { !$0.sendAsGroup })
+}
+
 @Test func parsesConversationDirections() throws {
     let json = #"{"result":{"type":"apiChat","chat":{"chatItems":[{"chatDir":{"type":"directRcv"},"meta":{"itemId":1,"itemText":"Hi","itemTs":"2026-08-02T20:00:00Z"}},{"chatDir":{"type":"directSnd"},"meta":{"itemId":2,"itemText":"Hey","itemTs":"2026-08-02T20:01:00Z"}}]}}}"#
     let messages = try NativeChatParser.messages(from: Data(json.utf8))
@@ -97,6 +126,13 @@ private let replyEligibilityCases = [
     ReplyEligibilityCase(
         name: "live message",
         itemID: 4,
+        metaFields: #", "itemLive":true"#,
+        content: #"{"type":"rcvMsgContent","msgContent":{"type":"text","text":"Typing"}}"#,
+        expected: false
+    ),
+    ReplyEligibilityCase(
+        name: "legacy live message alias",
+        itemID: 6,
         metaFields: #", "isLive":true"#,
         content: #"{"type":"rcvMsgContent","msgContent":{"type":"text","text":"Typing"}}"#,
         expected: false
@@ -232,6 +268,74 @@ private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: Quot
         quotedItemID: nil
     )
     #expect(ordinary["quotedItemId"] == nil)
+}
+
+@Test func coreSendCommandsPreserveQuoteIdentityForDirectAndGroupReplies() throws {
+    // Given
+    let message = SimpleXCore.composedMessage(
+        messageContent: ["type": "text", "text": "Reply"],
+        quotedItemID: 42
+    )
+    let direct = NativeChat(
+        id: "@7",
+        apiID: 7,
+        kind: .direct,
+        displayName: "Maya",
+        image: nil,
+        preview: "",
+        timestamp: nil,
+        unreadCount: 0,
+        sendAsGroup: false
+    )
+    let group = NativeChat(
+        id: "#9",
+        apiID: 9,
+        kind: .group,
+        displayName: "Weekend plans",
+        image: nil,
+        preview: "",
+        timestamp: nil,
+        unreadCount: 0,
+        sendAsGroup: true
+    )
+
+    // When
+    let directCommand = try SimpleXCore.sendCommand(message: message, to: direct)
+    let groupCommand = try SimpleXCore.sendCommand(message: message, to: group)
+
+    // Then
+    #expect(directCommand.hasPrefix("/_send @7 live=off ttl=default sign=off json "))
+    #expect(groupCommand.hasPrefix("/_send #9(as_group=on) live=off ttl=default sign=off json "))
+    for command in [directCommand, groupCommand] {
+        let json = try #require(command.components(separatedBy: " json ").last)
+        let encoded = try #require(json.data(using: .utf8))
+        let messages = try #require(JSONSerialization.jsonObject(with: encoded) as? [[String: Any]])
+        #expect(messages.first?["quotedItemId"] as? Int64 == 42)
+    }
+}
+
+@Test func coreRejectsQuotedMessagesInNonReplyableConversations() {
+    // Given
+    let message = SimpleXCore.composedMessage(
+        messageContent: ["type": "text", "text": "Reply"],
+        quotedItemID: 42
+    )
+    let notes = NativeChat(
+        id: "*1",
+        apiID: 1,
+        kind: .local,
+        displayName: "Private notes",
+        image: nil,
+        preview: "",
+        timestamp: nil,
+        unreadCount: 0,
+        sendAsGroup: false
+    )
+
+    // When / Then
+    #expect(throws: NativeChatError.self) {
+        _ = try SimpleXCore.sendCommand(message: message, to: notes)
+    }
 }
 
 @Test func singleMessageReloadUsesTheCoreQuoteResolutionPagination() {

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -391,6 +391,30 @@ private actor DelayedConversationLoadFailure {
     }
 }
 
+private actor DelayedValue<Value: Sendable> {
+    private let value: Value
+    private var requested = false
+    private var released = false
+
+    init(_ value: Value) {
+        self.value = value
+    }
+
+    func load() async -> Value {
+        requested = true
+        while !released { await Task.yield() }
+        return value
+    }
+
+    func waitUntilRequested() async {
+        while !requested { await Task.yield() }
+    }
+
+    func release() {
+        released = true
+    }
+}
+
 @MainActor
 @Test func offscreenQuoteFailureCannotLeakIntoANewConversation() async throws {
     // Given
@@ -412,6 +436,105 @@ private actor DelayedConversationLoadFailure {
     #expect(model.selectedChatID == "#2")
     #expect(model.quoteNavigationError == nil)
     #expect(model.phase == .ready)
+}
+
+@MainActor
+@Test func newerKnownQuoteCancelsOlderUnresolvedQuoteNavigation() async throws {
+    // Given
+    let model = AppModel(previewMode: true)
+    let newerTarget = try #require(model.messages.first)
+    let olderTarget = NativeMessage(
+        id: 906,
+        text: "Older target",
+        timestamp: nil,
+        sent: false,
+        author: "Maya",
+        deletable: true,
+        content: .text
+    )
+    let olderContainingMessage = NativeMessage(
+        id: 907,
+        text: "Reply with unresolved metadata",
+        timestamp: nil,
+        sent: true,
+        author: nil,
+        deletable: true,
+        content: .text,
+        quotedItem: NativeQuote(
+            messageID: olderTarget.id,
+            text: olderTarget.text,
+            sent: olderTarget.sent,
+            author: olderTarget.author
+        )
+    )
+    let probe = DelayedValue<NativeMessage?>(olderContainingMessage)
+    let testModel = AppModel(
+        previewMode: true,
+        loadMessageOperation: { _, _ in await probe.load() }
+    )
+    let unresolvedQuote = NativeQuote(messageID: nil, text: olderTarget.text, sent: false, author: "Maya")
+
+    // When: the older metadata reload starts, then a newer loaded quote is opened.
+    let olderNavigation = try #require(testModel.openQuotedMessage(unresolvedQuote, from: olderContainingMessage.id))
+    await probe.waitUntilRequested()
+    let newerQuote = NativeQuote(
+        messageID: newerTarget.id,
+        text: newerTarget.text,
+        sent: newerTarget.sent,
+        author: newerTarget.author
+    )
+    #expect(testModel.openQuotedMessage(newerQuote, from: 908) == nil)
+    await probe.release()
+    await olderNavigation.value
+
+    // Then: the late older result cannot replace the newest scroll target.
+    #expect(testModel.targetMessageID == newerTarget.id)
+    #expect(testModel.quoteNavigationError == nil)
+}
+
+@MainActor
+@Test func loadedQuoteCancelsOlderOffscreenPageLoad() async throws {
+    // Given
+    let offscreenTarget = NativeMessage(
+        id: 909,
+        text: "Offscreen target",
+        timestamp: nil,
+        sent: false,
+        author: "Maya",
+        deletable: true,
+        content: .text
+    )
+    let probe = DelayedValue([offscreenTarget])
+    let model = AppModel(
+        previewMode: true,
+        loadMessagesOperation: { _, _ in await probe.load() }
+    )
+    let originalMessages = model.messages
+    let newerTarget = try #require(originalMessages.first)
+    let offscreenQuote = NativeQuote(
+        messageID: offscreenTarget.id,
+        text: offscreenTarget.text,
+        sent: offscreenTarget.sent,
+        author: offscreenTarget.author
+    )
+
+    // When: an offscreen load starts, then a loaded quote is chosen.
+    let olderNavigation = try #require(model.openQuotedMessage(offscreenQuote, from: 910))
+    await probe.waitUntilRequested()
+    let newerQuote = NativeQuote(
+        messageID: newerTarget.id,
+        text: newerTarget.text,
+        sent: newerTarget.sent,
+        author: newerTarget.author
+    )
+    #expect(model.openQuotedMessage(newerQuote, from: 911) == nil)
+    await probe.release()
+    await olderNavigation.value
+
+    // Then: the cancelled page cannot replace the transcript or newest target.
+    #expect(model.messages == originalMessages)
+    #expect(model.targetMessageID == newerTarget.id)
+    #expect(model.quoteNavigationError == nil)
 }
 
 private actor AttachmentOpenProbe {

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -86,6 +86,13 @@ private let replyEligibilityCases = [
         content: #"{"type":"rcvMsgContent","msgContent":{"type":"text","text":"Typing"}}"#,
         expected: false
     ),
+    ReplyEligibilityCase(
+        name: "other temporary message",
+        itemID: -1,
+        metaFields: "",
+        content: #"{"type":"sndMsgContent","msgContent":{"type":"text","text":"Pending"}}"#,
+        expected: false
+    ),
 ]
 
 @Test(arguments: replyEligibilityCases)
@@ -418,6 +425,31 @@ private actor AttachmentOpenProbe {
 }
 
 @MainActor
+@Test func replyActionUsesTheCurrentTranscriptItemInsteadOfAStaleRow() throws {
+    // Given
+    let original = try #require(NativePreviewData.messages(for: "@1").first)
+    let unavailable = NativeMessage(
+        id: original.id,
+        text: "Message deleted",
+        timestamp: original.timestamp,
+        sent: original.sent,
+        author: original.author,
+        deletable: false,
+        content: original.content,
+        replyable: false
+    )
+    let model = AppModel(previewMode: true)
+    model.messages = [unavailable]
+
+    // When: a row action captured before the refresh invokes Reply afterward.
+    model.beginReply(to: original)
+
+    // Then
+    #expect(model.replyingTo == nil)
+    #expect(model.composerFocusRequest == 0)
+}
+
+@MainActor
 @Test func liveRefreshUpdatesOrInvalidatesReplyContextWithoutLosingDraft() throws {
     // Given
     let original = try #require(NativePreviewData.messages(for: "@1").first)
@@ -534,17 +566,83 @@ private actor AttachmentSendProbe {
     }
 }
 
+private actor ReplyValidationProbe {
+    private var requested = false
+    private var released = false
+    private var sendCount = 0
+
+    func validate() async -> NativeMessage? {
+        requested = true
+        while !released { await Task.yield() }
+        return nil
+    }
+
+    func waitUntilRequested() async {
+        while !requested { await Task.yield() }
+    }
+
+    func release() {
+        released = true
+    }
+
+    func recordSend() {
+        sendCount += 1
+    }
+
+    func recordedSendCount() -> Int {
+        sendCount
+    }
+}
+
 @MainActor
 private func makeSendTestModel(
     sendTextOperation: SendTextOperation? = nil,
-    sendAttachmentOperation: SendAttachmentOperation? = nil
+    sendAttachmentOperation: SendAttachmentOperation? = nil,
+    loadMessageOperation: LoadMessageOperation? = nil
 ) -> AppModel {
     let model = AppModel(
         previewMode: true,
         sendTextOperation: sendTextOperation,
-        sendAttachmentOperation: sendAttachmentOperation
+        sendAttachmentOperation: sendAttachmentOperation,
+        loadMessageOperation: loadMessageOperation
     )
     return model
+}
+
+@MainActor
+@Test func deletedReplyTargetIsRecheckedBeforeSendingAndTheDraftSurvivesAChatSwitch() async throws {
+    // Given
+    let probe = ReplyValidationProbe()
+    let model = makeSendTestModel(
+        sendTextOperation: { _, _, _ in await probe.recordSend() },
+        loadMessageOperation: { _, _ in await probe.validate() }
+    )
+    let original = try #require(model.messages.first)
+    model.draft = "Keep this reply"
+    model.beginReply(to: original)
+
+    // When
+    model.sendDraft()
+    let send = try #require(model.sendTask)
+    await probe.waitUntilRequested()
+    model.selectChat("#2")
+    await probe.release()
+    await send.value
+
+    // Then: nothing is sent or leaked into the currently visible conversation.
+    let sendCount = await probe.recordedSendCount()
+    #expect(sendCount == 0)
+    #expect(model.selectedChatID == "#2")
+    #expect(model.draft.isEmpty)
+    #expect(model.replyingTo == nil)
+    #expect(model.replyContextError == nil)
+    #expect(model.phase == .ready)
+
+    // And: returning to the originating chat restores the draft and explains the cancelled quote.
+    model.selectChat("@1")
+    #expect(model.draft == "Keep this reply")
+    #expect(model.replyingTo == nil)
+    #expect(model.replyContextError == "The message you were replying to is no longer available. Your draft was kept.")
 }
 
 @MainActor

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -1881,6 +1881,33 @@ private actor DelayedTextSendProbe {
     }
 }
 
+private actor DelayedPostSendRefreshFailure {
+    private let failureMessage: String
+    private let recoveredMessages: [NativeMessage]
+    private var requestCount = 0
+    private var firstRequestReleased = false
+
+    init(failureMessage: String, recoveredMessages: [NativeMessage]) {
+        self.failureMessage = failureMessage
+        self.recoveredMessages = recoveredMessages
+    }
+
+    func load() async throws -> [NativeMessage] {
+        requestCount += 1
+        guard requestCount == 1 else { return recoveredMessages }
+        while !firstRequestReleased { await Task.yield() }
+        throw NativeChatError.unavailable(failureMessage)
+    }
+
+    func waitUntilRequested() async {
+        while requestCount == 0 { await Task.yield() }
+    }
+
+    func release() {
+        firstRequestReleased = true
+    }
+}
+
 @MainActor
 private func makeSendTestModel(
     sendTextOperation: SendTextOperation? = nil,
@@ -2063,10 +2090,77 @@ private func unavailableVersion(of message: NativeMessage) -> NativeMessage {
     #expect(model.replyingTo == nil)
     #expect(model.messages == [original, committedReply])
     #expect(model.targetMessageID == committedReply.id)
-    #expect(model.phase == .failed(
+    #expect(model.phase == .ready)
+    #expect(model.sendStatusMessage ==
         "Your message was sent, but the conversation could not refresh. Use Refresh to load it. \(refreshFailure)"
-    ))
+    )
     #expect(!model.isSending)
+}
+
+@MainActor
+@Test func postSendRefreshNoticeWaitsForItsOriginatingConversation() async throws {
+    // Given
+    let refreshFailure = "The newest messages are temporarily unavailable."
+    let original = NativePreviewData.messages(for: "@1")[0]
+    let committedReply = NativeMessage(
+        id: 9_901,
+        text: "Committed before switching chats",
+        timestamp: Date(timeIntervalSince1970: 2),
+        sent: true,
+        author: nil,
+        deletable: true,
+        content: .text,
+        quotedItem: NativeQuote(
+            messageID: original.id,
+            text: original.replyPreview,
+            sent: original.sent,
+            author: original.author
+        )
+    )
+    let refreshProbe = DelayedPostSendRefreshFailure(
+        failureMessage: refreshFailure,
+        recoveredMessages: [original, committedReply]
+    )
+    let model = makeSendTestModel(
+        sendTextOperation: { _, quotedItemID, _ in
+            #expect(quotedItemID == original.id)
+            return NativeSendReceipt(
+                committedMessages: [committedReply],
+                replyContextConfirmed: true
+            )
+        },
+        loadMessagesOperation: { chatID, _ in
+            if chatID == "@1" { return try await refreshProbe.load() }
+            return NativePreviewData.messages(for: chatID)
+        }
+    )
+    model.messages = [original]
+    model.draft = "Send this once"
+    model.beginReply(to: original)
+
+    // When: the reply commits, then the user changes chats before refresh fails.
+    model.sendDraft()
+    let send = try #require(model.sendTask)
+    await refreshProbe.waitUntilRequested()
+    model.selectChat("#2")
+    await refreshProbe.release()
+    await send.value
+
+    // Then: no stale notice interrupts the new conversation.
+    #expect(model.selectedChatID == "#2")
+    #expect(model.phase == .ready)
+    #expect(model.sendStatusMessage == nil)
+
+    // When: the user returns to the conversation that sent the reply.
+    model.selectChat("@1")
+
+    // Then: its queued nonfatal status appears there, and only there.
+    #expect(model.phase == .ready)
+    #expect(model.sendStatusMessage ==
+        "Your message was sent, but the conversation could not refresh. Use Refresh to load it. \(refreshFailure)"
+    )
+    #expect(model.draft.isEmpty)
+    #expect(model.replyingTo == nil)
 }
 
 @MainActor
@@ -3271,6 +3365,19 @@ func databasePassphraseKeychainAddsUpdatesLoadsAndDeletes() async throws {
         let committedReply = try #require(replyReceipt.committedMessages.first)
         #expect(committedReply.text == "Bundled-core reply")
         #expect(committedReply.quotedItem?.messageID == firstItemID)
+
+        let deletedOriginal = try sendCoreCommand(
+            "/_delete item #\(groupID) \(firstItemID) internal"
+        )
+        try NativeChatParser.validateCommandResponse(deletedOriginal)
+        let staleReplyMessage = SimpleXCore.composedMessage(
+            messageContent: ["type": "text", "text": "Stale bundled-core reply"],
+            quotedItemID: firstItemID
+        )
+        let staleReplySend = try sendCoreCommand(
+            SimpleXCore.sendCommand(message: staleReplyMessage, to: group)
+        )
+        #expect(NativeChatParser.commandErrorMakesReplyTargetUnavailable(staleReplySend))
 
         let originalURL = temporaryDirectory.appendingPathComponent("original.jpg")
         let encryptedURL = temporaryDirectory.appendingPathComponent("encrypted.jpg")

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -350,6 +350,51 @@ private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: Quot
 }
 
 @MainActor
+@Test func replyContextNavigatesBackToItsOriginalMessage() throws {
+    // Given
+    let model = AppModel(previewMode: true)
+    let original = try #require(model.messages.first)
+    model.beginReply(to: original)
+    model.targetMessageID = nil
+
+    // When
+    let navigation = model.openReplyTarget()
+
+    // Then
+    #expect(navigation == nil)
+    #expect(model.targetMessageID == original.id)
+    #expect(model.replyingTo?.id == original.id)
+}
+
+@MainActor
+@Test func offscreenReplyContextLoadsItsOriginalMessageBeforeScrolling() async throws {
+    // Given
+    let original = NativePreviewData.messages(for: "@1")[0]
+    let probe = DelayedValue([original])
+    let model = AppModel(
+        previewMode: true,
+        loadMessagesOperation: { chatID, aroundMessageID in
+            #expect(chatID == "@1")
+            #expect(aroundMessageID == original.id)
+            return await probe.load()
+        }
+    )
+    model.beginReply(to: original)
+    model.messages = Array(NativePreviewData.messages(for: "@1").dropFirst())
+
+    // When
+    let navigation = try #require(model.openReplyTarget())
+    await probe.waitUntilRequested()
+    await probe.release()
+    await navigation.value
+
+    // Then
+    #expect(model.messages == [original])
+    #expect(model.targetMessageID == original.id)
+    #expect(model.replyingTo?.id == original.id)
+}
+
+@MainActor
 @Test func deletedOffscreenQuoteShowsLocalErrorWithoutBreakingConversation() async throws {
     // Given
     let quote = NativeQuote(messageID: 902, text: "Deleted original", sent: false, author: "Maya")
@@ -413,6 +458,50 @@ private actor DelayedValue<Value: Sendable> {
     func release() {
         released = true
     }
+}
+
+@MainActor
+@Test func switchingChatsClearsStaleMessagesBeforeTheNewTranscriptLoads() async throws {
+    // Given
+    let oldMessages = NativePreviewData.messages(for: "@1")
+    let newMessages = NativePreviewData.messages(for: "#2")
+    let probe = DelayedValue(newMessages)
+    let model = AppModel(
+        previewMode: false,
+        loadMessagesOperation: { chatID, aroundMessageID in
+            #expect(chatID == "#2")
+            #expect(aroundMessageID == nil)
+            return await probe.load()
+        }
+    )
+    model.phase = .ready
+    model.profile = NativePreviewData.profile
+    model.chats = NativePreviewData.chats
+    model.selectedChatID = "@1"
+    model.messages = oldMessages
+    let staleReplyTarget = try #require(oldMessages.first)
+
+    // When: the new conversation has not loaded yet.
+    model.selectChat("#2")
+
+    // Then: no message from the previous conversation remains interactive.
+    #expect(model.selectedChatID == "#2")
+    #expect(model.messages.isEmpty)
+    #expect(!model.canReply(to: staleReplyTarget))
+    model.beginReply(to: staleReplyTarget)
+    #expect(model.replyingTo == nil)
+
+    // When: the new transcript arrives.
+    await probe.waitUntilRequested()
+    await probe.release()
+    for _ in 0..<1_000 {
+        if model.messages == newMessages { break }
+        await Task.yield()
+    }
+
+    // Then
+    #expect(model.messages == newMessages)
+    #expect(model.selectedChatID == "#2")
 }
 
 @MainActor

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -1,0 +1,60 @@
+import CoreBridge
+import Foundation
+import Testing
+@testable import SimpleXNative
+
+@Test func parsesDesktopChatListResponse() throws {
+    let json = #"{"result":{"type":"apiChats","user":{"userId":7},"chats":[{"chatInfo":{"type":"direct","contact":{"contactId":42,"localDisplayName":"Alice","profile":{"displayName":"Alice"}}},"chatItems":[{"meta":{"itemText":"Hello","itemTs":"2026-08-02T20:00:00Z"}}],"chatStats":{"unreadCount":2}}]}}"#
+    let chats = try NativeChatParser.chats(from: Data(json.utf8))
+    #expect(chats.count == 1)
+    #expect(chats[0].id == "@42")
+    #expect(chats[0].displayName == "Alice")
+    #expect(chats[0].preview == "Hello")
+    #expect(chats[0].unreadCount == 2)
+}
+
+@Test func parsesConversationDirections() throws {
+    let json = #"{"result":{"type":"apiChat","chat":{"chatItems":[{"chatDir":{"type":"directRcv"},"meta":{"itemId":1,"itemText":"Hi","itemTs":"2026-08-02T20:00:00Z"}},{"chatDir":{"type":"directSnd"},"meta":{"itemId":2,"itemText":"Hey","itemTs":"2026-08-02T20:01:00Z"}}]}}}"#
+    let messages = try NativeChatParser.messages(from: Data(json.utf8))
+    #expect(messages.map(\.sent) == [false, true])
+    #expect(messages.map(\.text) == ["Hi", "Hey"])
+}
+
+@Test func recognizesMigrationSuccess() {
+    #expect(NativeChatParser.migrationSucceeded(Data(#"{"type":"ok"}"#.utf8)))
+    #expect(NativeChatParser.migrationSucceeded(Data(#""ok""#.utf8)))
+}
+
+@Test func opensTemporaryDatabaseWithBundledCore() throws {
+    guard let libraryDirectory = ProcessInfo.processInfo.environment["SIMPLEX_CORE_LIB_DIR"] else {
+        return
+    }
+
+    let temporaryDirectory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("simplex-native-core-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+    var error = [CChar](repeating: 0, count: 4096)
+    #expect(sx_core_load(libraryDirectory, &error, error.count))
+    #expect(sx_core_initialize(&error, error.count))
+
+    var controller: UnsafeMutableRawPointer?
+    let databasePrefix = temporaryDirectory.appendingPathComponent("simplex_v1").path
+    let result = databasePrefix.withCString { path in
+        "".withCString { key in
+            "yesUp".withCString { confirmation in
+                sx_core_migrate_init(path, key, confirmation, &controller)
+            }
+        }
+    }
+
+    let response = try #require(result.flatMap(String.init(validatingUTF8:)))
+    #expect(NativeChatParser.migrationSucceeded(Data(response.utf8)))
+    if let result { sx_core_free(result) }
+    if let controller {
+        if let closeResult = sx_core_close_store(controller) {
+            sx_core_free(closeResult)
+        }
+    }
+}

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -3456,6 +3456,43 @@ private actor DelayedDeletionProbe {
     #expect(toggled.selection == [20, 40])
 }
 
+@Test func selectedAttachmentsCopyMeaningfulTextInTranscriptOrder() {
+    let messages = [
+        NativeMessage(
+            id: 1,
+            text: "First message",
+            timestamp: nil,
+            sent: false,
+            author: nil,
+            deletable: true,
+            content: .text
+        ),
+        NativeMessage(
+            id: 2,
+            text: "",
+            timestamp: nil,
+            sent: false,
+            author: nil,
+            deletable: true,
+            content: .image(preview: nil, fileName: "photo.jpg")
+        ),
+        NativeMessage(
+            id: 3,
+            text: "",
+            timestamp: nil,
+            sent: false,
+            author: nil,
+            deletable: true,
+            content: .voice(fileName: nil, duration: 75)
+        ),
+    ]
+
+    #expect(
+        MessageSelection.clipboardText(for: messages)
+            == "First message\n\nphoto.jpg\n\nVoice message, 1:15"
+    )
+}
+
 @Test func replyControlRemainsVisibleAcrossItsHoverRegion() {
     #expect(MessageReplyControlVisibility.isVisible(canReply: true, hovering: true, selected: false))
     #expect(MessageReplyControlVisibility.isVisible(canReply: true, hovering: false, selected: true))

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -783,6 +783,20 @@ private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: Quot
     #expect(model.conversationSearchText == "Hey")
     #expect(model.selectedMessageIDs == [1])
     #expect(model.phase == .ready)
+
+    // When: a notification changes chats before the quote error is acknowledged.
+    model.openNotificationRoute(NotificationRoute(
+        userID: NativePreviewData.profile.userID,
+        remoteHostID: nil,
+        chatID: "#2",
+        messageID: nil
+    ))
+
+    // Then: only the originating chat retains the quote-navigation error.
+    #expect(model.selectedChatID == "#2")
+    #expect(model.quoteNavigationError == nil)
+    model.selectChat("@1")
+    #expect(model.quoteNavigationError == "The original quoted message is no longer available in this conversation.")
 }
 
 @MainActor
@@ -1680,6 +1694,21 @@ private actor AttachmentOpenProbe {
     #expect(model.replyingTo == nil)
     #expect(model.draft == "Keep this draft")
     #expect(model.replyContextError == "The message you were replying to is no longer available. Your draft was kept.")
+
+    // When: a notification moves to another chat before the warning is acknowledged.
+    model.openNotificationRoute(NotificationRoute(
+        userID: NativePreviewData.profile.userID,
+        remoteHostID: nil,
+        chatID: "#2",
+        messageID: nil
+    ))
+
+    // Then: the warning follows its draft instead of leaking or disappearing.
+    #expect(model.selectedChatID == "#2")
+    #expect(model.replyContextError == nil)
+    model.selectChat("@1")
+    #expect(model.draft == "Keep this draft")
+    #expect(model.replyContextError == "The message you were replying to is no longer available. Your draft was kept.")
 }
 
 @MainActor
@@ -2115,6 +2144,22 @@ private func unavailableVersion(of message: NativeMessage) -> NativeMessage {
         "Your message was sent, but the conversation could not refresh. Use Refresh to load it. \(refreshFailure)"
     )
     #expect(!model.isSending)
+
+    // When: the user follows a notification before acknowledging the status.
+    model.openNotificationRoute(NotificationRoute(
+        userID: NativePreviewData.profile.userID,
+        remoteHostID: nil,
+        chatID: "#2",
+        messageID: nil
+    ))
+
+    // Then: the status is retained only for the conversation that sent the reply.
+    #expect(model.selectedChatID == "#2")
+    #expect(model.sendStatusMessage == nil)
+    model.selectChat("@1")
+    #expect(model.sendStatusMessage ==
+        "Your message was sent, but the conversation could not refresh. Use Refresh to load it. \(refreshFailure)"
+    )
 }
 
 @MainActor

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -460,6 +460,182 @@ private actor DelayedValue<Value: Sendable> {
     }
 }
 
+private actor ConversationRefreshProbe {
+    private let messages: [NativeMessage]
+    private let delayFirstRequest: Bool
+    private var requests: [Int64?] = []
+    private var firstRequestReleased: Bool
+
+    init(messages: [NativeMessage], delayFirstRequest: Bool = false) {
+        self.messages = messages
+        self.delayFirstRequest = delayFirstRequest
+        firstRequestReleased = !delayFirstRequest
+    }
+
+    func load(around messageID: Int64?) async -> [NativeMessage] {
+        requests.append(messageID)
+        if delayFirstRequest, requests.count == 1 {
+            while !firstRequestReleased { await Task.yield() }
+        }
+        return messages
+    }
+
+    func waitUntilFirstRequested() async {
+        while requests.isEmpty { await Task.yield() }
+    }
+
+    func releaseFirstRequest() {
+        firstRequestReleased = true
+    }
+
+    func recordedRequests() -> [Int64?] {
+        requests
+    }
+}
+
+private actor FallbackRefreshProbe {
+    private let latestMessages: [NativeMessage]
+    private var requests: [Int64?] = []
+
+    init(latestMessages: [NativeMessage]) {
+        self.latestMessages = latestMessages
+    }
+
+    func load(around messageID: Int64?) throws -> [NativeMessage] {
+        requests.append(messageID)
+        if messageID != nil {
+            throw NativeChatError.unavailable("The anchored message was deleted.")
+        }
+        return latestMessages
+    }
+
+    func recordedRequests() -> [Int64?] {
+        requests
+    }
+}
+
+@MainActor
+private func makeLiveRefreshModel(probe: ConversationRefreshProbe) -> AppModel {
+    let model = AppModel(
+        previewMode: false,
+        loadMessagesOperation: { _, aroundMessageID in
+            await probe.load(around: aroundMessageID)
+        },
+        loadChatsOperation: { userID in
+            #expect(userID == NativePreviewData.profile.userID)
+            return NativePreviewData.chats
+        }
+    )
+    model.phase = .ready
+    model.profile = NativePreviewData.profile
+    model.chats = NativePreviewData.chats
+    model.selectedChatID = "@1"
+    model.messages = Array(NativePreviewData.messages(for: "@1").dropFirst())
+    return model
+}
+
+@MainActor
+@Test func liveEventRefreshPreservesTheActiveQuoteNavigationAnchor() async throws {
+    // Given
+    let target = NativePreviewData.messages(for: "@1")[0]
+    let quote = NativeQuote(
+        messageID: target.id,
+        text: target.text,
+        sent: target.sent,
+        author: target.author
+    )
+    let probe = ConversationRefreshProbe(messages: [target])
+    let model = makeLiveRefreshModel(probe: probe)
+
+    // When: the user opens an offscreen quote, then a live event refreshes the transcript.
+    let navigation = try #require(model.openQuotedMessage(quote, from: 912))
+    await navigation.value
+    await model.refreshAfterEvent()
+
+    // Then: both loads stay anchored to the user-selected original message.
+    let requests = await probe.recordedRequests()
+    #expect(requests == [target.id, target.id])
+    #expect(model.conversationAnchorMessageID == target.id)
+    #expect(model.messages == [target])
+    #expect(model.quoteNavigationError == nil)
+    #expect(model.phase == .ready)
+}
+
+@MainActor
+@Test func liveEventRefreshCannotSupersedeAnInFlightQuoteNavigation() async throws {
+    // Given
+    let target = NativePreviewData.messages(for: "@1")[0]
+    let quote = NativeQuote(
+        messageID: target.id,
+        text: target.text,
+        sent: target.sent,
+        author: target.author
+    )
+    let probe = ConversationRefreshProbe(messages: [target], delayFirstRequest: true)
+    let model = makeLiveRefreshModel(probe: probe)
+
+    // When: a live event arrives while the user-requested page is still loading.
+    let navigation = try #require(model.openQuotedMessage(quote, from: 913))
+    await probe.waitUntilFirstRequested()
+    #expect(model.isLoadingConversation)
+    await model.refreshAfterEvent()
+
+    // Then: the event updates the chat list without starting a competing transcript load.
+    var requests = await probe.recordedRequests()
+    #expect(requests == [target.id])
+
+    // When: the original navigation finishes.
+    await probe.releaseFirstRequest()
+    await navigation.value
+
+    // Then
+    requests = await probe.recordedRequests()
+    #expect(requests == [target.id])
+    #expect(model.conversationAnchorMessageID == target.id)
+    #expect(model.messages == [target])
+    #expect(!model.isLoadingConversation)
+    #expect(model.quoteNavigationError == nil)
+}
+
+@MainActor
+@Test func liveEventRefreshFallsBackWhenTheAnchoredMessageDisappears() async throws {
+    // Given
+    let target = NativePreviewData.messages(for: "@1")[0]
+    let latestMessages = Array(NativePreviewData.messages(for: "@1").dropFirst())
+    let probe = FallbackRefreshProbe(latestMessages: latestMessages)
+    let model = AppModel(
+        previewMode: false,
+        loadMessagesOperation: { _, aroundMessageID in
+            try await probe.load(around: aroundMessageID)
+        },
+        loadChatsOperation: { _ in NativePreviewData.chats }
+    )
+    model.phase = .ready
+    model.profile = NativePreviewData.profile
+    model.chats = NativePreviewData.chats
+    model.selectedChatID = "@1"
+    model.messages = [target]
+    let quote = NativeQuote(
+        messageID: target.id,
+        text: target.text,
+        sent: target.sent,
+        author: target.author
+    )
+    #expect(model.openQuotedMessage(quote, from: 914) == nil)
+    #expect(model.conversationAnchorMessageID == target.id)
+
+    // When
+    await model.refreshAfterEvent()
+
+    // Then: the missing anchor is dropped and the newest transcript is loaded.
+    let requests = await probe.recordedRequests()
+    #expect(requests == [target.id, nil])
+    #expect(model.conversationAnchorMessageID == nil)
+    #expect(model.messages == latestMessages)
+    #expect(model.quoteNavigationError == nil)
+    #expect(model.phase == .ready)
+}
+
 @MainActor
 @Test func switchingChatsClearsStaleMessagesBeforeTheNewTranscriptLoads() async throws {
     // Given

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -351,10 +351,12 @@ private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: Quot
         expectedType: "newChatItems",
         requireChatItems: true
     )
-    #expect(try NativeChatParser.validateSendResponse(
+    let committedReplyReceipt = try NativeChatParser.validateSendResponse(
         committedReply,
         quotedItemID: 42
-    ).replyContextConfirmed)
+    )
+    #expect(committedReplyReceipt.replyContextConfirmed)
+    #expect(committedReplyReceipt.committedMessages.map(\.id) == [9])
     #expect(try !NativeChatParser.validateSendResponse(
         committed,
         quotedItemID: 42
@@ -1795,7 +1797,22 @@ private actor AttachmentSendProbe {
         if requests.count == failingRequest {
             throw NativeChatError.unavailable("The attachment could not be sent.")
         }
-        return .confirmed
+        let committedMessage = NativeMessage(
+            id: 20_000 + Int64(requests.count),
+            text: caption,
+            timestamp: nil,
+            sent: true,
+            author: nil,
+            deletable: true,
+            content: .image(preview: nil, fileName: attachment.fileName),
+            quotedItem: quotedItemID.map {
+                NativeQuote(messageID: $0, text: "Original message", sent: false, author: "Maya")
+            }
+        )
+        return NativeSendReceipt(
+            committedMessages: [committedMessage],
+            replyContextConfirmed: quotedItemID == nil || committedMessage.quotedItem?.messageID == quotedItemID
+        )
     }
 
     func recordedRequests() -> [Request] {
@@ -1970,7 +1987,7 @@ private func unavailableVersion(of message: NativeMessage) -> NativeMessage {
     let model = makeSendTestModel(sendTextOperation: { _, quotedItemID, _ in
         #expect(quotedItemID == original.id)
         withUnsafeCurrentTask { $0?.cancel() }
-        return NativeSendReceipt(replyContextConfirmed: false)
+        return NativeSendReceipt(committedMessages: [], replyContextConfirmed: false)
     })
     model.messages = [original]
     model.draft = "Send this once"
@@ -1994,10 +2011,37 @@ private func unavailableVersion(of message: NativeMessage) -> NativeMessage {
     // Given
     let refreshFailure = "The newest messages are temporarily unavailable."
     let original = NativePreviewData.messages(for: "@1")[0]
+    let racingEventCopy = NativeMessage(
+        id: 9_900,
+        text: "Sending reply",
+        timestamp: Date(timeIntervalSince1970: 1),
+        sent: true,
+        author: nil,
+        deletable: true,
+        content: .text
+    )
+    let committedReply = NativeMessage(
+        id: racingEventCopy.id,
+        text: "Committed reply",
+        timestamp: Date(timeIntervalSince1970: 2),
+        sent: true,
+        author: nil,
+        deletable: true,
+        content: .text,
+        quotedItem: NativeQuote(
+            messageID: original.id,
+            text: original.replyPreview,
+            sent: original.sent,
+            author: original.author
+        )
+    )
     let model = makeSendTestModel(
         sendTextOperation: { _, quotedItemID, _ in
             #expect(quotedItemID == original.id)
-            return .confirmed
+            return NativeSendReceipt(
+                committedMessages: [committedReply],
+                replyContextConfirmed: true
+            )
         },
         loadMessagesOperation: { chatID, aroundMessageID in
             #expect(chatID == "@1")
@@ -2005,7 +2049,7 @@ private func unavailableVersion(of message: NativeMessage) -> NativeMessage {
             throw NativeChatError.unavailable(refreshFailure)
         }
     )
-    model.messages = [original]
+    model.messages = [original, racingEventCopy]
     model.draft = "Send this once"
     model.beginReply(to: original)
 
@@ -2017,6 +2061,8 @@ private func unavailableVersion(of message: NativeMessage) -> NativeMessage {
     // Then: the committed message is not restored for a duplicate retry.
     #expect(model.draft.isEmpty)
     #expect(model.replyingTo == nil)
+    #expect(model.messages == [original, committedReply])
+    #expect(model.targetMessageID == committedReply.id)
     #expect(model.phase == .failed(
         "Your message was sent, but the conversation could not refresh. Use Refresh to load it. \(refreshFailure)"
     ))
@@ -2107,6 +2153,7 @@ private func unavailableVersion(of message: NativeMessage) -> NativeMessage {
         try await probe.send(attachment, caption: caption, quotedItemID: quotedItemID)
     })
     let original = try #require(model.messages.first)
+    let initialMessageCount = model.messages.count
     let attachments = ["one.jpg", "two.jpg"].map {
         PendingAttachment(
             id: UUID(),
@@ -2134,6 +2181,9 @@ private func unavailableVersion(of message: NativeMessage) -> NativeMessage {
     #expect(model.pendingAttachments == [attachments[1]])
     #expect(model.draft == "Batch caption")
     #expect(model.replyingTo == nil)
+    #expect(model.messages.count == initialMessageCount + 1)
+    #expect(model.messages.last?.content == .image(preview: nil, fileName: "one.jpg"))
+    #expect(model.messages.last?.quotedItem?.messageID == original.id)
     #expect(!model.isSending)
 }
 
@@ -2186,7 +2236,7 @@ private func unavailableVersion(of message: NativeMessage) -> NativeMessage {
     let model = makeSendTestModel(sendAttachmentOperation: { _, _, quotedItemID, _ in
         #expect(quotedItemID != nil)
         withUnsafeCurrentTask { $0?.cancel() }
-        return NativeSendReceipt(replyContextConfirmed: false)
+        return NativeSendReceipt(committedMessages: [], replyContextConfirmed: false)
     })
     let original = try #require(model.messages.first)
     model.pendingAttachments = [attachment]
@@ -3218,6 +3268,9 @@ func databasePassphraseKeychainAddsUpdatesLoadsAndDeletes() async throws {
             quotedItemID: firstItemID
         )
         #expect(replyReceipt.replyContextConfirmed)
+        let committedReply = try #require(replyReceipt.committedMessages.first)
+        #expect(committedReply.text == "Bundled-core reply")
+        #expect(committedReply.quotedItem?.messageID == firstItemID)
 
         let originalURL = temporaryDirectory.appendingPathComponent("original.jpg")
         let encryptedURL = temporaryDirectory.appendingPathComponent("encrypted.jpg")

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -187,6 +187,24 @@ private func whitespaceOnlyQuotedAttachmentsUseMeaningfulPreviews(testCase: Quot
     #expect(unnamedPhoto.replyPreview == "Photo")
 }
 
+@Test func parsesVoiceMessageForPlaybackAndReplyContext() throws {
+    // Given
+    let json = #"{"result":{"type":"apiChat","chat":{"chatItems":[{"chatDir":{"type":"directRcv"},"meta":{"itemId":12,"itemText":"","itemTs":"2026-08-02T20:00:00Z"},"content":{"type":"rcvMsgContent","msgContent":{"type":"voice","text":"","duration":65}},"file":{"fileName":"voice.m4a","fileSource":{"filePath":"voice.m4a","cryptoArgs":{"fileKey":"key","fileNonce":"nonce"}}}}]}}}"#
+
+    // When
+    let message = try #require(NativeChatParser.messages(from: Data(json.utf8)).first)
+
+    // Then
+    #expect(message.content == .voice(fileName: "voice.m4a", duration: 65))
+    #expect(message.content.fileName == "voice.m4a")
+    #expect(message.replyPreview == "Voice message, 1:05")
+    #expect(message.fileSource == NativeCryptoFile(
+        filePath: "voice.m4a",
+        cryptoArgs: NativeCryptoFileArgs(fileKey: "key", fileNonce: "nonce")
+    ))
+    #expect(message.replyable)
+}
+
 @Test func composedMessagesIncludeAQuoteOnlyWhenReplying() {
     let reply = SimpleXCore.composedMessage(
         messageContent: ["type": "text", "text": "Reply"],

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -1477,6 +1477,30 @@ private actor AttachmentOpenProbe {
     }
 }
 
+private actor DelayedAttachmentOpenFailure {
+    private let message: String
+    private var requested = false
+    private var released = false
+
+    init(_ message: String) {
+        self.message = message
+    }
+
+    func open() async throws {
+        requested = true
+        while !released { await Task.yield() }
+        throw NativeChatError.unavailable(message)
+    }
+
+    func waitUntilRequested() async {
+        while !requested { await Task.yield() }
+    }
+
+    func release() {
+        released = true
+    }
+}
+
 @MainActor
 @Test func attachmentOpenRefreshesMissingEncryptionMetadata() async throws {
     // Given
@@ -1527,7 +1551,70 @@ private actor AttachmentOpenProbe {
     #expect(await probe.source() == encryptedSource)
     #expect(model.messages.first?.fileSource == encryptedSource)
     #expect(model.attachmentOpenError == nil)
-    #expect(model.openingAttachmentIDs.isEmpty)
+    #expect(!model.isOpeningAttachment(original.id))
+}
+
+@MainActor
+@Test func attachmentOpeningStateAndFailuresStayWithTheirConversation() async throws {
+    // Given: an attachment is still opening when the user moves to another chat
+    // whose transcript happens to reuse the same message ID.
+    let failure = "The stored photo could not be decrypted."
+    let probe = DelayedAttachmentOpenFailure(failure)
+    let source = NativeCryptoFile(filePath: "/tmp/encrypted-photo.jpg", cryptoArgs: nil)
+    let first = NativeMessage(
+        id: 92,
+        text: "First photo",
+        timestamp: nil,
+        sent: false,
+        author: "Maya",
+        deletable: true,
+        content: .image(preview: nil, fileName: "first.jpg"),
+        fileSource: source
+    )
+    let second = NativeMessage(
+        id: first.id,
+        text: "Different photo",
+        timestamp: nil,
+        sent: false,
+        author: "Jordan",
+        deletable: true,
+        content: .image(preview: nil, fileName: "second.jpg"),
+        fileSource: source
+    )
+    let model = AppModel(
+        previewMode: true,
+        loadMessageOperation: { chatID, _ in chatID == "@1" ? first : second },
+        openAttachmentOperation: { _, fileName in
+            if fileName == "first.jpg" { try await probe.open() }
+        }
+    )
+    model.messages = [first]
+
+    // When: the first chat's open remains in flight and the second chat appears.
+    let opening = try #require(model.openAttachment(first))
+    await probe.waitUntilRequested()
+    #expect(model.isOpeningAttachment(first.id))
+    model.selectChat("#2")
+    model.messages = [second]
+
+    // Then: the colliding message ID in the new chat is not shown as busy.
+    #expect(!model.isOpeningAttachment(second.id))
+    #expect(model.attachmentOpenError == nil)
+    let secondOpening = try #require(model.openAttachment(second))
+    await secondOpening.value
+    #expect(!model.isOpeningAttachment(second.id))
+    #expect(model.attachmentOpenError == nil)
+
+    // When: the old operation fails after the transition.
+    await probe.release()
+    await opening.value
+
+    // Then: its error waits for its originating conversation.
+    #expect(model.selectedChatID == "#2")
+    #expect(model.attachmentOpenError == nil)
+    model.selectChat("@1")
+    #expect(model.attachmentOpenError == failure)
+    #expect(!model.isOpeningAttachment(first.id))
 }
 
 @MainActor

--- a/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
+++ b/apps/macos-native/Tests/SimpleXNativeTests/NativeChatParserTests.swift
@@ -239,6 +239,17 @@ private func messageBodyHeight(_ text: String) -> CGFloat {
     #expect(AudioPlaybackTime.label(65) == "1:05")
 }
 
+@Test func inlineAudioAutoplayIsConsumedAfterItsFirstAppearance() {
+    var policy = AudioAutoplayPolicy()
+    let firstAppearance = policy.shouldAutoplayOnAppear()
+    let secondAppearance = policy.shouldAutoplayOnAppear()
+    let thirdAppearance = policy.shouldAutoplayOnAppear()
+
+    #expect(firstAppearance)
+    #expect(!secondAppearance)
+    #expect(!thirdAppearance)
+}
+
 @Test func youtubeLinksBecomePrivacyEnhancedInlinePlayersAtTheirTimestamp() throws {
     let embed = try #require(NativeMessageLink.youtubeEmbedURL(for: "https://youtu.be/ishgn7-NLIU?t=24"))
     let components = try #require(URLComponents(url: embed, resolvingAgainstBaseURL: false))

--- a/apps/macos-native/build-app.sh
+++ b/apps/macos-native/build-app.sh
@@ -35,6 +35,7 @@ plutil -insert CFBundlePackageType -string APPL ${APP_DIR}/Contents/Info.plist
 plutil -insert CFBundleShortVersionString -string 7.0.0 ${APP_DIR}/Contents/Info.plist
 plutil -insert CFBundleVersion -string 1 ${APP_DIR}/Contents/Info.plist
 plutil -insert LSApplicationCategoryType -string public.app-category.social-networking ${APP_DIR}/Contents/Info.plist
+plutil -insert LSMultipleInstancesProhibited -bool YES ${APP_DIR}/Contents/Info.plist
 plutil -insert LSMinimumSystemVersion -string 14.0 ${APP_DIR}/Contents/Info.plist
 plutil -insert NSHighResolutionCapable -bool YES ${APP_DIR}/Contents/Info.plist
 plutil -insert NSHumanReadableCopyright -string "Copyright © 2020-2026 SimpleX Chat" ${APP_DIR}/Contents/Info.plist

--- a/apps/macos-native/build-app.sh
+++ b/apps/macos-native/build-app.sh
@@ -12,7 +12,7 @@ if [[ ! -f ${CORE_LIB_DIR}/libsimplex.dylib ]]; then
   exit 1
 fi
 
-swift build --package-path ${SCRIPT_DIR} -c release --product SimpleXNative
+swift build --disable-sandbox --package-path ${SCRIPT_DIR} -c release --product SimpleXNative
 
 if [[ -d ${APP_DIR} ]]; then
   BUILD_TIMESTAMP=$(date +%Y%m%d-%H%M%S)
@@ -38,6 +38,7 @@ plutil -insert LSApplicationCategoryType -string public.app-category.social-netw
 plutil -insert LSMinimumSystemVersion -string 14.0 ${APP_DIR}/Contents/Info.plist
 plutil -insert NSHighResolutionCapable -bool YES ${APP_DIR}/Contents/Info.plist
 plutil -insert NSHumanReadableCopyright -string "Copyright © 2020-2026 SimpleX Chat" ${APP_DIR}/Contents/Info.plist
+plutil -insert SimpleXKeychainPassphraseStorageEnabled -bool NO ${APP_DIR}/Contents/Info.plist
 
 xattr -cr ${APP_DIR}
 codesign --force --deep --sign - ${APP_DIR}

--- a/apps/macos-native/build-app.sh
+++ b/apps/macos-native/build-app.sh
@@ -38,6 +38,7 @@ plutil -insert LSApplicationCategoryType -string public.app-category.social-netw
 plutil -insert LSMinimumSystemVersion -string 14.0 ${APP_DIR}/Contents/Info.plist
 plutil -insert NSHighResolutionCapable -bool YES ${APP_DIR}/Contents/Info.plist
 plutil -insert NSHumanReadableCopyright -string "Copyright © 2020-2026 SimpleX Chat" ${APP_DIR}/Contents/Info.plist
+plutil -insert NSPrincipalClass -string NSApplication ${APP_DIR}/Contents/Info.plist
 plutil -insert SimpleXKeychainPassphraseStorageEnabled -bool NO ${APP_DIR}/Contents/Info.plist
 
 xattr -cr ${APP_DIR}

--- a/apps/macos-native/build-app.sh
+++ b/apps/macos-native/build-app.sh
@@ -1,0 +1,44 @@
+#!/bin/zsh
+set -euo pipefail
+
+SCRIPT_DIR=${0:A:h}
+REPO_ROOT=${SCRIPT_DIR:h:h}
+CORE_LIB_DIR=${SIMPLEX_CORE_LIB_DIR:-${REPO_ROOT}/apps/multiplatform/release/main/app/SimpleX.app/Contents/app/resources}
+OUTPUT_DIR=${SIMPLEX_NATIVE_OUTPUT_DIR:-/private/tmp/simplex-native-build}
+APP_DIR=${OUTPUT_DIR}/SimpleX.app
+
+if [[ ! -f ${CORE_LIB_DIR}/libsimplex.dylib ]]; then
+  print -u2 "SimpleX core libraries not found at ${CORE_LIB_DIR}"
+  exit 1
+fi
+
+swift build --package-path ${SCRIPT_DIR} -c release --product SimpleXNative
+
+if [[ -d ${APP_DIR} ]]; then
+  BUILD_TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+  mv ${APP_DIR} ${OUTPUT_DIR}/SimpleX.previous.${BUILD_TIMESTAMP}.app
+fi
+
+mkdir -p ${APP_DIR}/Contents/MacOS ${APP_DIR}/Contents/Frameworks ${APP_DIR}/Contents/Resources
+cp ${SCRIPT_DIR}/.build/release/SimpleXNative ${APP_DIR}/Contents/MacOS/SimpleX
+cp ${CORE_LIB_DIR}/*.dylib ${APP_DIR}/Contents/Frameworks/
+cp ${REPO_ROOT}/apps/multiplatform/desktop/src/jvmMain/resources/distribute/simplex.icns ${APP_DIR}/Contents/Resources/SimpleX.icns
+
+plutil -create xml1 ${APP_DIR}/Contents/Info.plist
+plutil -insert CFBundleDevelopmentRegion -string en ${APP_DIR}/Contents/Info.plist
+plutil -insert CFBundleExecutable -string SimpleX ${APP_DIR}/Contents/Info.plist
+plutil -insert CFBundleIconFile -string SimpleX ${APP_DIR}/Contents/Info.plist
+plutil -insert CFBundleIdentifier -string chat.simplex.native ${APP_DIR}/Contents/Info.plist
+plutil -insert CFBundleInfoDictionaryVersion -string 6.0 ${APP_DIR}/Contents/Info.plist
+plutil -insert CFBundleName -string SimpleX ${APP_DIR}/Contents/Info.plist
+plutil -insert CFBundlePackageType -string APPL ${APP_DIR}/Contents/Info.plist
+plutil -insert CFBundleShortVersionString -string 7.0.0 ${APP_DIR}/Contents/Info.plist
+plutil -insert CFBundleVersion -string 1 ${APP_DIR}/Contents/Info.plist
+plutil -insert LSApplicationCategoryType -string public.app-category.social-networking ${APP_DIR}/Contents/Info.plist
+plutil -insert LSMinimumSystemVersion -string 14.0 ${APP_DIR}/Contents/Info.plist
+plutil -insert NSHighResolutionCapable -bool YES ${APP_DIR}/Contents/Info.plist
+plutil -insert NSHumanReadableCopyright -string "Copyright © 2020-2026 SimpleX Chat" ${APP_DIR}/Contents/Info.plist
+
+xattr -cr ${APP_DIR}
+codesign --force --deep --sign - ${APP_DIR}
+print ${APP_DIR}

--- a/apps/multiplatform/README.md
+++ b/apps/multiplatform/README.md
@@ -15,11 +15,14 @@ This is the **Kotlin Multiplatform (KMP)** mobile and desktop client for SimpleX
 # Android release APK
 ./gradlew assembleRelease
 
-# Desktop distribution (current OS)
-./gradlew :desktop:packageDistributionForCurrentOS
+# Compile the desktop UI without configuring Android SDK/NDK projects
+./gradlew -PdesktopOnly=true :common:compileKotlinDesktop
+
+# Desktop distribution (current OS, without configuring Android SDK/NDK projects)
+./gradlew -PdesktopOnly=true :desktop:packageDistributionForCurrentOS
 
 # Run desktop/JVM tests
-./gradlew desktopTest
+./gradlew -PdesktopOnly=true desktopTest
 
 # Run Android instrumented tests (requires connected device/emulator)
 ./gradlew connectedAndroidTest

--- a/apps/multiplatform/android/src/main/java/chat/simplex/app/SimplexApp.kt
+++ b/apps/multiplatform/android/src/main/java/chat/simplex/app/SimplexApp.kt
@@ -192,7 +192,7 @@ class SimplexApp: Application(), LifecycleEventObserver {
       override fun hasNotificationsForChat(chatId: String): Boolean = NtfManager.hasNotificationsForChat(chatId)
       override fun cancelNotificationsForChat(chatId: String) = NtfManager.cancelNotificationsForChat(chatId)
       override fun cancelNotificationsForUser(userId: Long) = NtfManager.cancelNotificationsForUser(userId)
-      override fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String?, actions: List<Pair<NotificationAction, () -> Unit>>) = NtfManager.displayNotification(user, chatId, displayName, msgText, image, actions.map { it.first })
+      override fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String?, actions: List<Pair<NotificationAction, () -> Unit>>, remoteHostId: Long?, messageId: Long?) = NtfManager.displayNotification(user, chatId, displayName, msgText, image, actions.map { it.first })
       override fun androidCreateNtfChannelsMaybeShowAlert() = NtfManager.createNtfChannelsMaybeShowAlert()
       override fun cancelCallNotification() = NtfManager.cancelCallNotification()
       override fun cancelAllNotifications() = NtfManager.cancelAllNotifications()

--- a/apps/multiplatform/common/build.gradle.kts
+++ b/apps/multiplatform/common/build.gradle.kts
@@ -1,11 +1,18 @@
+import com.android.build.api.dsl.LibraryExtension
+
 plugins {
   kotlin("multiplatform")
   id("org.jetbrains.compose")
-  id("com.android.library")
+  id("com.android.library") apply false
   id("org.jetbrains.kotlin.plugin.serialization")
   id("org.jetbrains.kotlin.plugin.compose")
   id("dev.icerock.mobile.multiplatform-resources")
   id("com.github.gmazzo.buildconfig") version "5.3.5"
+}
+
+val desktopOnly = providers.gradleProperty("desktopOnly").map(String::toBoolean).getOrElse(false)
+if (!desktopOnly) {
+  apply(plugin = "com.android.library")
 }
 
 group = "chat.simplex"
@@ -37,7 +44,9 @@ if (simplexAssetsDir != null) {
 }
 
 kotlin {
-  androidTarget()
+  if (!desktopOnly) {
+    androidTarget()
+  }
   jvm("desktop")
   applyDefaultHierarchyTemplate()
   sourceSets {
@@ -95,45 +104,47 @@ kotlin {
         implementation(kotlin("test-annotations-common"))
       }
     }
-    val androidMain by getting {
-      kotlin.srcDir("build/generated/moko/androidMain/src")
-      dependencies {
-        implementation("androidx.activity:activity-compose:1.9.1")
-        val workVersion = "2.9.1"
-        implementation("androidx.work:work-runtime-ktx:$workVersion")
+    if (!desktopOnly) {
+      val androidMain by getting {
+        kotlin.srcDir("build/generated/moko/androidMain/src")
+        dependencies {
+          implementation("androidx.activity:activity-compose:1.9.1")
+          val workVersion = "2.9.1"
+          implementation("androidx.work:work-runtime-ktx:$workVersion")
 
-        // Video support
-        implementation("com.google.android.exoplayer:exoplayer:2.19.1")
+          // Video support
+          implementation("com.google.android.exoplayer:exoplayer:2.19.1")
 
-        // Biometric authentication
-        implementation("androidx.biometric:biometric:1.2.0-alpha05")
+          // Biometric authentication
+          implementation("androidx.biometric:biometric:1.2.0-alpha05")
 
-        //Barcode
-        implementation("org.boofcv:boofcv-android:1.1.3")
+          //Barcode
+          implementation("org.boofcv:boofcv-android:1.1.3")
 
-        //Camera Permission
-        implementation("com.google.accompanist:accompanist-permissions:0.34.0")
+          //Camera Permission
+          implementation("com.google.accompanist:accompanist-permissions:0.34.0")
 
-        implementation("androidx.webkit:webkit:1.11.0")
+          implementation("androidx.webkit:webkit:1.11.0")
 
-        // GIFs support
-        implementation("io.coil-kt:coil-compose:2.6.0")
-        implementation("io.coil-kt:coil-gif:2.6.0")
+          // GIFs support
+          implementation("io.coil-kt:coil-compose:2.6.0")
+          implementation("io.coil-kt:coil-gif:2.6.0")
 
-        // Emojis
-        implementation("androidx.emoji2:emoji2-emojipicker:1.4.0")
+          // Emojis
+          implementation("androidx.emoji2:emoji2-emojipicker:1.4.0")
 
-        implementation("com.jakewharton:process-phoenix:3.0.0")
+          implementation("com.jakewharton:process-phoenix:3.0.0")
 
-        // https://issuetracker.google.com/issues/351313880
-        val cameraXVersion = "1.5.1"
-        implementation("androidx.camera:camera-core:${cameraXVersion}")
-        implementation("androidx.camera:camera-camera2:${cameraXVersion}")
-        implementation("androidx.camera:camera-lifecycle:${cameraXVersion}")
-        implementation("androidx.camera:camera-view:${cameraXVersion}")
+          // https://issuetracker.google.com/issues/351313880
+          val cameraXVersion = "1.5.1"
+          implementation("androidx.camera:camera-core:${cameraXVersion}")
+          implementation("androidx.camera:camera-camera2:${cameraXVersion}")
+          implementation("androidx.camera:camera-lifecycle:${cameraXVersion}")
+          implementation("androidx.camera:camera-view:${cameraXVersion}")
 
-        // Calls lifecycle listener
-        implementation("androidx.lifecycle:lifecycle-process:2.8.4")
+          // Calls lifecycle listener
+          implementation("androidx.lifecycle:lifecycle-process:2.8.4")
+        }
       }
     }
     val desktopMain by getting {
@@ -157,23 +168,25 @@ kotlin {
   }
 }
 
-android {
-  namespace = "chat.simplex.common"
-  compileSdk = 35
-  sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
-  defaultConfig {
-    minSdk = 26
-  }
-  testOptions.targetSdk = 34
-  lint.targetSdk = 34
-  val isAndroid = gradle.startParameter.taskNames.find {
-    val lower = it.lowercase()
-    lower.contains("release") || lower.startsWith("assemble") || lower.startsWith("install")
-  } != null
-  if (isAndroid) {
-    // This is not needed on Android but can't be moved to desktopMain because MR lib don't support this.
-    // No other ways to exclude a file work, but it's large and should be excluded
-    kotlin.sourceSets["commonMain"].resources.exclude("/MR/fonts/NotoColorEmoji-Regular.ttf")
+if (!desktopOnly) {
+  extensions.configure<LibraryExtension> {
+    namespace = "chat.simplex.common"
+    compileSdk = 35
+    sourceSets.getByName("main").manifest.srcFile("src/androidMain/AndroidManifest.xml")
+    defaultConfig {
+      minSdk = 26
+    }
+    testOptions.targetSdk = 34
+    lint.targetSdk = 34
+    val isAndroid = gradle.startParameter.taskNames.find {
+      val lower = it.lowercase()
+      lower.contains("release") || lower.startsWith("assemble") || lower.startsWith("install")
+    } != null
+    if (isAndroid) {
+      // This is not needed on Android but can't be moved to desktopMain because MR lib don't support this.
+      // No other ways to exclude a file work, but it's large and should be excluded
+      kotlin.sourceSets["commonMain"].resources.exclude("/MR/fonts/NotoColorEmoji-Regular.ttf")
+    }
   }
 }
 

--- a/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/platform/Modifier.android.kt
+++ b/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/platform/Modifier.android.kt
@@ -10,11 +10,21 @@ actual fun Modifier.desktopOnExternalDrag(
   enabled: Boolean,
   onFiles: (List<File>) -> Unit,
   onImage: (File) -> Unit,
-  onText: (String) -> Unit
+  onText: (String) -> Unit,
+  onDragging: (Boolean) -> Unit,
 ): Modifier = this
 
 actual fun Modifier.onRightClick(action: () -> Unit): Modifier = this
 
 actual fun Modifier.desktopPointerHoverIconHand(): Modifier = this
+
+actual fun Modifier.desktopPointerHoverIconResize(): Modifier = this
+
+actual val macOSWindowVibrancyAvailable: Boolean = false
+
+actual fun openSystemNotificationSettings() {}
+
+@Composable
+actual fun Modifier.desktopMessageSelection(enabled: Boolean, onToggle: () -> Unit, onRange: () -> Unit): Modifier = this
 
 actual fun Modifier.desktopOnHovered(action: (Boolean) -> Unit): Modifier = Modifier

--- a/apps/multiplatform/common/src/commonMain/cpp/desktop/CMakeLists.txt
+++ b/apps/multiplatform/common/src/commonMain/cpp/desktop/CMakeLists.txt
@@ -53,6 +53,13 @@ add_library( # Sets the name of the library.
     # Provides a relative path to your source file(s).
     simplex-api.c)
 
+if(APPLE)
+    enable_language(OBJC)
+    target_sources(app-lib PRIVATE macos-platform.m)
+    find_library(APPKIT_FRAMEWORK AppKit REQUIRED)
+    find_library(USER_NOTIFICATIONS_FRAMEWORK UserNotifications REQUIRED)
+endif()
+
 add_library( simplex SHARED IMPORTED )
 FILE(GLOB SIMPLEXLIB ${CMAKE_SOURCE_DIR}/libs/${OS_LIB_PATH}-${OS_LIB_ARCH}/libsimplex.${OS_LIB_EXT})
 if(WIN32)
@@ -73,7 +80,7 @@ else()
 	FILE(GLOB RTSLIB ${CMAKE_SOURCE_DIR}/libs/${OS_LIB_PATH}-${OS_LIB_ARCH}/libHSrts*_thr-*.${OS_LIB_EXT})
 	set_target_properties( rts PROPERTIES IMPORTED_LOCATION ${RTSLIB})
 
-	target_link_libraries(app-lib rts simplex)
+	target_link_libraries(app-lib rts simplex ${APPKIT_FRAMEWORK} ${USER_NOTIFICATIONS_FRAMEWORK})
 endif()
 
 if(APPLE)

--- a/apps/multiplatform/common/src/commonMain/cpp/desktop/macos-platform.m
+++ b/apps/multiplatform/common/src/commonMain/cpp/desktop/macos-platform.m
@@ -3,6 +3,7 @@
 #include <jni.h>
 
 static NSString * const SimpleXVibrancyIdentifier = @"chat.simplex.sidebar.vibrancy";
+static NSString * const SimpleXTitlebarBackdropIdentifier = @"chat.simplex.titlebar.backdrop";
 static NSString * const SimpleXMessageCategory = @"MESSAGE";
 static NSString * const SimpleXContactCategory = @"CONTACT_REQUEST";
 static NSString * const SimpleXCallCategory = @"INCOMING_CALL";
@@ -81,7 +82,7 @@ static NSSet<UNNotificationCategory *> *notificationCategories(void) {
     ]];
 }
 
-static BOOL configureWindow(NSWindow *window) {
+static BOOL configureWindow(NSWindow *window, NSColor *chromeColor) {
     if (window == nil || window.contentView == nil) return NO;
 
     window.styleMask |= NSWindowStyleMaskFullSizeContentView;
@@ -89,27 +90,54 @@ static BOOL configureWindow(NSWindow *window) {
     window.titleVisibility = NSWindowTitleHidden;
 
     NSView *contentView = window.contentView;
+    NSVisualEffectView *effectView = nil;
+    NSView *titlebarBackdrop = nil;
     for (NSView *view in contentView.subviews.copy) {
-        if ([view.identifier isEqualToString:SimpleXVibrancyIdentifier]) return YES;
+        if ([view.identifier isEqualToString:SimpleXVibrancyIdentifier]) effectView = (NSVisualEffectView *)view;
+        if ([view.identifier isEqualToString:SimpleXTitlebarBackdropIdentifier]) titlebarBackdrop = view;
     }
 
-    NSVisualEffectView *effectView = [[NSVisualEffectView alloc] initWithFrame:contentView.bounds];
-    effectView.identifier = SimpleXVibrancyIdentifier;
-    effectView.material = NSVisualEffectMaterialSidebar;
-    effectView.blendingMode = NSVisualEffectBlendingModeBehindWindow;
-    effectView.state = NSVisualEffectStateFollowsWindowActiveState;
-    effectView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
-    [contentView addSubview:effectView positioned:NSWindowBelow relativeTo:contentView.subviews.firstObject];
+    if (effectView == nil) {
+        effectView = [[NSVisualEffectView alloc] initWithFrame:contentView.bounds];
+        effectView.identifier = SimpleXVibrancyIdentifier;
+        effectView.material = NSVisualEffectMaterialSidebar;
+        effectView.blendingMode = NSVisualEffectBlendingModeBehindWindow;
+        effectView.state = NSVisualEffectStateFollowsWindowActiveState;
+        effectView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+        [contentView addSubview:effectView positioned:NSWindowBelow relativeTo:contentView.subviews.firstObject];
+    }
+
+    CGFloat titlebarHeight = MAX(28.0, NSHeight(contentView.bounds) - NSHeight(window.contentLayoutRect));
+    NSRect titlebarFrame = NSMakeRect(
+        NSMinX(contentView.bounds),
+        NSMaxY(contentView.bounds) - titlebarHeight,
+        NSWidth(contentView.bounds),
+        titlebarHeight
+    );
+    if (titlebarBackdrop == nil) {
+        titlebarBackdrop = [[NSView alloc] initWithFrame:titlebarFrame];
+        titlebarBackdrop.identifier = SimpleXTitlebarBackdropIdentifier;
+        titlebarBackdrop.wantsLayer = YES;
+        titlebarBackdrop.autoresizingMask = NSViewWidthSizable | NSViewMinYMargin;
+        [contentView addSubview:titlebarBackdrop positioned:NSWindowAbove relativeTo:effectView];
+    } else {
+        titlebarBackdrop.frame = titlebarFrame;
+    }
+    titlebarBackdrop.layer.backgroundColor = chromeColor.CGColor;
     return YES;
 }
 
 JNIEXPORT jboolean JNICALL
-Java_chat_simplex_common_MacOSPlatformKt_macOSConfigureWindow(JNIEnv *env, jclass clazz, jlong windowHandle) {
+Java_chat_simplex_common_MacOSPlatformKt_macOSConfigureWindow(
+    JNIEnv *env, jclass clazz, jlong windowHandle,
+    jfloat chromeRed, jfloat chromeGreen, jfloat chromeBlue, jfloat chromeAlpha
+) {
     if (windowHandle == 0) return JNI_FALSE;
     __block BOOL configured = NO;
     void (^work)(void) = ^{
         @autoreleasepool {
-            configured = configureWindow((__bridge NSWindow *)(void *)windowHandle);
+            NSColor *chromeColor = [NSColor colorWithSRGBRed:chromeRed green:chromeGreen blue:chromeBlue alpha:chromeAlpha];
+            configured = configureWindow((__bridge NSWindow *)(void *)windowHandle, chromeColor);
         }
     };
     if ([NSThread isMainThread]) work(); else dispatch_sync(dispatch_get_main_queue(), work);

--- a/apps/multiplatform/common/src/commonMain/cpp/desktop/macos-platform.m
+++ b/apps/multiplatform/common/src/commonMain/cpp/desktop/macos-platform.m
@@ -1,0 +1,234 @@
+#import <AppKit/AppKit.h>
+#import <UserNotifications/UserNotifications.h>
+#include <jni.h>
+
+static NSString * const SimpleXVibrancyIdentifier = @"chat.simplex.sidebar.vibrancy";
+static NSString * const SimpleXMessageCategory = @"MESSAGE";
+static NSString * const SimpleXContactCategory = @"CONTACT_REQUEST";
+static NSString * const SimpleXCallCategory = @"INCOMING_CALL";
+static JavaVM *SimpleXJavaVM = NULL;
+static jclass SimpleXCallbackClass = NULL;
+static jmethodID SimpleXCallbackMethod = NULL;
+
+@interface SimpleXNotificationDelegate : NSObject <UNUserNotificationCenterDelegate>
+@end
+
+@implementation SimpleXNotificationDelegate
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+       willPresentNotification:(UNNotification *)notification
+         withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler {
+    completionHandler(UNNotificationPresentationOptionBanner |
+                      UNNotificationPresentationOptionList |
+                      UNNotificationPresentationOptionSound);
+}
+
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+ didReceiveNotificationResponse:(UNNotificationResponse *)response
+          withCompletionHandler:(void (^)(void))completionHandler {
+    NSDictionary *info = response.notification.request.content.userInfo;
+    if (SimpleXJavaVM != NULL && SimpleXCallbackClass != NULL && SimpleXCallbackMethod != NULL) {
+        JNIEnv *env = NULL;
+        BOOL detach = NO;
+        jint status = (*SimpleXJavaVM)->GetEnv(SimpleXJavaVM, (void **)&env, JNI_VERSION_1_6);
+        if (status == JNI_EDETACHED && (*SimpleXJavaVM)->AttachCurrentThread(SimpleXJavaVM, (void **)&env, NULL) == JNI_OK) detach = YES;
+        if (env != NULL) {
+            NSString *chatId = info[@"chatId"] ?: @"";
+            NSString *action = response.actionIdentifier ?: UNNotificationDefaultActionIdentifier;
+            jstring jChatId = (*env)->NewStringUTF(env, chatId.UTF8String);
+            jstring jAction = (*env)->NewStringUTF(env, action.UTF8String);
+            (*env)->CallStaticVoidMethod(
+                env,
+                SimpleXCallbackClass,
+                SimpleXCallbackMethod,
+                [info[@"userId"] longLongValue],
+                [info[@"remoteHostId"] longLongValue],
+                jChatId,
+                [info[@"messageId"] longLongValue],
+                jAction
+            );
+            (*env)->DeleteLocalRef(env, jChatId);
+            (*env)->DeleteLocalRef(env, jAction);
+            if ((*env)->ExceptionCheck(env)) {
+                (*env)->ExceptionDescribe(env);
+                (*env)->ExceptionClear(env);
+            }
+        }
+        if (detach) (*SimpleXJavaVM)->DetachCurrentThread(SimpleXJavaVM);
+    }
+    completionHandler();
+}
+@end
+
+static SimpleXNotificationDelegate *SimpleXNotificationDelegateInstance = nil;
+
+static NSString *stringFromJNI(JNIEnv *env, jstring value) {
+    if (value == NULL) return nil;
+    const char *chars = (*env)->GetStringUTFChars(env, value, NULL);
+    if (chars == NULL) return nil;
+    NSString *result = [NSString stringWithUTF8String:chars];
+    (*env)->ReleaseStringUTFChars(env, value, chars);
+    return result;
+}
+
+static NSSet<UNNotificationCategory *> *notificationCategories(void) {
+    UNNotificationAction *acceptContact = [UNNotificationAction actionWithIdentifier:@"ACCEPT_CONTACT_REQUEST" title:@"Accept" options:UNNotificationActionOptionForeground];
+    UNNotificationAction *acceptCall = [UNNotificationAction actionWithIdentifier:@"ACCEPT_CALL" title:@"Accept" options:UNNotificationActionOptionForeground];
+    UNNotificationAction *rejectCall = [UNNotificationAction actionWithIdentifier:@"REJECT_CALL" title:@"Decline" options:UNNotificationActionOptionDestructive];
+    return [NSSet setWithArray:@[
+        [UNNotificationCategory categoryWithIdentifier:SimpleXMessageCategory actions:@[] intentIdentifiers:@[] options:UNNotificationCategoryOptionNone],
+        [UNNotificationCategory categoryWithIdentifier:SimpleXContactCategory actions:@[acceptContact] intentIdentifiers:@[] options:UNNotificationCategoryOptionNone],
+        [UNNotificationCategory categoryWithIdentifier:SimpleXCallCategory actions:@[acceptCall, rejectCall] intentIdentifiers:@[] options:UNNotificationCategoryOptionNone],
+    ]];
+}
+
+static BOOL configureWindow(NSWindow *window) {
+    if (window == nil || window.contentView == nil) return NO;
+
+    window.styleMask |= NSWindowStyleMaskFullSizeContentView;
+    window.titlebarAppearsTransparent = YES;
+    window.titleVisibility = NSWindowTitleHidden;
+
+    NSView *contentView = window.contentView;
+    for (NSView *view in contentView.subviews.copy) {
+        if ([view.identifier isEqualToString:SimpleXVibrancyIdentifier]) return YES;
+    }
+
+    NSVisualEffectView *effectView = [[NSVisualEffectView alloc] initWithFrame:contentView.bounds];
+    effectView.identifier = SimpleXVibrancyIdentifier;
+    effectView.material = NSVisualEffectMaterialSidebar;
+    effectView.blendingMode = NSVisualEffectBlendingModeBehindWindow;
+    effectView.state = NSVisualEffectStateFollowsWindowActiveState;
+    effectView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+    [contentView addSubview:effectView positioned:NSWindowBelow relativeTo:contentView.subviews.firstObject];
+    return YES;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_chat_simplex_common_MacOSPlatformKt_macOSConfigureWindow(JNIEnv *env, jclass clazz, jlong windowHandle) {
+    if (windowHandle == 0) return JNI_FALSE;
+    __block BOOL configured = NO;
+    void (^work)(void) = ^{
+        @autoreleasepool {
+            configured = configureWindow((__bridge NSWindow *)(void *)windowHandle);
+        }
+    };
+    if ([NSThread isMainThread]) work(); else dispatch_sync(dispatch_get_main_queue(), work);
+    return configured ? JNI_TRUE : JNI_FALSE;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_chat_simplex_common_model_MacOSNotificationsKt_macOSInitializeNotifications(JNIEnv *env, jclass clazz) {
+    if ((*env)->GetJavaVM(env, &SimpleXJavaVM) != JNI_OK) return JNI_FALSE;
+    if (SimpleXCallbackClass == NULL) {
+        jclass localClass = (*env)->FindClass(env, "chat/simplex/common/model/MacOSNotificationsKt");
+        if (localClass == NULL) return JNI_FALSE;
+        SimpleXCallbackClass = (*env)->NewGlobalRef(env, localClass);
+        (*env)->DeleteLocalRef(env, localClass);
+        SimpleXCallbackMethod = (*env)->GetStaticMethodID(env, SimpleXCallbackClass, "onMacOSNotificationResponse", "(JJLjava/lang/String;JLjava/lang/String;)V");
+        if (SimpleXCallbackMethod == NULL) return JNI_FALSE;
+    }
+    void (^work)(void) = ^{
+        if (SimpleXNotificationDelegateInstance == nil) SimpleXNotificationDelegateInstance = [SimpleXNotificationDelegate new];
+        UNUserNotificationCenter *center = UNUserNotificationCenter.currentNotificationCenter;
+        center.delegate = SimpleXNotificationDelegateInstance;
+        [center setNotificationCategories:notificationCategories()];
+    };
+    if ([NSThread isMainThread]) work(); else dispatch_sync(dispatch_get_main_queue(), work);
+    return JNI_TRUE;
+}
+
+JNIEXPORT void JNICALL
+Java_chat_simplex_common_model_MacOSNotificationsKt_macOSRequestNotificationPermission(JNIEnv *env, jclass clazz) {
+    [UNUserNotificationCenter.currentNotificationCenter requestAuthorizationWithOptions:(UNAuthorizationOptionAlert | UNAuthorizationOptionSound | UNAuthorizationOptionBadge)
+                                                                      completionHandler:^(BOOL granted, NSError *error) {}];
+}
+
+JNIEXPORT jint JNICALL
+Java_chat_simplex_common_model_MacOSNotificationsKt_macOSNotificationPermissionState(JNIEnv *env, jclass clazz) {
+    __block UNAuthorizationStatus status = UNAuthorizationStatusNotDetermined;
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    [UNUserNotificationCenter.currentNotificationCenter getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings *settings) {
+        status = settings.authorizationStatus;
+        dispatch_semaphore_signal(semaphore);
+    }];
+    dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)));
+    switch (status) {
+        case UNAuthorizationStatusNotDetermined: return 0;
+        case UNAuthorizationStatusDenied: return 1;
+        case UNAuthorizationStatusAuthorized: return 2;
+        case UNAuthorizationStatusProvisional: return 3;
+        default: return 4;
+    }
+}
+
+JNIEXPORT jboolean JNICALL
+Java_chat_simplex_common_model_MacOSNotificationsKt_macOSDeliverNotification(
+    JNIEnv *env, jclass clazz, jstring identifier, jlong userId, jlong remoteHostId, jstring chatId,
+    jlong messageId, jstring title, jstring body, jstring category, jboolean playSound, jstring imagePath
+) {
+    UNMutableNotificationContent *content = [UNMutableNotificationContent new];
+    NSString *identifierValue = stringFromJNI(env, identifier);
+    NSString *chatIdValue = stringFromJNI(env, chatId);
+    content.title = stringFromJNI(env, title) ?: @"SimpleX";
+    content.body = stringFromJNI(env, body) ?: @"";
+    content.categoryIdentifier = stringFromJNI(env, category) ?: SimpleXMessageCategory;
+    content.threadIdentifier = [NSString stringWithFormat:@"%lld:%lld:%@", (long long)userId, (long long)remoteHostId, chatIdValue];
+    content.userInfo = @{
+        @"userId": @(userId),
+        @"remoteHostId": @(remoteHostId),
+        @"chatId": chatIdValue ?: @"",
+        @"messageId": @(messageId),
+    };
+    if (playSound) content.sound = UNNotificationSound.defaultSound;
+    NSString *path = stringFromJNI(env, imagePath);
+    if (path.length > 0) {
+        UNNotificationAttachment *attachment = [UNNotificationAttachment attachmentWithIdentifier:@"image" URL:[NSURL fileURLWithPath:path] options:nil error:nil];
+        if (attachment != nil) content.attachments = @[attachment];
+    }
+    UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:identifierValue content:content trigger:nil];
+    [UNUserNotificationCenter.currentNotificationCenter addNotificationRequest:request withCompletionHandler:^(NSError *error) {}];
+    return JNI_TRUE;
+}
+
+static void removeNotificationsMatching(BOOL (^matches)(NSDictionary *info)) {
+    UNUserNotificationCenter *center = UNUserNotificationCenter.currentNotificationCenter;
+    [center getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> *notifications) {
+        NSMutableArray<NSString *> *identifiers = [NSMutableArray array];
+        for (UNNotification *notification in notifications) {
+            if (matches(notification.request.content.userInfo)) [identifiers addObject:notification.request.identifier];
+        }
+        if (identifiers.count > 0) [center removeDeliveredNotificationsWithIdentifiers:identifiers];
+    }];
+    [center getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> *requests) {
+        NSMutableArray<NSString *> *identifiers = [NSMutableArray array];
+        for (UNNotificationRequest *request in requests) {
+            if (matches(request.content.userInfo)) [identifiers addObject:request.identifier];
+        }
+        if (identifiers.count > 0) [center removePendingNotificationRequestsWithIdentifiers:identifiers];
+    }];
+}
+
+JNIEXPORT void JNICALL
+Java_chat_simplex_common_model_MacOSNotificationsKt_macOSRemoveNotificationsForChat(JNIEnv *env, jclass clazz, jlong userId, jlong remoteHostId, jstring chatId) {
+    NSString *chatIdValue = stringFromJNI(env, chatId);
+    removeNotificationsMatching(^BOOL(NSDictionary *info) {
+        return [info[@"userId"] longLongValue] == userId && [info[@"remoteHostId"] longLongValue] == remoteHostId && [info[@"chatId"] isEqualToString:chatIdValue];
+    });
+}
+
+JNIEXPORT void JNICALL
+Java_chat_simplex_common_model_MacOSNotificationsKt_macOSRemoveNotificationsForUser(JNIEnv *env, jclass clazz, jlong userId) {
+    removeNotificationsMatching(^BOOL(NSDictionary *info) { return [info[@"userId"] longLongValue] == userId; });
+}
+
+JNIEXPORT void JNICALL
+Java_chat_simplex_common_model_MacOSNotificationsKt_macOSRemoveAllNotifications(JNIEnv *env, jclass clazz) {
+    [UNUserNotificationCenter.currentNotificationCenter removeAllDeliveredNotifications];
+    [UNUserNotificationCenter.currentNotificationCenter removeAllPendingNotificationRequests];
+}
+
+JNIEXPORT void JNICALL
+Java_chat_simplex_common_model_MacOSNotificationsKt_macOSOpenNotificationSettings(JNIEnv *env, jclass clazz) {
+    NSURL *url = [NSURL URLWithString:@"x-apple.systempreferences:com.apple.Notifications-Settings.extension"];
+    if (url != nil) dispatch_async(dispatch_get_main_queue(), ^{ [NSWorkspace.sharedWorkspace openURL:url]; });
+}

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/App.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/App.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -26,6 +27,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.progressBarRangeInfo
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.setProgress
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -428,7 +430,30 @@ fun CenterPartOfScreen() {
             .background(MaterialTheme.colors.background),
           contentAlignment = Alignment.Center
         ) {
-          Text(stringResource(if (chatModel.desktopNoUserNoRemote) MR.strings.no_connected_mobile else MR.strings.no_selected_chat))
+          Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Surface(
+              modifier = Modifier.size(64.dp),
+              shape = RoundedCornerShape(18.dp),
+              color = MaterialTheme.colors.onBackground.copy(alpha = 0.06f),
+              elevation = 0.dp,
+            ) {
+              Box(contentAlignment = Alignment.Center) {
+                Icon(
+                  painterResource(MR.images.ic_chat),
+                  contentDescription = null,
+                  modifier = Modifier.size(30.dp),
+                  tint = MaterialTheme.colors.secondary.copy(alpha = 0.72f),
+                )
+              }
+            }
+            Spacer(Modifier.height(18.dp))
+            Text(
+              stringResource(if (chatModel.desktopNoUserNoRemote) MR.strings.no_connected_mobile else MR.strings.no_selected_chat),
+              style = MaterialTheme.typography.h3,
+              fontWeight = FontWeight.Medium,
+              color = MaterialTheme.colors.secondary,
+            )
+          }
         }
       } else {
         ModalManager.center.showInView()
@@ -493,6 +518,14 @@ fun DesktopScreen(userPickerState: MutableStateFlow<AnimatedViewState>) {
     }
 
     if (sidebarVisible) {
+      Box(
+        Modifier
+          .offset(x = sidebarWidth - 0.5.dp)
+          .width(1.dp)
+          .fillMaxHeight()
+          .zIndex(3f)
+          .background(MaterialTheme.colors.onBackground.copy(alpha = 0.12f))
+      )
       val updateSidebarWidth: (Float) -> Boolean = { requested ->
         val clamped = requested.coerceIn(DesktopLayoutState.MIN_SIDEBAR_WIDTH, maxSidebarWidth.value)
         DesktopLayoutState.setSidebarWidth(clamped)
@@ -538,7 +571,6 @@ fun DesktopScreen(userPickerState: MutableStateFlow<AnimatedViewState>) {
             )
             setProgress { updateSidebarWidth(it) }
           }
-          .background(MaterialTheme.colors.onBackground.copy(alpha = 0.14f))
       )
     }
 

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/App.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/App.kt
@@ -145,11 +145,22 @@ fun MainScreen() {
     }
   }
 
-  Box {
-    val unauthorized = remember { derivedStateOf { AppLock.userAuthorized.value != true } }
-    val onboarding by remember { chatModel.controller.appPrefs.onboardingStage.state }
-    val localUserCreated = chatModel.localUserCreated.value
-    var showInitializationView by remember { mutableStateOf(false) }
+  val unauthorized = remember { derivedStateOf { AppLock.userAuthorized.value != true } }
+  val onboarding by remember { chatModel.controller.appPrefs.onboardingStage.state }
+  val localUserCreated = chatModel.localUserCreated.value
+  var showInitializationView by remember { mutableStateOf(false) }
+  val desktopChatVisible = appPlatform.isDesktop &&
+      onboarding == OnboardingStage.OnboardingComplete &&
+      chatModel.chatDbStatus.value == DBMigrationResult.OK &&
+      remember { chatModel.chatDbEncrypted }.value != null &&
+      localUserCreated != null
+  val windowBackground = if (macOSWindowVibrancyAvailable && desktopChatVisible) {
+    Color.Transparent
+  } else {
+    MaterialTheme.colors.background
+  }
+
+  Box(Modifier.fillMaxSize().background(windowBackground)) {
     when {
       onboarding == OnboardingStage.Step1_SimpleXInfo && chatModel.migrationState.value != null -> {
         // In migration process. Nothing should interrupt it, that's why it's the first branch in when()

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/App.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/App.kt
@@ -483,9 +483,15 @@ fun DesktopScreen(userPickerState: MutableStateFlow<AnimatedViewState>) {
     val autoCollapsed = maxWidth < DesktopLayoutState.MIN_SIDEBAR_WIDTH.dp + 520.dp
     val sidebarVisible = !DesktopLayoutState.sidebarCollapsed.value && !autoCollapsed
     val visibleSidebarWidth = if (sidebarVisible) sidebarWidth else 0.dp
+    val opaqueSidebar = useOpaqueDesktopSidebar(
+      macOSWindowVibrancyAvailable,
+      isInDarkTheme(),
+      chat.simplex.common.ui.theme.isSystemInDarkTheme(),
+    )
+    val sidebarBackground = if (opaqueSidebar) MaterialTheme.colors.background else Color.Transparent
 
     if (sidebarVisible) {
-      Box(Modifier.width(sidebarWidth).fillMaxHeight()) {
+      Box(Modifier.width(sidebarWidth).fillMaxHeight().background(sidebarBackground)) {
         Box(Modifier.fillMaxSize().padding(top = if (macOSWindowVibrancyAvailable) 28.dp else 0.dp)) {
           StartPartOfScreen(userPickerState)
           tryOrShowError("UserPicker", error = {}) {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/App.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/App.kt
@@ -4,6 +4,8 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.*
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
@@ -15,9 +17,18 @@ import androidx.compose.ui.draw.*
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.*
+import androidx.compose.ui.input.key.*
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.progressBarRangeInfo
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.setProgress
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import chat.simplex.common.views.usersettings.SetDeliveryReceiptsView
 import chat.simplex.common.model.*
 import chat.simplex.common.model.ChatController.appPrefs
@@ -48,7 +59,7 @@ import kotlinx.coroutines.flow.*
 fun AppScreen() {
   AppBarHandler.appBarMaxHeightPx = with(LocalDensity.current) { AppBarHeight.roundToPx() }
   SimpleXTheme {
-    Surface(color = MaterialTheme.colors.background, contentColor = LocalContentColor.current) {
+    Surface(color = if (macOSWindowVibrancyAvailable) Color.Transparent else MaterialTheme.colors.background, contentColor = LocalContentColor.current) {
       // This padding applies to landscape view only taking care of navigation bar and holes in screen in status bar area
       // (because nav bar and holes located on vertical sides of screen in landscape view)
       val direction = LocalLayoutDirection.current
@@ -424,42 +435,117 @@ fun EndPartOfScreen() {
 // Spec: spec/client/navigation.md#DesktopScreen
 @Composable
 fun DesktopScreen(userPickerState: MutableStateFlow<AnimatedViewState>) {
-  Box(Modifier.width(DEFAULT_START_MODAL_WIDTH * fontSizeSqrtMultiplier)) {
-    StartPartOfScreen(userPickerState)
-    tryOrShowError("UserPicker", error = {}) {
-      UserPicker(chatModel, userPickerState, setPerformLA = AppLock::setPerformLA)
-    }
-  }
-  Box(Modifier.widthIn(max = DEFAULT_START_MODAL_WIDTH * fontSizeSqrtMultiplier)) {
-    ModalManager.start.showInView()
-    SwitchingUsersView()
-  }
-  Row(Modifier.padding(start = DEFAULT_START_MODAL_WIDTH * fontSizeSqrtMultiplier).clipToBounds()) {
-    Box(Modifier.widthIn(min = DEFAULT_MIN_CENTER_MODAL_WIDTH).weight(1f)) {
-      CenterPartOfScreen()
-    }
-    if (ModalManager.end.hasModalsOpen()) {
-      VerticalDivider()
-    }
-    Box(Modifier.widthIn(max = DEFAULT_END_MODAL_WIDTH * fontSizeSqrtMultiplier).clipToBounds()) {
-      EndPartOfScreen()
-    }
-  }
-  if (userPickerState.collectAsState().value.isVisible() || (ModalManager.start.hasModalsOpen && !ModalManager.center.hasModalsOpen)) {
-    Box(
-      Modifier
-        .fillMaxSize()
-        .padding(start = DEFAULT_START_MODAL_WIDTH * fontSizeSqrtMultiplier)
-        .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, onClick = {
-          if (chatModel.centerPanelBackgroundClickHandler == null || chatModel.centerPanelBackgroundClickHandler?.invoke() == false) {
-            ModalManager.start.closeModals()
-            userPickerState.value = AnimatedViewState.HIDING
-          }
-        })
+  BoxWithConstraints(Modifier.fillMaxSize()) {
+    val density = LocalDensity.current
+    val direction = LocalLayoutDirection.current
+    val savedSidebarWidth = DesktopLayoutState.sidebarWidth.floatValue.dp
+    val maxSidebarWidth = minOf(
+      DesktopLayoutState.MAX_SIDEBAR_WIDTH.dp,
+      (maxWidth - 520.dp).coerceAtLeast(DesktopLayoutState.MIN_SIDEBAR_WIDTH.dp)
     )
+    val sidebarWidth = savedSidebarWidth.coerceIn(DesktopLayoutState.MIN_SIDEBAR_WIDTH.dp, maxSidebarWidth)
+    val autoCollapsed = maxWidth < DesktopLayoutState.MIN_SIDEBAR_WIDTH.dp + 520.dp
+    val sidebarVisible = !DesktopLayoutState.sidebarCollapsed.value && !autoCollapsed
+    val visibleSidebarWidth = if (sidebarVisible) sidebarWidth else 0.dp
+
+    if (sidebarVisible) {
+      Box(Modifier.width(sidebarWidth).fillMaxHeight()) {
+        Box(Modifier.fillMaxSize().padding(top = if (macOSWindowVibrancyAvailable) 28.dp else 0.dp)) {
+          StartPartOfScreen(userPickerState)
+          tryOrShowError("UserPicker", error = {}) {
+            UserPicker(chatModel, userPickerState, setPerformLA = AppLock::setPerformLA)
+          }
+        }
+      }
+      Box(Modifier.widthIn(max = sidebarWidth).fillMaxHeight()) {
+        ModalManager.start.showInView()
+        SwitchingUsersView()
+      }
+    }
+
+    Row(
+      Modifier
+        .padding(start = visibleSidebarWidth)
+        .fillMaxSize()
+        .clipToBounds()
+        .background(MaterialTheme.colors.background)
+    ) {
+      Box(Modifier.widthIn(min = 520.dp).weight(1f)) {
+        CenterPartOfScreen()
+      }
+      if (ModalManager.end.hasModalsOpen()) {
+        VerticalDivider()
+      }
+      Box(Modifier.widthIn(max = DEFAULT_END_MODAL_WIDTH * fontSizeSqrtMultiplier).clipToBounds()) {
+        EndPartOfScreen()
+      }
+    }
+
+    if (sidebarVisible) {
+      val updateSidebarWidth: (Float) -> Boolean = { requested ->
+        val clamped = requested.coerceIn(DesktopLayoutState.MIN_SIDEBAR_WIDTH, maxSidebarWidth.value)
+        DesktopLayoutState.setSidebarWidth(clamped)
+        true
+      }
+      Box(
+        Modifier
+          .offset(x = sidebarWidth - 3.dp)
+          .width(6.dp)
+          .fillMaxHeight()
+          .zIndex(4f)
+          .desktopPointerHoverIconResize()
+          .pointerInput(maxSidebarWidth, direction) {
+            detectDragGestures { change, dragAmount ->
+              change.consume()
+              val dragDp = with(density) { dragAmount.x.toDp().value }
+              val signedDrag = if (direction == LayoutDirection.Ltr) dragDp else -dragDp
+              updateSidebarWidth(DesktopLayoutState.sidebarWidth.floatValue + signedDrag)
+            }
+          }
+          .pointerInput(Unit) {
+            detectTapGestures(onDoubleTap = { DesktopLayoutState.resetSidebarWidth() })
+          }
+          .focusable()
+          .onPreviewKeyEvent { event ->
+            if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+            val delta = when (event.key) {
+              Key.DirectionLeft -> if (direction == LayoutDirection.Ltr) -8f else 8f
+              Key.DirectionRight -> if (direction == LayoutDirection.Ltr) 8f else -8f
+              Key.Enter, Key.NumPadEnter -> {
+                DesktopLayoutState.resetSidebarWidth()
+                return@onPreviewKeyEvent true
+              }
+              else -> return@onPreviewKeyEvent false
+            }
+            updateSidebarWidth(DesktopLayoutState.sidebarWidth.floatValue + delta)
+          }
+          .semantics {
+            contentDescription = "Resize conversations sidebar"
+            progressBarRangeInfo = ProgressBarRangeInfo(
+              DesktopLayoutState.sidebarWidth.floatValue,
+              DesktopLayoutState.MIN_SIDEBAR_WIDTH..maxSidebarWidth.value
+            )
+            setProgress { updateSidebarWidth(it) }
+          }
+          .background(MaterialTheme.colors.onBackground.copy(alpha = 0.14f))
+      )
+    }
+
+    if (userPickerState.collectAsState().value.isVisible() || (ModalManager.start.hasModalsOpen && !ModalManager.center.hasModalsOpen)) {
+      Box(
+        Modifier
+          .fillMaxSize()
+          .padding(start = visibleSidebarWidth)
+          .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, onClick = {
+            if (chatModel.centerPanelBackgroundClickHandler == null || chatModel.centerPanelBackgroundClickHandler?.invoke() == false) {
+              ModalManager.start.closeModals()
+              userPickerState.value = AnimatedViewState.HIDING
+            }
+          })
+      )
+    }
+    ModalManager.fullscreen.showInView()
   }
-  VerticalDivider(Modifier.padding(start = DEFAULT_START_MODAL_WIDTH * fontSizeSqrtMultiplier))
-  ModalManager.fullscreen.showInView()
 }
 
 @Composable

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/App.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/App.kt
@@ -505,6 +505,7 @@ fun DesktopScreen(userPickerState: MutableStateFlow<AnimatedViewState>) {
         .fillMaxSize()
         .clipToBounds()
         .background(MaterialTheme.colors.background)
+        .padding(top = if (macOSWindowVibrancyAvailable) 28.dp else 0.dp)
     ) {
       Box(Modifier.widthIn(min = 520.dp).weight(1f)) {
         CenterPartOfScreen()

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/DesktopLayout.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/DesktopLayout.kt
@@ -1,0 +1,49 @@
+package chat.simplex.common
+
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+enum class DesktopChatDensity {
+  Compact,
+  Comfortable,
+  Spacious;
+
+  companion object { val default = Compact }
+}
+
+data class DesktopDensityTokens(
+  val chatRowVerticalPadding: Dp,
+  val messageVerticalPadding: Dp,
+  val groupedMessageGap: Dp,
+  val conversationGap: Dp,
+  val composerVerticalPadding: Dp,
+)
+
+fun DesktopChatDensity.tokens(): DesktopDensityTokens = when (this) {
+  DesktopChatDensity.Compact -> DesktopDensityTokens(6.dp, 4.dp, 2.dp, 8.dp, 6.dp)
+  DesktopChatDensity.Comfortable -> DesktopDensityTokens(8.dp, 7.dp, 4.dp, 12.dp, 9.dp)
+  DesktopChatDensity.Spacious -> DesktopDensityTokens(12.dp, 10.dp, 7.dp, 16.dp, 12.dp)
+}
+
+object DesktopLayoutState {
+  const val DEFAULT_SIDEBAR_WIDTH = 320f
+  const val MIN_SIDEBAR_WIDTH = 240f
+  const val MAX_SIDEBAR_WIDTH = 480f
+
+  val sidebarWidth = mutableFloatStateOf(DEFAULT_SIDEBAR_WIDTH)
+  val sidebarCollapsed = mutableStateOf(false)
+
+  fun setSidebarWidth(width: Float) {
+    sidebarWidth.floatValue = width.coerceIn(MIN_SIDEBAR_WIDTH, MAX_SIDEBAR_WIDTH)
+  }
+
+  fun resetSidebarWidth() {
+    sidebarWidth.floatValue = DEFAULT_SIDEBAR_WIDTH
+  }
+
+  fun toggleSidebar() {
+    sidebarCollapsed.value = !sidebarCollapsed.value
+  }
+}

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/DesktopLayout.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/DesktopLayout.kt
@@ -15,6 +15,9 @@ enum class DesktopChatDensity {
 
 data class DesktopDensityTokens(
   val chatRowVerticalPadding: Dp,
+  val sidebarAvatarSize: Dp,
+  val sidebarPreviewMinHeight: Dp,
+  val sidebarPreviewMaxLines: Int,
   val messageVerticalPadding: Dp,
   val groupedMessageGap: Dp,
   val conversationGap: Dp,
@@ -22,9 +25,9 @@ data class DesktopDensityTokens(
 )
 
 fun DesktopChatDensity.tokens(): DesktopDensityTokens = when (this) {
-  DesktopChatDensity.Compact -> DesktopDensityTokens(6.dp, 4.dp, 2.dp, 8.dp, 6.dp)
-  DesktopChatDensity.Comfortable -> DesktopDensityTokens(8.dp, 7.dp, 4.dp, 12.dp, 9.dp)
-  DesktopChatDensity.Spacious -> DesktopDensityTokens(12.dp, 10.dp, 7.dp, 16.dp, 12.dp)
+  DesktopChatDensity.Compact -> DesktopDensityTokens(5.dp, 44.dp, 20.dp, 1, 4.dp, 2.dp, 8.dp, 6.dp)
+  DesktopChatDensity.Comfortable -> DesktopDensityTokens(7.dp, 50.dp, 24.dp, 1, 7.dp, 4.dp, 12.dp, 9.dp)
+  DesktopChatDensity.Spacious -> DesktopDensityTokens(10.dp, 58.dp, 36.dp, 2, 10.dp, 7.dp, 16.dp, 12.dp)
 }
 
 object DesktopLayoutState {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/DesktopLayout.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/DesktopLayout.kt
@@ -30,6 +30,12 @@ fun DesktopChatDensity.tokens(): DesktopDensityTokens = when (this) {
   DesktopChatDensity.Spacious -> DesktopDensityTokens(10.dp, 58.dp, 36.dp, 2, 10.dp, 7.dp, 16.dp, 12.dp)
 }
 
+internal fun useOpaqueDesktopSidebar(
+  vibrancyAvailable: Boolean,
+  appDark: Boolean,
+  systemDark: Boolean,
+): Boolean = !vibrancyAvailable || appDark != systemDark
+
 object DesktopLayoutState {
   const val DEFAULT_SIDEBAR_WIDTH = 320f
   const val MIN_SIDEBAR_WIDTH = 240f

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import chat.simplex.common.DesktopChatDensity
 import chat.simplex.common.model.ChatController.getNetCfg
 import chat.simplex.common.model.ChatController.setNetCfg
 import chat.simplex.common.model.ChatModel.changingActiveUserMutex
@@ -108,6 +109,8 @@ class AppPreferences {
   )  { NotificationsMode.values().firstOrNull { it.name == this } }
   val closeBehavior: SharedPreference<CloseBehavior> = mkSafeEnumPreference(SHARED_PREFS_DESKTOP_CLOSE_BEHAVIOR, CloseBehavior.default)
   val notificationPreviewMode = mkStrPreference(SHARED_PREFS_NOTIFICATION_PREVIEW_MODE, NotificationPreviewMode.default.name)
+  val desktopNotificationSound = mkBoolPreference(SHARED_PREFS_DESKTOP_NOTIFICATION_SOUND, true)
+  val desktopNotificationExplanationShown = mkBoolPreference(SHARED_PREFS_DESKTOP_NOTIFICATION_EXPLANATION_SHOWN, false)
   val canAskToEnableNotifications = mkBoolPreference(SHARED_PREFS_CAN_ASK_TO_ENABLE_NOTIFICATIONS, true)
   val backgroundServiceNoticeShown = mkBoolPreference(SHARED_PREFS_SERVICE_NOTICE_SHOWN, false)
   val backgroundServiceBatteryNoticeShown = mkBoolPreference(SHARED_PREFS_SERVICE_BATTERY_NOTICE_SHOWN, false)
@@ -243,6 +246,7 @@ class AppPreferences {
   val chatItemTail = mkBoolPreference(SHARED_PREFS_CHAT_ITEM_TAIL, true)
   val fontScale = mkFloatPreference(SHARED_PREFS_FONT_SCALE, 1f)
   val densityScale = mkFloatPreference(SHARED_PREFS_DENSITY_SCALE, 1f)
+  val desktopChatDensity = mkSafeEnumPreference(SHARED_PREFS_DESKTOP_CHAT_DENSITY, DesktopChatDensity.default)
   val inAppBarsDefaultAlpha = if (deviceSupportsBlur) 0.875f else 0.975f
   val inAppBarsAlpha = mkFloatPreference(SHARED_PREFS_IN_APP_BARS_ALPHA, inAppBarsDefaultAlpha)
 
@@ -388,6 +392,8 @@ class AppPreferences {
     private const val SHARED_PREFS_RUN_SERVICE_IN_BACKGROUND = "RunServiceInBackground"
     private const val SHARED_PREFS_NOTIFICATIONS_MODE = "NotificationsMode"
     private const val SHARED_PREFS_NOTIFICATION_PREVIEW_MODE = "NotificationPreviewMode"
+    private const val SHARED_PREFS_DESKTOP_NOTIFICATION_SOUND = "DesktopNotificationSound"
+    private const val SHARED_PREFS_DESKTOP_NOTIFICATION_EXPLANATION_SHOWN = "DesktopNotificationExplanationShown"
     private const val SHARED_PREFS_CAN_ASK_TO_ENABLE_NOTIFICATIONS = "CanAskToEnableNotifications"
     private const val SHARED_PREFS_SERVICE_NOTICE_SHOWN = "BackgroundServiceNoticeShown"
     private const val SHARED_PREFS_SERVICE_BATTERY_NOTICE_SHOWN = "BackgroundServiceBatteryNoticeShown"
@@ -492,6 +498,7 @@ class AppPreferences {
     private const val SHARED_PREFS_CHAT_ITEM_TAIL = "ChatItemTail"
     private const val SHARED_PREFS_FONT_SCALE = "FontScale"
     private const val SHARED_PREFS_DENSITY_SCALE = "DensityScale"
+    private const val SHARED_PREFS_DESKTOP_CHAT_DENSITY = "DesktopChatDensity"
     private const val SHARED_PREFS_IN_APP_BARS_ALPHA = "InAppBarsAlpha"
     private const val SHARED_PREFS_WHATS_NEW_VERSION = "WhatsNewVersion"
     private const val SHARED_PREFS_LAST_MIGRATED_VERSION_CODE = "LastMigratedVersionCode"

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/platform/Modifier.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/platform/Modifier.kt
@@ -19,12 +19,26 @@ expect fun Modifier.desktopOnExternalDrag(
   enabled: Boolean = true,
   onFiles: (List<File>) -> Unit = {},
   onImage: (File) -> Unit = {},
-  onText: (String) -> Unit = {}
+  onText: (String) -> Unit = {},
+  onDragging: (Boolean) -> Unit = {},
 ): Modifier
 
 expect fun Modifier.onRightClick(action: () -> Unit): Modifier
 
 expect fun Modifier.desktopPointerHoverIconHand(): Modifier
+
+expect fun Modifier.desktopPointerHoverIconResize(): Modifier
+
+expect val macOSWindowVibrancyAvailable: Boolean
+
+expect fun openSystemNotificationSettings()
+
+@Composable
+expect fun Modifier.desktopMessageSelection(
+  enabled: Boolean,
+  onToggle: () -> Unit,
+  onRange: () -> Unit,
+): Modifier
 
 expect fun Modifier.desktopOnHovered(action: (Boolean) -> Unit): Modifier
 

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/platform/NtfManager.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/platform/NtfManager.kt
@@ -10,7 +10,66 @@ import chat.simplex.res.MR
 import kotlinx.coroutines.delay
 
 enum class NotificationAction {
-  ACCEPT_CONTACT_REQUEST
+  ACCEPT_CONTACT_REQUEST,
+  ACCEPT_CALL,
+  REJECT_CALL
+}
+
+enum class DesktopNotificationCategory { MESSAGE, CONTACT_REQUEST, INCOMING_CALL }
+
+enum class NotificationPermissionState { NOT_DETERMINED, DENIED, AUTHORIZED, PROVISIONAL, UNKNOWN }
+
+data class NotificationRoute(
+  val userId: Long?,
+  val remoteHostId: Long?,
+  val chatId: ChatId,
+  val messageId: Long? = null,
+)
+
+data class DesktopNotificationPayload(
+  val identifier: String,
+  val route: NotificationRoute,
+  val title: String,
+  val preview: String,
+  val category: DesktopNotificationCategory,
+  val playSound: Boolean,
+  val imagePath: String? = null,
+)
+
+data class DesktopNotificationPreview(val title: String, val body: String)
+
+fun desktopNotificationPreview(
+  mode: NotificationPreviewMode,
+  displayName: String,
+  message: String,
+  hiddenTitle: String,
+  hiddenBody: String,
+): DesktopNotificationPreview = DesktopNotificationPreview(
+  title = if (mode == NotificationPreviewMode.HIDDEN) hiddenTitle else displayName,
+  body = if (mode == NotificationPreviewMode.MESSAGE) message else hiddenBody,
+)
+
+fun desktopNotificationIdentifier(route: NotificationRoute, fallbackMessageId: Long): String {
+  val safeChat = route.chatId.replace(Regex("[^A-Za-z0-9._-]"), "_")
+  return "simplex.${route.userId ?: -1}.${route.remoteHostId ?: -1}.$safeChat.${route.messageId ?: fallbackMessageId}"
+}
+
+fun suppressDesktopNotification(
+  windowFocused: Boolean,
+  activeUserId: Long?,
+  activeRemoteHostId: Long?,
+  activeChatId: String?,
+  route: NotificationRoute,
+): Boolean = windowFocused && activeUserId == route.userId &&
+  activeRemoteHostId == route.remoteHostId && activeChatId == route.chatId
+
+class NotificationRouteQueue {
+  private val routes = ArrayDeque<NotificationRoute>()
+
+  fun enqueue(route: NotificationRoute) { routes.addLast(route) }
+
+  fun consumeIfReady(ready: Boolean): List<NotificationRoute> =
+    if (!ready) emptyList() else buildList { while (routes.isNotEmpty()) add(routes.removeFirst()) }
 }
 
 // Spec: spec/services/notifications.md#ntfManager
@@ -21,7 +80,8 @@ abstract class NtfManager {
     user = user,
     chatId = contact.id,
     displayName = contact.displayName,
-    msgText = generalGetString(MR.strings.notification_contact_connected)
+    msgText = generalGetString(MR.strings.notification_contact_connected),
+    remoteHostId = chatModel.remoteHostId(),
   )
 
   fun notifyContactRequestReceived(user: UserLike, cInfo: ChatInfo.ContactRequest) = displayNotification(
@@ -30,9 +90,10 @@ abstract class NtfManager {
     displayName = cInfo.displayName,
     msgText = generalGetString(MR.strings.notification_new_contact_request),
     image = cInfo.image,
-    listOf(
+    actions = listOf(
       NotificationAction.ACCEPT_CONTACT_REQUEST to { acceptContactRequestAction(user.userId, incognito = false, cInfo.id) }
-    )
+    ),
+    remoteHostId = chatModel.remoteHostId(),
   )
 
   fun notifyMessageReceived(rhId: Long?, user: UserLike, cInfo: ChatInfo, cItem: ChatItem) {
@@ -41,43 +102,60 @@ abstract class NtfManager {
       cInfo.ntfsEnabled(cItem) &&
       (
           allowedToShowNotification() ||
+              chatModel.currentUser.value?.userId != user.userId ||
               chatModel.chatId.value != cInfo.id ||
               chatModel.remoteHostId() != rhId)
     ) {
-      displayNotification(user = user, chatId = cInfo.id, displayName = cInfo.displayName, msgText = hideSecrets(cItem, cInfo.isChannel))
+      displayNotification(
+        user = user,
+        chatId = cInfo.id,
+        displayName = cInfo.displayName,
+        msgText = hideSecrets(cItem, cInfo.isChannel),
+        remoteHostId = rhId,
+        messageId = cItem.id,
+      )
     }
   }
 
-  fun acceptContactRequestAction(userId: Long?, incognito: Boolean, chatId: ChatId) {
+  fun acceptContactRequestAction(userId: Long?, incognito: Boolean, chatId: ChatId) =
+    acceptContactRequestAction(userId, null, incognito, chatId)
+
+  fun acceptContactRequestAction(userId: Long?, remoteHostId: Long?, incognito: Boolean, chatId: ChatId) {
     val apiId = chatId.replace("<@", "").toLongOrNull() ?: return
     withLongRunningApi {
       awaitChatStartedIfNeeded(chatModel)
+      if (chatModel.remoteHostId() != remoteHostId) chatModel.controller.switchUIRemoteHost(remoteHostId)
       // switching to the user the request was sent to, so that accepted contact is shown
       if (userId != null && userId != chatModel.currentUser.value?.userId && chatModel.currentUser.value != null) {
         chatModel.controller.showProgressIfNeeded {
-          chatModel.controller.changeActiveUser(null, userId, null)
+          chatModel.controller.changeActiveUser(remoteHostId, userId, null)
         }
         chatModel.clearOverlays.value = true
       }
       val isCurrentUser = chatModel.currentUser.value?.userId == userId
-      // TODO include remote host in notification
-      acceptContactRequest(null, incognito, apiId, isCurrentUser, chatModel)
+      acceptContactRequest(remoteHostId, incognito, apiId, isCurrentUser, chatModel)
       cancelNotificationsForChat(chatId)
     }
   }
 
-  fun openChatAction(userId: Long?, chatId: ChatId) {
+  fun openChatAction(userId: Long?, chatId: ChatId) = openChatAction(userId, null, chatId, null)
+
+  fun openChatAction(userId: Long?, remoteHostId: Long?, chatId: ChatId, messageId: Long?) {
     withLongRunningApi {
       awaitChatStartedIfNeeded(chatModel)
+      if (chatModel.remoteHostId() != remoteHostId) {
+        chatModel.controller.switchUIRemoteHost(remoteHostId)
+      }
       if (userId != null && userId != chatModel.currentUser.value?.userId && chatModel.currentUser.value != null) {
-        // TODO include remote host ID in desktop notifications?
         chatModel.controller.showProgressIfNeeded {
-          chatModel.controller.changeActiveUser(null, userId, null)
+          chatModel.controller.changeActiveUser(remoteHostId, userId, null)
         }
       }
-      val cInfo = chatModel.getChat(chatId)?.chatInfo
+      val cInfo = chatModel.chats.value.firstOrNull { it.id == chatId && it.remoteHostId == remoteHostId }?.chatInfo
       chatModel.clearOverlays.value = true
-      if (cInfo != null && (cInfo is ChatInfo.Direct || cInfo is ChatInfo.Group)) openChat(secondaryChatsCtx = null, rhId = null, cInfo)
+      if (cInfo != null && (cInfo is ChatInfo.Direct || cInfo is ChatInfo.Group)) {
+        openChat(secondaryChatsCtx = null, rhId = remoteHostId, cInfo.chatType, cInfo.apiId, messageId)
+      }
     }
   }
 
@@ -105,11 +183,31 @@ abstract class NtfManager {
     }
   }
 
+  fun acceptCallAction(userId: Long?, remoteHostId: Long?, chatId: ChatId) {
+    withLongRunningApi {
+      awaitChatStartedIfNeeded(chatModel)
+      if (chatModel.remoteHostId() != remoteHostId) chatModel.controller.switchUIRemoteHost(remoteHostId)
+      if (userId != null && userId != chatModel.currentUser.value?.userId && chatModel.currentUser.value != null) {
+        chatModel.controller.changeActiveUser(remoteHostId, userId, null)
+      }
+      acceptCallAction(chatId)
+    }
+  }
+
   abstract fun notifyCallInvitation(invitation: RcvCallInvitation): Boolean
   abstract fun hasNotificationsForChat(chatId: String): Boolean
   abstract fun cancelNotificationsForChat(chatId: String)
   abstract fun cancelNotificationsForUser(userId: Long)
-  abstract fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String? = null, actions: List<Pair<NotificationAction, () -> Unit>> = emptyList())
+  abstract fun displayNotification(
+    user: UserLike,
+    chatId: String,
+    displayName: String,
+    msgText: String,
+    image: String? = null,
+    actions: List<Pair<NotificationAction, () -> Unit>> = emptyList(),
+    remoteHostId: Long? = null,
+    messageId: Long? = null,
+  )
   abstract fun cancelCallNotification()
   abstract fun cancelAllNotifications()
   abstract fun showMessage(title: String, text: String)

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/TerminalView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/TerminalView.kt
@@ -75,7 +75,7 @@ fun TerminalLayout(
   fun onMessageChange(s: ComposeMessage) {
     composeState.value = composeState.value.copy(message = s)
   }
-  val oneHandUI = remember { appPrefs.oneHandUI.state }
+  val oneHandUI = rememberOneHandUIState()
   Box(Modifier.fillMaxSize()) {
     val composeViewHeight = remember { mutableStateOf(0.dp) }
     AdaptingBottomPaddingLayout(Modifier, CONSOLE_COMPOSE_LAYOUT_ID, composeViewHeight) {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/call/CallManager.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/call/CallManager.kt
@@ -17,7 +17,7 @@ class CallManager(val chatModel: ChatModel) {
           activeCallInvitation.value = invitation
         } else {
           val contact = invitation.contact
-          ntfManager.displayNotification(user = invitation.user, chatId = contact.id, displayName = contact.displayName, msgText = invitation.callTypeText)
+          ntfManager.displayNotification(user = invitation.user, chatId = contact.id, displayName = contact.displayName, msgText = invitation.callTypeText, remoteHostId = invitation.remoteHostId)
         }
       }
     }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatItemInfoView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatItemInfoView.kt
@@ -510,7 +510,7 @@ fun ChatItemInfoView(chatRh: Long?, ci: ChatItem, ciInfo: ChatItemInfo, devTools
             selection.value = CIInfoTab.Delivery(ciInfo.memberDeliveryStatuses)
           }
         }
-        val oneHandUI = remember { appPrefs.oneHandUI.state }
+        val oneHandUI = rememberOneHandUIState()
         Box(Modifier.align(Alignment.BottomCenter).navigationBarsPadding().offset(x = 0.dp, y = if (oneHandUI.value) -AppBarHeight * fontSizeSqrtMultiplier else 0.dp)) {
           TabRow(
             selectedTabIndex = availableTabs.indexOfFirst { it::class == selection.value::class },

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
@@ -1617,7 +1617,7 @@ fun ChatInfoToolbarTitle(cInfo: ChatInfo, imageSize: Dp = 40.dp, iconColor: Colo
     ChatInfoImage(cInfo, size = imageSize * fontSizeSqrtMultiplier, iconColor)
     Column(
       Modifier.padding(start = 8.dp),
-      horizontalAlignment = Alignment.CenterHorizontally
+      horizontalAlignment = if (appPlatform.isDesktop) Alignment.Start else Alignment.CenterHorizontally
     ) {
       Row(verticalAlignment = Alignment.CenterVertically) {
         if ((cInfo as? ChatInfo.Direct)?.contact?.verified == true) {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
@@ -57,6 +57,8 @@ import kotlin.math.*
 @Stable
 data class ItemSeparation(val timestamp: Boolean, val largeGap: Boolean, val date: Instant?)
 
+internal val chatSearchRequest = mutableIntStateOf(0)
+
 @Composable
 fun ConnectInProgressView(s: String) {
   Surface(color = MaterialTheme.colors.background) {
@@ -102,6 +104,12 @@ fun ChatView(
   onComposed: suspend (chatId: String) -> Unit
 ) {
   val showSearch = rememberSaveable { mutableStateOf(false) }
+  val searchRequest = chatSearchRequest.intValue
+  LaunchedEffect(searchRequest) {
+    if (searchRequest > 0 && appPlatform.isDesktop) {
+      showSearch.value = true
+    }
+  }
   val chat = chatModel.chats.value.firstOrNull { chat -> chat.chatInfo.id == staleChatId.value }
   // They have their own iterator inside for a reason to prevent crash "Reading a state that was created after the snapshot..."
   val remoteHostId = remember { derivedStateOf { chatModel.chats.value.firstOrNull { chat -> chat.chatInfo.id == staleChatId.value }?.remoteHostId } }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
@@ -5,8 +5,11 @@ import androidx.compose.animation.core.*
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.*
 import androidx.compose.foundation.gestures.*
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.*
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.runtime.*
@@ -2081,6 +2084,7 @@ fun BoxScope.ChatItemsList(
         }
 
         Box {
+          val memberImageSize = if (appPlatform.isDesktop) 30.dp else MEMBER_IMAGE_SIZE
           val voiceWithTransparentBack = cItem.content.msgContent is MsgContent.MCVoice && cItem.content.text.isEmpty() && cItem.quotedItem == null && cItem.meta.itemForwarded == null
           val selectionVisible = selectedChatItems.value != null && cItem.canBeDeletedForSelf
           val selectionOffset by animateDpAsState(if (selectionVisible && !sent) 4.dp + 22.dp * fontSizeMultiplier else 0.dp)
@@ -2113,7 +2117,7 @@ fun BoxScope.ChatItemsList(
                         memberNames(member, prevMember, memCount),
                         if (prevMember == null && memCount == 1) member.nameBadge else null,
                         Modifier
-                          .padding(start = (MEMBER_IMAGE_SIZE * fontSizeSqrtMultiplier) + DEFAULT_PADDING_HALF)
+                          .padding(start = (memberImageSize * fontSizeSqrtMultiplier) + DEFAULT_PADDING_HALF)
                           .weight(1f, false),
                         fontSize = 13.5.sp,
                         color = MaterialTheme.colors.secondary,
@@ -2170,7 +2174,7 @@ fun BoxScope.ChatItemsList(
                   }
                   Row(
                     Modifier
-                      .padding(start = if (chatInfo.isChannel) 12.dp else 8.dp + (MEMBER_IMAGE_SIZE * fontSizeSqrtMultiplier) + 4.dp, end = if (voiceWithTransparentBack || chatInfo.isChannel) 12.dp else adjustTailPaddingOffset(66.dp, start = false))
+                      .padding(start = if (chatInfo.isChannel) 12.dp else 8.dp + (memberImageSize * fontSizeSqrtMultiplier) + 4.dp, end = if (voiceWithTransparentBack || chatInfo.isChannel) 12.dp else adjustTailPaddingOffset(66.dp, start = false))
                       .chatItemOffset(cItem, itemSeparation.largeGap, revealed = revealed.value)
                       .then(swipeableOrSelectionModifier)
                   ) {
@@ -2195,7 +2199,7 @@ fun BoxScope.ChatItemsList(
                       Text(
                         chatInfo.groupInfo.chatViewName,
                         Modifier
-                          .padding(start = (MEMBER_IMAGE_SIZE * fontSizeSqrtMultiplier) + DEFAULT_PADDING_HALF)
+                          .padding(start = (memberImageSize * fontSizeSqrtMultiplier) + DEFAULT_PADDING_HALF)
                           .weight(1f, false),
                         fontSize = 13.5.sp,
                         color = MaterialTheme.colors.secondary,
@@ -2225,7 +2229,7 @@ fun BoxScope.ChatItemsList(
                       Row(Modifier.graphicsLayer { translationX = selectionOffset.toPx() }) {
                         Box(Modifier.clickable { showChatInfo() }) {
                           ProfileImage(
-                            MEMBER_IMAGE_SIZE * fontSizeSqrtMultiplier,
+                            memberImageSize * fontSizeSqrtMultiplier,
                             chatInfo.groupInfo.image,
                             chatInfo.groupInfo.chatIconName,
                             backgroundColor = MaterialTheme.colors.background
@@ -2253,7 +2257,7 @@ fun BoxScope.ChatItemsList(
                   }
                   Row(
                     Modifier
-                      .padding(start = if (chatInfo.isChannel) 12.dp else 8.dp + (MEMBER_IMAGE_SIZE * fontSizeSqrtMultiplier) + 4.dp, end = if (voiceWithTransparentBack || chatInfo.isChannel) 12.dp else adjustTailPaddingOffset(66.dp, start = false))
+                      .padding(start = if (chatInfo.isChannel) 12.dp else 8.dp + (memberImageSize * fontSizeSqrtMultiplier) + 4.dp, end = if (voiceWithTransparentBack || chatInfo.isChannel) 12.dp else adjustTailPaddingOffset(66.dp, start = false))
                       .chatItemOffset(cItem, itemSeparation.largeGap, revealed = revealed.value)
                       .then(swipeableOrSelectionModifier)
                   ) {
@@ -2826,7 +2830,7 @@ fun BoxScope.FloatingButtons(
   }
   // Don't show top FAB if is in search
   if (searchValue.value.isNotEmpty()) return
-  val fabSize = 56.dp
+  val fabSize = if (appPlatform.isDesktop) 34.dp else 56.dp
   val topUnreadCount = remember { derivedStateOf {
     if (bottomUnreadCount.value >= 0) (unreadCount.value - bottomUnreadCount.value).coerceAtLeast(0) else 0 }
   }
@@ -2850,10 +2854,11 @@ fun BoxScope.FloatingButtons(
 
   Box(Modifier.fillMaxWidth().wrapContentSize(Alignment.TopEnd).align(Alignment.TopEnd)) {
     val density = LocalDensity.current
-    val width = remember { mutableStateOf(250.dp) }
+    val minimumMenuWidth = if (appPlatform.isDesktop) 180.dp else 250.dp
+    val width = remember { mutableStateOf(minimumMenuWidth) }
     DefaultDropdownMenu(
       showDropDown,
-      modifier = Modifier.onSizeChanged { with(density) { width.value = it.width.toDp().coerceAtLeast(250.dp) } },
+      modifier = Modifier.onSizeChanged { with(density) { width.value = it.width.toDp().coerceAtLeast(minimumMenuWidth) } },
       offset = DpOffset(-DEFAULT_PADDING - width.value, 24.dp + fabSize + topPaddingToContent)
     ) {
       ItemAction(
@@ -2965,7 +2970,8 @@ val MEMBER_IMAGE_SIZE: Dp = 37.dp
 
 @Composable
 fun MemberImage(member: GroupMember) {
-  MemberProfileImage(MEMBER_IMAGE_SIZE * fontSizeSqrtMultiplier, member, backgroundColor = MaterialTheme.colors.background)
+  val imageSize = if (appPlatform.isDesktop) 30.dp else MEMBER_IMAGE_SIZE
+  MemberProfileImage(imageSize * fontSizeSqrtMultiplier, member, backgroundColor = MaterialTheme.colors.background)
 }
 
 @Composable
@@ -2979,6 +2985,24 @@ private fun TopEndFloatingButton(
 ) {
   if (remember { derivedStateOf { unreadCount.value > 0 && !animatedScrollingInProgress.value } }.value) {
     val interactionSource = interactionSourceWithDetection(onClick, onLongClick)
+    if (appPlatform.isDesktop) {
+      DesktopTranscriptButton(
+        modifier = modifier.onRightClick(onLongClick),
+        interactionSource = interactionSource,
+      ) {
+        if (requestedTopScroll.value) {
+          LoadingProgressIndicator()
+        } else {
+          Text(
+            unreadCountStr(unreadCount.value),
+            color = MaterialTheme.colors.primary,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Medium
+          )
+        }
+      }
+      return
+    }
     FloatingActionButton(
       {}, // no action here
       modifier.size(48.dp).onRightClick(onLongClick),
@@ -3110,9 +3134,14 @@ private fun FloatingDate(
             color = MaterialTheme.colors.secondaryVariant,
             RoundedCornerShape(25.dp)
           )
-          .padding(vertical = 4.dp, horizontal = 8.dp)
+          .border(
+            if (appPlatform.isDesktop) 1.dp else 0.dp,
+            MaterialTheme.colors.onSurface.copy(alpha = if (appPlatform.isDesktop) 0.1f else 0f),
+            RoundedCornerShape(25.dp)
+          )
+          .padding(vertical = if (appPlatform.isDesktop) 3.dp else 4.dp, horizontal = 8.dp)
           .clip(RoundedCornerShape(25.dp)),
-        fontSize = 14.sp,
+        fontSize = if (appPlatform.isDesktop) 12.sp else 14.sp,
         fontWeight = FontWeight.Medium,
         textAlign = TextAlign.Center,
         color = MaterialTheme.colors.secondary
@@ -3193,8 +3222,10 @@ private fun ButtonRow(horizontalArrangement: Arrangement.Horizontal, content: @C
 private fun DateSeparator(date: Instant) {
   Text(
     text = getTimestampDateText(date),
-    Modifier.padding(vertical = DEFAULT_PADDING_HALF + 4.dp, horizontal = DEFAULT_PADDING_HALF).fillMaxWidth(),
-    fontSize = 14.sp,
+    Modifier
+      .padding(vertical = if (appPlatform.isDesktop) 10.dp else DEFAULT_PADDING_HALF + 4.dp, horizontal = DEFAULT_PADDING_HALF)
+      .fillMaxWidth(),
+    fontSize = if (appPlatform.isDesktop) 12.sp else 14.sp,
     fontWeight = FontWeight.Medium,
     textAlign = TextAlign.Center,
     color = MaterialTheme.colors.secondary
@@ -3395,6 +3426,24 @@ private fun BoxScope.BottomEndFloatingButton(
 ) {
   when {
     showButtonWithCounter.value && !animatedScrollingInProgress.value -> {
+      if (appPlatform.isDesktop) {
+        DesktopTranscriptButton(
+          modifier = Modifier.padding(end = DEFAULT_PADDING, bottom = DEFAULT_PADDING + composeViewHeight.value).align(Alignment.BottomEnd),
+          onClick = onClick
+        ) {
+          if (requestedBottomScroll.value) {
+            LoadingProgressIndicator()
+          } else {
+            Text(
+              unreadCountStr(unreadCount.value),
+              color = MaterialTheme.colors.primary,
+              fontSize = 12.sp,
+              fontWeight = FontWeight.Medium
+            )
+          }
+        }
+        return
+      }
       FloatingActionButton(
         onClick = onClick,
         elevation = FloatingActionButtonDefaults.elevation(0.dp, 0.dp, 0.dp, 0.dp),
@@ -3413,6 +3462,24 @@ private fun BoxScope.BottomEndFloatingButton(
       }
     }
     showButtonWithArrow.value && !animatedScrollingInProgress.value -> {
+      if (appPlatform.isDesktop) {
+        DesktopTranscriptButton(
+          modifier = Modifier.padding(end = DEFAULT_PADDING, bottom = DEFAULT_PADDING + composeViewHeight.value).align(Alignment.BottomEnd),
+          onClick = onClick
+        ) {
+          if (requestedBottomScroll.value) {
+            LoadingProgressIndicator()
+          } else {
+            Icon(
+              painter = painterResource(MR.images.ic_keyboard_arrow_down),
+              contentDescription = null,
+              modifier = Modifier.size(18.dp),
+              tint = MaterialTheme.colors.primary
+            )
+          }
+        }
+        return
+      }
       FloatingActionButton(
         onClick = onClick,
         elevation = FloatingActionButtonDefaults.elevation(0.dp, 0.dp, 0.dp, 0.dp),
@@ -3432,6 +3499,31 @@ private fun BoxScope.BottomEndFloatingButton(
     }
     else -> {}
   }
+}
+
+@Composable
+private fun DesktopTranscriptButton(
+  modifier: Modifier,
+  interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+  onClick: () -> Unit = {},
+  content: @Composable BoxScope.() -> Unit
+) {
+  val hovered = interactionSource.collectIsHoveredAsState().value
+  Box(
+    modifier
+      .size(34.dp)
+      .shadow(if (hovered) 4.dp else 2.dp, CircleShape)
+      .background(MaterialTheme.colors.surface.copy(alpha = 0.96f), CircleShape)
+      .border(1.dp, MaterialTheme.colors.onSurface.copy(alpha = 0.12f), CircleShape)
+      .clip(CircleShape)
+      .clickable(
+        interactionSource = interactionSource,
+        indication = LocalIndication.current,
+        onClick = onClick
+      ),
+    contentAlignment = Alignment.Center,
+    content = content
+  )
 }
 
 @Composable
@@ -3464,7 +3556,7 @@ private fun LoadingProgressIndicator() {
     contentAlignment = Alignment.Center
   ) {
     CircularProgressIndicator(
-      Modifier.size(30.dp),
+      Modifier.size(if (appPlatform.isDesktop) 18.dp else 30.dp),
       color = MaterialTheme.colors.secondary,
       strokeWidth = 2.dp
     )

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
@@ -1016,7 +1016,7 @@ fun ChatLayout(
         val remoteHostId = remember { remoteHostId }.value
         val chat = remember { chat }.value
         val chatInfo = chat?.chatInfo
-        val oneHandUI = remember { if (appPlatform.isDesktop) mutableStateOf(false) else appPrefs.oneHandUI.state }
+        val oneHandUI = rememberOneHandUIState()
         val chatBottomBar = remember { appPrefs.chatBottomBar.state }
         val composeViewFocusRequester = remember { if (appPlatform.isDesktop) FocusRequester() else null }
         AdaptingBottomPaddingLayout(Modifier, CHAT_COMPOSE_LAYOUT_ID, composeViewHeight) {
@@ -1459,7 +1459,7 @@ fun BoxScope.ChatInfoToolbar(
       }
     }
   }
-  val oneHandUI = remember { if (appPlatform.isDesktop) mutableStateOf(false) else appPrefs.oneHandUI.state }
+  val oneHandUI = rememberOneHandUIState()
   val chatBottomBar = remember { appPrefs.chatBottomBar.state }
   val searchTrailingContent: @Composable (() -> Unit)? = if (showContentFilterButton) {{
     IconButton({ showContentFilterMenu.value = true }) {
@@ -3001,7 +3001,7 @@ private fun TopEndFloatingButton(
 
 @Composable
 fun topPaddingToContent(chatView: Boolean, additionalTopBar: Boolean = false): Dp {
-  val oneHandUI = remember { if (appPlatform.isDesktop) mutableStateOf(false) else appPrefs.oneHandUI.state }
+  val oneHandUI = rememberOneHandUIState()
   val chatBottomBar = remember { appPrefs.chatBottomBar.state }
   val reportsPadding = if (additionalTopBar) AppBarHeight * fontSizeSqrtMultiplier else 0.dp
   return if (oneHandUI.value && (!chatView || chatBottomBar.value)) {
@@ -3013,7 +3013,7 @@ fun topPaddingToContent(chatView: Boolean, additionalTopBar: Boolean = false): D
 
 @Composable
 private fun numberOfBottomAppBars(): Int {
-  val oneHandUI = remember { if (appPlatform.isDesktop) mutableStateOf(false) else appPrefs.oneHandUI.state }
+  val oneHandUI = rememberOneHandUIState()
   val chatBottomBar = remember { appPrefs.chatBottomBar.state }
   return if (oneHandUI.value && chatBottomBar.value) {
     2

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
@@ -14,11 +14,15 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.*
 import androidx.compose.ui.draw.*
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.graphics.*
 import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.input.key.*
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.*
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import dev.icerock.moko.resources.compose.painterResource
 import dev.icerock.moko.resources.compose.stringResource
 import androidx.compose.foundation.text.appendInlineContent
@@ -28,6 +32,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.*
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.*
+import chat.simplex.common.tokens
 import chat.simplex.common.model.*
 import chat.simplex.common.model.CIDirection.GroupRcv
 import chat.simplex.common.model.ChatController.appPrefs
@@ -56,6 +61,20 @@ import kotlin.math.*
 
 @Stable
 data class ItemSeparation(val timestamp: Boolean, val largeGap: Boolean, val date: Instant?)
+
+internal fun desktopRangeSelection(
+  orderedItems: List<Pair<Long, Boolean>>,
+  anchorId: Long,
+  targetId: Long,
+): Set<Long> {
+  val anchorIndex = orderedItems.indexOfFirst { it.first == anchorId }
+  val targetIndex = orderedItems.indexOfFirst { it.first == targetId }
+  if (anchorIndex < 0 || targetIndex < 0) return emptySet()
+  return orderedItems
+    .subList(minOf(anchorIndex, targetIndex), maxOf(anchorIndex, targetIndex) + 1)
+    .filter { it.second }
+    .mapTo(linkedSetOf()) { it.first }
+}
 
 internal val chatSearchRequest = mutableIntStateOf(0)
 
@@ -965,6 +984,7 @@ fun ChatLayout(
   val chatInfo = remember { derivedStateOf { chat.value?.chatInfo } }
   val scope = rememberCoroutineScope()
   val attachmentDisabled = remember { derivedStateOf { composeState.value.attachmentDisabled } }
+  var externalDragActive by remember { mutableStateOf(false) }
   Box(
     Modifier
       .fillMaxWidth()
@@ -976,6 +996,7 @@ fun ChatLayout(
           // Need to parse HTML in order to correctly display the content
           //composeState.value = composeState.value.copy(message = composeState.value.message + it)
         },
+        onDragging = { externalDragActive = it },
       )
   ) {
     ModalBottomSheetLayout(
@@ -1174,6 +1195,26 @@ fun ChatLayout(
                 SupportChatsCountToolbar(chatInfo, reportsCount, supportUnreadCount, withStatusBar = false, showReports, showSupportChats)
               }
             }
+          }
+        }
+      }
+    }
+    if (externalDragActive) {
+      Box(
+        Modifier
+          .fillMaxSize()
+          .zIndex(20f)
+          .padding(18.dp)
+          .clip(RoundedCornerShape(18.dp))
+          .background(MaterialTheme.colors.primary.copy(alpha = 0.16f))
+          .border(2.dp, MaterialTheme.colors.primary, RoundedCornerShape(18.dp)),
+        contentAlignment = Alignment.Center
+      ) {
+        Surface(shape = RoundedCornerShape(12.dp), elevation = 4.dp) {
+          Row(Modifier.padding(horizontal = 20.dp, vertical = 14.dp), verticalAlignment = Alignment.CenterVertically) {
+            Icon(painterResource(MR.images.ic_attach_file_filled), "Attach files", tint = MaterialTheme.colors.primary)
+            Spacer(Modifier.width(10.dp))
+            Text("Drop files to attach", style = MaterialTheme.typography.h6)
           }
         }
       }
@@ -1806,6 +1847,28 @@ fun BoxScope.ChatItemsList(
     }
   }
   val reversedChatItems = remember { derivedStateOf { chatsCtx.chatItems.value.asReversed() } }
+  val selectionAnchorId = remember(chatInfo.id) { mutableStateOf<Long?>(null) }
+
+  fun toggleDesktopMessageSelection(item: ChatItem, revealed: State<Boolean>) {
+    val selected = selectedChatItems.value.orEmpty()
+    selectUnselectChatItem(!selected.contains(item.id), item, revealed, selectedChatItems, reversedChatItems)
+    selectionAnchorId.value = item.id
+  }
+
+  fun selectDesktopMessageRange(item: ChatItem, revealed: State<Boolean>) {
+    val anchor = selectionAnchorId.value
+    if (anchor == null) {
+      toggleDesktopMessageSelection(item, revealed)
+      return
+    }
+    val items = reversedChatItems.value
+    val rangeIds = desktopRangeSelection(items.map { it.id to it.canBeDeletedForSelf }, anchor, item.id)
+    if (rangeIds.isEmpty()) {
+      toggleDesktopMessageSelection(item, revealed)
+      return
+    }
+    selectedChatItems.value = rangeIds
+  }
   val reportsCount = reportsCount(chatInfo.id)
   val supportUnreadCount = supportUnreadCount(chatInfo.id)
   val topPaddingToContent = topPaddingToContent(
@@ -1922,6 +1985,7 @@ fun BoxScope.ChatItemsList(
   ) {
     val itemScope = rememberCoroutineScope()
     val viewConfiguration = LocalViewConfiguration.current
+    val focusManager = LocalFocusManager.current
     CompositionLocalProvider(
       // Makes horizontal and vertical scrolling to coexist nicely.
       // With default touchSlop when you scroll LazyColumn, you can unintentionally open reply view.
@@ -1955,7 +2019,10 @@ fun BoxScope.ChatItemsList(
                 highlightedItems.value = setOf()
               }
           }
-          ChatItemView(chatsCtx, remoteHostId, chat, cItem, composeState, provider, useLinkPreviews = useLinkPreviews, linkMode = linkMode, revealed = revealed, highlighted = highlighted, hoveredItemId = hoveredItemId, range = range, searchIsNotBlank = searchValueIsNotBlank, fillMaxWidth = fillMaxWidth, selectedChatItems = selectedChatItems, selectChatItem = { selectUnselectChatItem(true, cItem, revealed, selectedChatItems, reversedChatItems) }, deleteMessage = deleteMessage, deleteMessages = deleteMessages, archiveReports = archiveReports, receiveFile = receiveFile, cancelFile = cancelFile, joinGroup = joinGroup, acceptCall = acceptCall, acceptFeature = acceptFeature, openDirectChat = openDirectChat, forwardItem = forwardItem, updateContactStats = updateContactStats, updateMemberStats = updateMemberStats, syncContactConnection = syncContactConnection, syncMemberConnection = syncMemberConnection, findModelChat = findModelChat, findModelMember = findModelMember, scrollToItem = scrollToItem, scrollToItemId = scrollToItemId, scrollToQuotedItemFromItem = scrollToQuotedItemFromItem, setReaction = setReaction, showItemDetails = showItemDetails, reveal = reveal, showMemberInfo = showMemberInfo, showChatInfo = showChatInfo, developerTools = developerTools, showViaProxy = showViaProxy, itemSeparation = itemSeparation, showTimestamp = itemSeparation.timestamp, swipeOffset = swipeOffset)
+          ChatItemView(chatsCtx, remoteHostId, chat, cItem, composeState, provider, useLinkPreviews = useLinkPreviews, linkMode = linkMode, revealed = revealed, highlighted = highlighted, hoveredItemId = hoveredItemId, range = range, searchIsNotBlank = searchValueIsNotBlank, fillMaxWidth = fillMaxWidth, selectedChatItems = selectedChatItems, selectChatItem = {
+            selectUnselectChatItem(true, cItem, revealed, selectedChatItems, reversedChatItems)
+            selectionAnchorId.value = cItem.id
+          }, deleteMessage = deleteMessage, deleteMessages = deleteMessages, archiveReports = archiveReports, receiveFile = receiveFile, cancelFile = cancelFile, joinGroup = joinGroup, acceptCall = acceptCall, acceptFeature = acceptFeature, openDirectChat = openDirectChat, forwardItem = forwardItem, updateContactStats = updateContactStats, updateMemberStats = updateMemberStats, syncContactConnection = syncContactConnection, syncMemberConnection = syncMemberConnection, findModelChat = findModelChat, findModelMember = findModelMember, scrollToItem = scrollToItem, scrollToItemId = scrollToItemId, scrollToQuotedItemFromItem = scrollToQuotedItemFromItem, setReaction = setReaction, showItemDetails = showItemDetails, reveal = reveal, showMemberInfo = showMemberInfo, showChatInfo = showChatInfo, developerTools = developerTools, showViaProxy = showViaProxy, itemSeparation = itemSeparation, showTimestamp = itemSeparation.timestamp, swipeOffset = swipeOffset)
         }
       }
 
@@ -1984,15 +2051,18 @@ fun BoxScope.ChatItemsList(
 
         @Composable
         fun ChatItemBox(modifier: Modifier = Modifier, content: @Composable () -> Unit = { }) {
+          val densityTokens = remember { appPrefs.desktopChatDensity.state }.value.tokens()
+          val compactGap = if (appPlatform.isDesktop) densityTokens.groupedMessageGap else 1.dp
+          val largeGap = if (appPlatform.isDesktop) densityTokens.messageVerticalPadding else 4.dp
           Box(
             modifier = modifier.padding(
               bottom = if (itemSeparation.largeGap) {
                 if (itemAtZeroIndexInWholeList) {
-                  8.dp
+                  largeGap * 2
                 } else {
-                  4.dp
+                  largeGap
                 }
-              } else 1.dp, top = if (previousItemSeparationLargeGap) 4.dp else 1.dp
+              } else compactGap, top = if (previousItemSeparationLargeGap) largeGap else compactGap
             ),
             contentAlignment = Alignment.CenterStart
           ) {
@@ -2223,11 +2293,39 @@ fun BoxScope.ChatItemsList(
               }
             }
           }
+          val keyboardMessageNavigation = if (appPlatform.isDesktop) {
+            Modifier
+              .focusable()
+              .semantics { selected = selectedChatItems.value?.contains(cItem.id) == true }
+              .onPreviewKeyEvent { event ->
+                if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+                when (event.key) {
+                  Key.DirectionUp -> focusManager.moveFocus(FocusDirection.Up)
+                  Key.DirectionDown -> focusManager.moveFocus(FocusDirection.Down)
+                  Key.Spacebar -> {
+                    toggleDesktopMessageSelection(cItem, revealed)
+                    true
+                  }
+                  else -> false
+                }
+              }
+          } else Modifier
           if (selectionVisible) {
-            Box(Modifier.matchParentSize().clickable {
+            Box(Modifier.matchParentSize().then(keyboardMessageNavigation).clickable {
               val checked = selectedChatItems.value?.contains(cItem.id) == true
               selectUnselectChatItem(select = !checked, cItem, revealed, selectedChatItems, reversedChatItems)
             })
+          } else if (appPlatform.isDesktop && cItem.canBeDeletedForSelf) {
+            Box(
+              Modifier
+                .matchParentSize()
+                .then(keyboardMessageNavigation)
+                .desktopMessageSelection(
+                  enabled = true,
+                  onToggle = { toggleDesktopMessageSelection(cItem, revealed) },
+                  onRange = { selectDesktopMessageRange(cItem, revealed) }
+                )
+            )
           }
         }
       }
@@ -2371,7 +2469,50 @@ fun BoxScope.ChatItemsList(
   }
 
   val manager = LocalSelectionManager.current
-  val modifier = if (appPlatform.isDesktop && manager != null) SelectionHandler(manager, listState, mergedItems, revealedItems, linkMode) else Modifier
+  val clipboard = LocalClipboardManager.current
+  val desktopSelectionKeys = if (appPlatform.isDesktop) {
+    Modifier.onPreviewKeyEvent { event ->
+      if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+      val command = event.isMetaPressed || event.isCtrlPressed
+      when {
+        command && event.key == Key.A -> {
+          selectedChatItems.value = reversedChatItems.value.filter { it.canBeDeletedForSelf }.mapTo(mutableSetOf()) { it.id }
+          selectionAnchorId.value = reversedChatItems.value.firstOrNull { it.canBeDeletedForSelf }?.id
+          true
+        }
+        command && event.key == Key.C && selectedChatItems.value != null -> {
+          val selected = selectedChatItems.value.orEmpty()
+          val copied = chatsCtx.chatItems.value
+            .filter { selected.contains(it.id) }
+            .joinToString("\n\n") { it.content.text }
+          clipboard.setText(AnnotatedString(copied))
+          true
+        }
+        event.key == Key.Escape && selectedChatItems.value != null -> {
+          selectedChatItems.value = null
+          selectionAnchorId.value = null
+          true
+        }
+        (event.key == Key.Delete || event.key == Key.Backspace) && selectedChatItems.value?.isNotEmpty() == true -> {
+          val ids = selectedChatItems.value.orEmpty().sorted()
+          deleteMessagesAlertDialog(
+            ids,
+            questionText = generalGetString(MR.strings.delete_messages_cannot_be_undone_warning),
+            forAll = false,
+            deleteMessages = { selectedIds, _ ->
+              deleteMessages(selectedIds)
+              selectedChatItems.value = null
+              selectionAnchorId.value = null
+            }
+          )
+          true
+        }
+        else -> false
+      }
+    }
+  } else Modifier
+  val textSelectionModifier = if (appPlatform.isDesktop && manager != null) SelectionHandler(manager, listState, mergedItems, revealedItems, linkMode) else Modifier
+  val modifier = textSelectionModifier.then(desktopSelectionKeys)
 
   LazyColumnWithScrollBar(
     modifier.align(Alignment.BottomCenter),

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
@@ -1016,7 +1016,7 @@ fun ChatLayout(
         val remoteHostId = remember { remoteHostId }.value
         val chat = remember { chat }.value
         val chatInfo = chat?.chatInfo
-        val oneHandUI = remember { appPrefs.oneHandUI.state }
+        val oneHandUI = remember { if (appPlatform.isDesktop) mutableStateOf(false) else appPrefs.oneHandUI.state }
         val chatBottomBar = remember { appPrefs.chatBottomBar.state }
         val composeViewFocusRequester = remember { if (appPlatform.isDesktop) FocusRequester() else null }
         AdaptingBottomPaddingLayout(Modifier, CHAT_COMPOSE_LAYOUT_ID, composeViewHeight) {
@@ -1459,7 +1459,7 @@ fun BoxScope.ChatInfoToolbar(
       }
     }
   }
-  val oneHandUI = remember { appPrefs.oneHandUI.state }
+  val oneHandUI = remember { if (appPlatform.isDesktop) mutableStateOf(false) else appPrefs.oneHandUI.state }
   val chatBottomBar = remember { appPrefs.chatBottomBar.state }
   val searchTrailingContent: @Composable (() -> Unit)? = if (showContentFilterButton) {{
     IconButton({ showContentFilterMenu.value = true }) {
@@ -1474,7 +1474,7 @@ fun BoxScope.ChatInfoToolbar(
 
   DefaultAppBar(
     navigationButton = { if (appPlatform.isAndroid || showSearch.value) { NavigationButtonBack(onBackClicked) }  },
-    title = { ChatInfoToolbarTitle(chatInfo) },
+    title = { ChatInfoToolbarTitle(chatInfo, imageSize = if (appPlatform.isDesktop) 32.dp else 40.dp) },
     onTitleClick = if (chatInfo is ChatInfo.Local) null else info,
     showSearch = showSearch.value,
     searchAlwaysVisible = contentFilter.value != null,
@@ -1482,6 +1482,7 @@ fun BoxScope.ChatInfoToolbar(
     searchPlaceholder = searchPlaceholder,
     onSearchValueChanged = onSearchValueChanged,
     searchTrailingContent = searchTrailingContent,
+    centeredTitle = true,
     buttons = { barButtons.forEach { it() } }
   )
   Box(Modifier.fillMaxWidth().wrapContentSize(Alignment.TopEnd)) {
@@ -3000,7 +3001,7 @@ private fun TopEndFloatingButton(
 
 @Composable
 fun topPaddingToContent(chatView: Boolean, additionalTopBar: Boolean = false): Dp {
-  val oneHandUI = remember { appPrefs.oneHandUI.state }
+  val oneHandUI = remember { if (appPlatform.isDesktop) mutableStateOf(false) else appPrefs.oneHandUI.state }
   val chatBottomBar = remember { appPrefs.chatBottomBar.state }
   val reportsPadding = if (additionalTopBar) AppBarHeight * fontSizeSqrtMultiplier else 0.dp
   return if (oneHandUI.value && (!chatView || chatBottomBar.value)) {
@@ -3012,7 +3013,7 @@ fun topPaddingToContent(chatView: Boolean, additionalTopBar: Boolean = false): D
 
 @Composable
 private fun numberOfBottomAppBars(): Int {
-  val oneHandUI = remember { appPrefs.oneHandUI.state }
+  val oneHandUI = remember { if (appPlatform.isDesktop) mutableStateOf(false) else appPrefs.oneHandUI.state }
   val chatBottomBar = remember { appPrefs.chatBottomBar.state }
   return if (oneHandUI.value && chatBottomBar.value) {
     2

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ComposeAttachmentsView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ComposeAttachmentsView.kt
@@ -1,0 +1,126 @@
+package chat.simplex.common.views.chat
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.filled.KeyboardArrowRight
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.*
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import chat.simplex.common.platform.base64ToBitmap
+import chat.simplex.common.ui.theme.DEFAULT_PADDING_HALF
+import chat.simplex.res.MR
+import dev.icerock.moko.resources.compose.painterResource
+import kotlin.math.abs
+
+@Composable
+fun ComposeAttachmentsView(
+  attachments: List<PendingAttachment>,
+  enabled: Boolean,
+  remove: (String) -> Unit,
+  move: (Int, Int) -> Unit,
+  clear: () -> Unit,
+) {
+  Row(
+    Modifier
+      .fillMaxWidth()
+      .padding(top = 6.dp)
+      .background(MaterialTheme.colors.surface.copy(alpha = 0.96f)),
+    verticalAlignment = Alignment.CenterVertically
+  ) {
+    LazyRow(
+      Modifier.weight(1f).padding(start = DEFAULT_PADDING_HALF, top = 6.dp, bottom = 6.dp),
+      horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+      itemsIndexed(attachments, key = { _, item -> item.id }) { index, attachment ->
+        var dragDistance by remember(attachment.id) { mutableFloatStateOf(0f) }
+        Surface(
+          modifier = Modifier
+            .width(154.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .focusable(enabled)
+            .onPreviewKeyEvent { event ->
+              if (enabled && event.type == KeyEventType.KeyDown && (event.key == Key.Delete || event.key == Key.Backspace)) {
+                remove(attachment.id)
+                true
+              } else false
+            }
+            .pointerInput(enabled, index, attachments.size) {
+              if (!enabled) return@pointerInput
+              detectHorizontalDragGestures(
+                onDragStart = { dragDistance = 0f },
+                onHorizontalDrag = { change, amount ->
+                  change.consume()
+                  dragDistance += amount
+                  if (abs(dragDistance) >= 44f) {
+                    val target = if (dragDistance < 0) index - 1 else index + 1
+                    if (target in attachments.indices) move(index, target)
+                    dragDistance = 0f
+                  }
+                }
+              )
+            },
+          shape = RoundedCornerShape(10.dp),
+          elevation = 1.dp
+        ) {
+          Column(Modifier.padding(6.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+            val preview = attachment.previewImage
+            if (preview != null) {
+              Box(contentAlignment = Alignment.Center) {
+                Image(
+                  bitmap = base64ToBitmap(preview),
+                  contentDescription = "Preview of ${attachment.fileName}",
+                  modifier = Modifier.fillMaxWidth().height(62.dp).clip(RoundedCornerShape(7.dp)),
+                  contentScale = ContentScale.Crop
+                )
+                if (attachment.kind == PendingAttachmentKind.Video) {
+                  Icon(painterResource(MR.images.ic_videocam_filled), "Video", tint = Color.White)
+                }
+              }
+            } else {
+              Box(Modifier.fillMaxWidth().height(62.dp), contentAlignment = Alignment.Center) {
+                Icon(painterResource(MR.images.ic_draft), null, Modifier.size(30.dp), tint = MaterialTheme.colors.secondary)
+              }
+            }
+            Text(
+              attachment.fileName,
+              Modifier.fillMaxWidth().padding(top = 4.dp),
+              maxLines = 1,
+              overflow = TextOverflow.Ellipsis,
+              style = MaterialTheme.typography.caption
+            )
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+              IconButton(onClick = { move(index, index - 1) }, enabled = enabled && index > 0, modifier = Modifier.size(30.dp)) {
+                Icon(Icons.Default.KeyboardArrowLeft, "Move ${attachment.fileName} left")
+              }
+              IconButton(onClick = { remove(attachment.id) }, enabled = enabled, modifier = Modifier.size(30.dp)) {
+                Icon(painterResource(MR.images.ic_close), "Remove ${attachment.fileName}")
+              }
+              IconButton(onClick = { move(index, index + 1) }, enabled = enabled && index < attachments.lastIndex, modifier = Modifier.size(30.dp)) {
+                Icon(Icons.Default.KeyboardArrowRight, "Move ${attachment.fileName} right")
+              }
+            }
+          }
+        }
+      }
+    }
+    IconButton(onClick = clear, enabled = enabled) {
+      Icon(painterResource(MR.images.ic_close), "Remove all attachments", tint = MaterialTheme.colors.primary)
+    }
+  }
+}

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ComposeAttachmentsView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ComposeAttachmentsView.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import chat.simplex.common.platform.base64ToBitmap
+import chat.simplex.common.platform.appPlatform
 import chat.simplex.common.ui.theme.DEFAULT_PADDING_HALF
 import chat.simplex.res.MR
 import dev.icerock.moko.resources.compose.painterResource
@@ -36,6 +37,10 @@ fun ComposeAttachmentsView(
   move: (Int, Int) -> Unit,
   clear: () -> Unit,
 ) {
+  val desktop = appPlatform.isDesktop
+  val cardWidth = if (desktop) 126.dp else 154.dp
+  val previewHeight = if (desktop) 52.dp else 62.dp
+  val controlSize = if (desktop) 26.dp else 30.dp
   Row(
     Modifier
       .fillMaxWidth()
@@ -51,7 +56,7 @@ fun ComposeAttachmentsView(
         var dragDistance by remember(attachment.id) { mutableFloatStateOf(0f) }
         Surface(
           modifier = Modifier
-            .width(154.dp)
+            .width(cardWidth)
             .clip(RoundedCornerShape(10.dp))
             .focusable(enabled)
             .onPreviewKeyEvent { event ->
@@ -85,7 +90,7 @@ fun ComposeAttachmentsView(
                 Image(
                   bitmap = base64ToBitmap(preview),
                   contentDescription = "Preview of ${attachment.fileName}",
-                  modifier = Modifier.fillMaxWidth().height(62.dp).clip(RoundedCornerShape(7.dp)),
+                  modifier = Modifier.fillMaxWidth().height(previewHeight).clip(RoundedCornerShape(7.dp)),
                   contentScale = ContentScale.Crop
                 )
                 if (attachment.kind == PendingAttachmentKind.Video) {
@@ -93,7 +98,7 @@ fun ComposeAttachmentsView(
                 }
               }
             } else {
-              Box(Modifier.fillMaxWidth().height(62.dp), contentAlignment = Alignment.Center) {
+              Box(Modifier.fillMaxWidth().height(previewHeight), contentAlignment = Alignment.Center) {
                 Icon(painterResource(MR.images.ic_draft), null, Modifier.size(30.dp), tint = MaterialTheme.colors.secondary)
               }
             }
@@ -105,13 +110,13 @@ fun ComposeAttachmentsView(
               style = MaterialTheme.typography.caption
             )
             Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-              IconButton(onClick = { move(index, index - 1) }, enabled = enabled && index > 0, modifier = Modifier.size(30.dp)) {
+              IconButton(onClick = { move(index, index - 1) }, enabled = enabled && index > 0, modifier = Modifier.size(controlSize)) {
                 Icon(Icons.Default.KeyboardArrowLeft, "Move ${attachment.fileName} left")
               }
-              IconButton(onClick = { remove(attachment.id) }, enabled = enabled, modifier = Modifier.size(30.dp)) {
+              IconButton(onClick = { remove(attachment.id) }, enabled = enabled, modifier = Modifier.size(controlSize)) {
                 Icon(painterResource(MR.images.ic_close), "Remove ${attachment.fileName}")
               }
-              IconButton(onClick = { move(index, index + 1) }, enabled = enabled && index < attachments.lastIndex, modifier = Modifier.size(30.dp)) {
+              IconButton(onClick = { move(index, index + 1) }, enabled = enabled && index < attachments.lastIndex, modifier = Modifier.size(controlSize)) {
                 Icon(Icons.Default.KeyboardArrowRight, "Move ${attachment.fileName} right")
               }
             }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ComposeView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ComposeView.kt
@@ -1341,10 +1341,11 @@ fun ComposeView(
     val commandsEnabled = chat.chatInfo.sendMsgEnabled && chat.chatInfo.menuCommands.isNotEmpty()
     IconButton(
       onClick = { showCommandsMenu.value = !showCommandsMenu.value },
-      enabled = commandsEnabled
+      modifier = if (appPlatform.isDesktop) Modifier.size(34.dp) else Modifier,
+      enabled = commandsEnabled,
     ) {
       Box(
-        modifier = Modifier.size(28.dp).clip(CircleShape),
+        modifier = Modifier.size(if (appPlatform.isDesktop) 20.dp else 28.dp).clip(CircleShape),
         contentAlignment = Alignment.Center
       ) {
         Text("//", style = MaterialTheme.typography.h3.copy(fontStyle = FontStyle.Italic, color = if (commandsEnabled) MaterialTheme.colors.primary else MaterialTheme.colors.secondary))
@@ -1375,14 +1376,15 @@ fun ComposeView(
           && !nextSendGrpInv.value
     IconButton(
       attachmentClicked,
-      enabled = attachmentEnabled
+      modifier = if (appPlatform.isDesktop) Modifier.size(34.dp) else Modifier,
+      enabled = attachmentEnabled,
     ) {
       Icon(
         painterResource(MR.images.ic_attach_file_filled_500),
         contentDescription = stringResource(MR.strings.attach),
         tint = if (attachmentEnabled) MaterialTheme.colors.primary else MaterialTheme.colors.secondary,
         modifier = Modifier
-          .size(28.dp)
+          .size(if (appPlatform.isDesktop) 20.dp else 28.dp)
           .clip(CircleShape)
       )
     }
@@ -1392,8 +1394,8 @@ fun ComposeView(
   fun AttachmentAndCommandsButtons() {
     val cInfo = chat.chatInfo
     Row(
-      Modifier.padding(start = 3.dp, end = 1.dp, bottom = if (appPlatform.isAndroid) 2.sp.toDp() else 5.sp.toDp() * fontSizeSqrtMultiplier),
-      horizontalArrangement = Arrangement.spacedBy((-8).dp)
+      Modifier.padding(start = 3.dp, end = 1.dp, bottom = if (appPlatform.isAndroid) 2.sp.toDp() else 7.dp),
+      horizontalArrangement = Arrangement.spacedBy(if (appPlatform.isDesktop) 0.dp else (-8).dp)
     ) {
       val msg = composeState.value.message.text.trim()
       val showAttachment = cInfo !is ChatInfo.Direct || cInfo.contact.profile.peerType != ChatPeerType.Bot || cInfo.featureEnabled(ChatFeature.Files)
@@ -1815,8 +1817,9 @@ fun ComposeView(
       }
     }
 
-    Surface(color = MaterialTheme.colors.background, contentColor = MaterialTheme.colors.onBackground) {
-      Divider()
+    val composeRowModifier = if (appPlatform.isDesktop) Modifier.fillMaxWidth().padding(horizontal = 8.dp) else Modifier.padding(end = 8.dp)
+    Surface(color = if (appPlatform.isDesktop) Color.Transparent else MaterialTheme.colors.background, contentColor = MaterialTheme.colors.onBackground) {
+      if (!appPlatform.isDesktop) Divider()
       if (chat.chatInfo is ChatInfo.Group && chat.chatInfo.groupInfo.nextConnectPrepared) {
         if (chat.chatInfo.groupInfo.businessChat == null) {
           val isChannel = chat.chatInfo.groupInfo.useRelays
@@ -1836,7 +1839,7 @@ fun ComposeView(
         Column {
           ContextSendMessageToConnect(generalGetString(MR.strings.compose_send_direct_message_to_connect))
           Divider()
-          Row(Modifier.padding(end = 8.dp), verticalAlignment = Alignment.Bottom) {
+          Row(composeRowModifier, verticalAlignment = Alignment.Bottom) {
             AttachmentAndCommandsButtons()
             SendMsgView_(
               disableSendButton = disableSendButton,
@@ -1891,7 +1894,7 @@ fun ComposeView(
           groupDirectInv = chat.chatInfo.contact.groupDirectInv
         )
       } else {
-        Row(Modifier.padding(end = 8.dp), verticalAlignment = Alignment.Bottom) {
+        Row(composeRowModifier, verticalAlignment = Alignment.Bottom) {
           AttachmentAndCommandsButtons()
           val broadcastPlaceholder = (chat.chatInfo as? ChatInfo.Group)?.groupInfo?.let { gi ->
             if (gi.useRelays && gi.membership.memberRole >= GroupMemberRole.Owner && chat.chatInfo.groupChatScope() == null) generalGetString(MR.strings.compose_view_broadcast)

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ComposeView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ComposeView.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.input.key.*
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontStyle
@@ -64,7 +65,29 @@ sealed class ComposePreview {
   @Serializable class MediaPreview(val images: List<String>, val content: List<UploadContent>): ComposePreview()
   @Serializable data class VoicePreview(val voice: String, val durationMs: Int, val finished: Boolean): ComposePreview()
   @Serializable class FilePreview(val fileName: String, val uri: URI): ComposePreview()
+  @Serializable data class AttachmentsPreview(val attachments: List<PendingAttachment>): ComposePreview()
 }
+
+@Serializable
+enum class PendingAttachmentKind { Image, AnimatedImage, Video, File }
+
+@Serializable
+data class PendingAttachment(
+  val id: String,
+  val uri: URI,
+  val fileName: String,
+  val kind: PendingAttachmentKind,
+  val previewImage: String? = null,
+  val durationSeconds: Int = 0,
+)
+
+internal fun reorderPendingAttachments(attachments: List<PendingAttachment>, from: Int, to: Int): List<PendingAttachment> {
+  if (from !in attachments.indices || to !in attachments.indices || from == to) return attachments
+  return attachments.toMutableList().apply { add(to, removeAt(from)) }
+}
+
+internal fun pendingAttachmentsAfterFailure(attachments: List<PendingAttachment>, failedIndex: Int): List<PendingAttachment> =
+  attachments.drop(failedIndex.coerceIn(0, attachments.size))
 
 @Serializable
 sealed class ComposeContextItem {
@@ -173,6 +196,7 @@ data class ComposeState(
         is ComposePreview.VoicePreview -> true
         is ComposePreview.ChatLinkPreview -> true
         is ComposePreview.FilePreview -> true
+        is ComposePreview.AttachmentsPreview -> preview.attachments.isNotEmpty()
         else -> !whitespaceOnly || forwarding || liveMessage != null || submittingValidReport
       }
       hasContent && !inProgress
@@ -187,6 +211,7 @@ data class ComposeState(
         is ComposePreview.MediaPreview -> false
         is ComposePreview.VoicePreview -> false
         is ComposePreview.FilePreview -> false
+        is ComposePreview.AttachmentsPreview -> false
         else -> useLinkPreviews
       }
   val linkPreview: LinkPreview?
@@ -202,6 +227,7 @@ data class ComposeState(
       return when (preview) {
         ComposePreview.NoPreview -> false
         is ComposePreview.CLinkPreview -> false
+        is ComposePreview.AttachmentsPreview -> false
         else -> true
       }
     }
@@ -214,6 +240,7 @@ data class ComposeState(
       is ComposePreview.MediaPreview -> preview.content.isNotEmpty()
       is ComposePreview.VoicePreview -> false
       is ComposePreview.FilePreview -> true
+      is ComposePreview.AttachmentsPreview -> preview.attachments.isNotEmpty()
     }
 
   val placeholder: String
@@ -285,13 +312,14 @@ expect fun AttachmentSelection(
 )
 
 fun MutableState<ComposeState>.onFilesAttached(uris: List<URI>) {
-  val groups = uris.groupBy { isImage(it) || isVideoUri(it) }
-  val media = groups[true] ?: emptyList()
-  val files = groups[false] ?: emptyList()
-  if (media.isNotEmpty()) {
-    CoroutineScope(Dispatchers.IO).launch { processPickedMedia(media, null) }
-  } else if (files.isNotEmpty()) {
-    processPickedFile(uris.first(), null)
+  CoroutineScope(Dispatchers.IO).launch {
+    uris.forEach { uri ->
+      if (isImage(uri) || isVideoUri(uri)) {
+        processPickedMedia(listOf(uri), null)
+      } else {
+        processPickedFile(uri, null)
+      }
+    }
   }
 }
 
@@ -308,7 +336,16 @@ fun MutableState<ComposeState>.processPickedFile(uri: URI?, text: String?) {
     if (fileSize != null && fileSize <= maxFileSize) {
       val fileName = getFileName(uri)
       if (fileName != null) {
-        value = value.copy(message = if (text != null) ComposeMessage(text) else value.message, preview = ComposePreview.FilePreview(fileName, uri))
+        if (appPlatform.isDesktop) {
+          appendPendingAttachments(
+            listOf(PendingAttachment(uri.toString(), uri, fileName, PendingAttachmentKind.File)),
+            text
+          )
+        } else {
+          value = value.copy(message = if (text != null) ComposeMessage(text) else value.message, preview = ComposePreview.FilePreview(fileName, uri))
+        }
+      } else {
+        showWrongUriAlert()
       }
     } else if (fileSize != null) {
       AlertManager.shared.showAlertMsg(
@@ -325,6 +362,7 @@ suspend fun MutableState<ComposeState>.processPickedMedia(uris: List<URI>, text:
   val maxFileSize = value.maxFileSize
   val content = ArrayList<UploadContent>()
   val imagesPreview = ArrayList<String>()
+  val pendingAttachments = ArrayList<PendingAttachment>()
   uris.forEach { uri ->
     var bitmap: ImageBitmap?
     val uploadContent: UploadContent? = when {
@@ -365,7 +403,23 @@ suspend fun MutableState<ComposeState>.processPickedMedia(uris: List<URI>, text:
     // Only pair them when a preview bitmap exists; otherwise skip the media entirely.
     if (bitmap != null && uploadContent != null) {
       content.add(uploadContent)
-      imagesPreview.add(resizeImageToStrSize(bitmap, maxDataSize = 14000))
+      val previewImage = resizeImageToStrSize(bitmap, maxDataSize = 14000)
+      imagesPreview.add(previewImage)
+      val kind = when (uploadContent) {
+        is UploadContent.SimpleImage -> PendingAttachmentKind.Image
+        is UploadContent.AnimatedImage -> PendingAttachmentKind.AnimatedImage
+        is UploadContent.Video -> PendingAttachmentKind.Video
+      }
+      pendingAttachments.add(
+        PendingAttachment(
+          id = uri.toString(),
+          uri = uri,
+          fileName = getFileName(uri) ?: "Attachment",
+          kind = kind,
+          previewImage = previewImage,
+          durationSeconds = (uploadContent as? UploadContent.Video)?.duration ?: 0,
+        )
+      )
     } else if (uploadContent is UploadContent.Video && !AlertManager.shared.hasAlertsShown()) {
       // A corrupted/undecodable video can yield a null preview frame without throwing, so
       // getBitmapFromVideo shows no alert. Skip it (other picked media still send) and tell
@@ -376,8 +430,20 @@ suspend fun MutableState<ComposeState>.processPickedMedia(uris: List<URI>, text:
     }
   }
   if (imagesPreview.isNotEmpty()) {
-    value = value.copy(message = if (text != null) ComposeMessage(text) else value.message, preview = ComposePreview.MediaPreview(imagesPreview, content))
+    if (appPlatform.isDesktop) {
+      appendPendingAttachments(pendingAttachments, text)
+    } else {
+      value = value.copy(message = if (text != null) ComposeMessage(text) else value.message, preview = ComposePreview.MediaPreview(imagesPreview, content))
+    }
   }
+}
+
+private fun MutableState<ComposeState>.appendPendingAttachments(attachments: List<PendingAttachment>, text: String?) {
+  val current = (value.preview as? ComposePreview.AttachmentsPreview)?.attachments.orEmpty()
+  value = value.copy(
+    message = if (text != null) ComposeMessage(text) else value.message,
+    preview = ComposePreview.AttachmentsPreview((current + attachments).distinctBy { it.id })
+  )
 }
 
 // Spec: spec/client/compose.md#ComposeView
@@ -821,6 +887,7 @@ fun ComposeView(
     } else {
       val msgs: ArrayList<MsgContent> = ArrayList()
       val files: ArrayList<CryptoFile> = ArrayList()
+      var failedAttachmentPreparationIndex: Int? = null
       val remoteHost = chatModel.currentRemoteHost.value
       when (val preview = cs.preview) {
         ComposePreview.NoPreview -> msgs.add(MsgContent.MCText(msgText))
@@ -899,13 +966,37 @@ fun ComposeView(
             msgs.add(MsgContent.MCFile(if (msgs.isEmpty()) msgText else ""))
           }
         }
+        is ComposePreview.AttachmentsPreview -> {
+          for ((index, attachment) in preview.attachments.withIndex()) {
+            val file = when (attachment.kind) {
+              PendingAttachmentKind.Image -> if (remoteHost == null) saveImage(attachment.uri) else desktopSaveImageInTmp(attachment.uri)
+              PendingAttachmentKind.AnimatedImage -> if (remoteHost == null) saveAnimImage(attachment.uri) else CryptoFile.desktopPlain(attachment.uri)
+              PendingAttachmentKind.Video -> if (remoteHost == null) saveFileFromUri(attachment.uri, cs.maxFileSize, hiddenFileNamePrefix = "video") else CryptoFile.desktopPlain(attachment.uri)
+              PendingAttachmentKind.File -> if (remoteHost == null) saveFileFromUri(attachment.uri, cs.maxFileSize) else CryptoFile.desktopPlain(attachment.uri)
+            }
+            if (file != null) {
+              files.add(file)
+              val caption = if (preview.attachments.lastIndex == index) msgText else ""
+              msgs.add(
+                when (attachment.kind) {
+                  PendingAttachmentKind.Image, PendingAttachmentKind.AnimatedImage -> MsgContent.MCImage(caption, attachment.previewImage ?: "")
+                  PendingAttachmentKind.Video -> MsgContent.MCVideo(caption, attachment.previewImage ?: "", attachment.durationSeconds)
+                  PendingAttachmentKind.File -> MsgContent.MCFile(caption)
+                }
+              )
+            } else {
+              failedAttachmentPreparationIndex = index
+              break
+            }
+          }
+        }
       }
       val quotedItemId: Long? = when (cs.contextItem) {
         is ComposeContextItem.QuotedItem -> cs.contextItem.chatItem.id
         else -> null
       }
-      sent = null
-      msgs.forEachIndexed { index, content ->
+      val sentItems = mutableListOf<ChatItem>()
+      for ((index, content) in msgs.withIndex()) {
         if (index > 0) delay(100)
         var file = files.getOrNull(index)
         if (remoteHost != null && file != null) {
@@ -921,13 +1012,29 @@ fun ComposeView(
           mentions = cs.memberMentions,
           sign = sign
         )
-        sent = if (sendResult != null) listOf(sendResult) else null
-        if (sent == null && index == msgs.lastIndex && cs.liveMessage == null) {
-          constructFailedMessage(cs)
-          // it's the last message in the series so if it fails, restore it in ComposeView for editing
-          lastMessageFailedToSend = constructFailedMessage(cs)
+        if (sendResult != null) {
+          sentItems.add(sendResult)
+        } else if (cs.liveMessage == null) {
+          lastMessageFailedToSend = if (cs.preview is ComposePreview.AttachmentsPreview) {
+            cs.copy(
+              inProgress = false,
+              preview = ComposePreview.AttachmentsPreview(pendingAttachmentsAfterFailure(cs.preview.attachments, index))
+            )
+          } else {
+            constructFailedMessage(cs)
+          }
+          break
         }
       }
+      if (lastMessageFailedToSend == null && cs.preview is ComposePreview.AttachmentsPreview) {
+        failedAttachmentPreparationIndex?.let { failedIndex ->
+          lastMessageFailedToSend = cs.copy(
+            inProgress = false,
+            preview = ComposePreview.AttachmentsPreview(pendingAttachmentsAfterFailure(cs.preview.attachments, failedIndex)),
+          )
+        }
+      }
+      sent = sentItems.ifEmpty { null }
     }
     val wasForwarding = cs.forwarding
     val forwardingFromChatId = (cs.contextItem as? ComposeContextItem.ForwardingItems)?.fromChatInfo?.id
@@ -1152,6 +1259,24 @@ fun ComposeView(
         preview.fileName,
         ::cancelFile,
         cancelEnabled = !composeState.value.editing && !composeState.value.inProgress
+      )
+      is ComposePreview.AttachmentsPreview -> ComposeAttachmentsView(
+        attachments = preview.attachments,
+        enabled = !composeState.value.inProgress,
+        remove = { id ->
+          val remaining = preview.attachments.filterNot { it.id == id }
+          composeState.value = composeState.value.copy(
+            preview = if (remaining.isEmpty()) ComposePreview.NoPreview else ComposePreview.AttachmentsPreview(remaining)
+          )
+        },
+        move = { from, to ->
+          if (from in preview.attachments.indices && to in preview.attachments.indices) {
+            composeState.value = composeState.value.copy(
+              preview = ComposePreview.AttachmentsPreview(reorderPendingAttachments(preview.attachments, from, to))
+            )
+          }
+        },
+        clear = { composeState.value = composeState.value.copy(preview = ComposePreview.NoPreview) }
       )
     }
   }
@@ -1594,7 +1719,22 @@ fun ComposeView(
 
   val relayListExpanded = remember { mutableStateOf(false) }
 
-  Column {
+  val escapeModifier = if (appPlatform.isDesktop) Modifier.onPreviewKeyEvent { event ->
+    if (event.type != KeyEventType.KeyDown || event.key != Key.Escape) return@onPreviewKeyEvent false
+    when {
+      showCommandsMenu.value -> showCommandsMenu.value = false
+      attachmentOption.value != null -> attachmentOption.value = null
+      composeState.value.preview is ComposePreview.AttachmentsPreview ->
+        composeState.value = composeState.value.copy(preview = ComposePreview.NoPreview)
+      composeState.value.contextItem is ComposeContextItem.EditingItem -> clearState()
+      composeState.value.contextItem != ComposeContextItem.NoContextItem ->
+        composeState.value = composeState.value.copy(contextItem = ComposeContextItem.NoContextItem)
+      else -> return@onPreviewKeyEvent false
+    }
+    true
+  } else Modifier
+
+  Column(escapeModifier) {
     val currentUser = chatModel.currentUser.value
     if (chat.chatInfo.nextConnectPrepared && !composeState.value.inProgress && currentUser != null) {
       ComposeContextProfilePickerView(
@@ -2115,4 +2255,3 @@ private data class SubscriberRelayState(
 
 private fun relayMemberRemoved(status: GroupMemberStatus?): Boolean =
   status in listOf(GroupMemberStatus.MemLeft, GroupMemberStatus.MemRemoved, GroupMemberStatus.MemGroupDeleted)
-

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/SendMsgView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/SendMsgView.kt
@@ -18,7 +18,9 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.*
+import chat.simplex.common.tokens
 import chat.simplex.common.model.*
+import chat.simplex.common.model.ChatController.appPrefs
 import chat.simplex.common.ui.theme.*
 import chat.simplex.common.views.chat.item.ItemAction
 import chat.simplex.common.views.helpers.*
@@ -65,7 +67,8 @@ fun SendMsgView(
   focusRequester: FocusRequester? = null,
   ) {
   val showCustomDisappearingMessageDialog = remember { mutableStateOf(false) }
-  val padding = if (appPlatform.isAndroid) PaddingValues(vertical = 8.dp) else PaddingValues(top = 3.dp, bottom = 4.dp)
+  val desktopDensity = remember { appPrefs.desktopChatDensity.state }.value.tokens()
+  val padding = if (appPlatform.isAndroid) PaddingValues(vertical = 8.dp) else PaddingValues(vertical = desktopDensity.composerVerticalPadding)
   Box(Modifier.padding(padding)) {
     val cs = composeState.value
     val showVoiceButton = !nextConnect && cs.message.text.isEmpty() && showVoiceRecordIcon && !composeState.value.editing &&
@@ -317,7 +320,7 @@ private fun BoxScope.DeleteTextButton(composeState: MutableState<ComposeState>) 
     { composeState.value = composeState.value.copy(message = ComposeMessage()) },
     Modifier.align(Alignment.TopEnd).size(36.dp)
   ) {
-    Icon(painterResource(MR.images.ic_close), null, Modifier.padding(7.dp).size(36.dp), tint = MaterialTheme.colors.secondary)
+    Icon(painterResource(MR.images.ic_close), "Clear message", Modifier.padding(7.dp).size(36.dp), tint = MaterialTheme.colors.secondary)
   }
 }
 

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/SendMsgView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/SendMsgView.kt
@@ -68,7 +68,11 @@ fun SendMsgView(
   ) {
   val showCustomDisappearingMessageDialog = remember { mutableStateOf(false) }
   val desktopDensity = remember { appPrefs.desktopChatDensity.state }.value.tokens()
-  val padding = if (appPlatform.isAndroid) PaddingValues(vertical = 8.dp) else PaddingValues(vertical = desktopDensity.composerVerticalPadding)
+  val padding = if (appPlatform.isAndroid) {
+    PaddingValues(vertical = 8.dp)
+  } else {
+    PaddingValues(horizontal = 12.dp, vertical = desktopDensity.composerVerticalPadding)
+  }
   val composerShape = RoundedCornerShape(18.dp)
   val composerModifier = Modifier.padding(padding).then(
     if (appPlatform.isDesktop) {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/SendMsgView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/SendMsgView.kt
@@ -69,7 +69,17 @@ fun SendMsgView(
   val showCustomDisappearingMessageDialog = remember { mutableStateOf(false) }
   val desktopDensity = remember { appPrefs.desktopChatDensity.state }.value.tokens()
   val padding = if (appPlatform.isAndroid) PaddingValues(vertical = 8.dp) else PaddingValues(vertical = desktopDensity.composerVerticalPadding)
-  Box(Modifier.padding(padding)) {
+  val composerShape = RoundedCornerShape(18.dp)
+  val composerModifier = Modifier.padding(padding).then(
+    if (appPlatform.isDesktop) {
+      Modifier
+        .clip(composerShape)
+        .background(MaterialTheme.colors.surface.copy(alpha = 0.96f))
+        .border(1.dp, MaterialTheme.colors.onSurface.copy(alpha = 0.12f), composerShape)
+        .padding(horizontal = 10.dp, vertical = 2.dp)
+    } else Modifier
+  )
+  Box(composerModifier) {
     val cs = composeState.value
     val showVoiceButton = !nextConnect && cs.message.text.isEmpty() && showVoiceRecordIcon && !composeState.value.editing &&
         !composeState.value.forwarding && cs.liveMessage == null && (cs.preview is ComposePreview.NoPreview || recState.value is RecordingState.Started) && (cs.contextItem !is ComposeContextItem.ReportedItem)

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupChatInfoView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupChatInfoView.kt
@@ -549,7 +549,7 @@ fun ModalData.GroupChatInfoLayout(
     }
   }
   Box {
-    val oneHandUI = remember { appPrefs.oneHandUI.state }
+    val oneHandUI = rememberOneHandUIState()
     val selectedItemsBarHeight = if (selectedItems.value != null) AppBarHeight * fontSizeSqrtMultiplier else 0.dp
     val navBarPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
     val imePadding = WindowInsets.ime.asPaddingValues().calculateBottomPadding()
@@ -861,7 +861,7 @@ fun ModalData.GroupChatInfoLayout(
 
 @Composable
 private fun BoxScope.SelectedItemsButtonsToolbar(chat: Chat, groupInfo: GroupInfo, selectedItems: MutableState<Set<Long>?>, activeMembers: State<List<GroupMember>>) {
-  val oneHandUI = remember { appPrefs.oneHandUI.state }
+  val oneHandUI = rememberOneHandUIState()
   Column(Modifier.align(Alignment.BottomCenter)) {
     AnimatedVisibility(selectedItems.value != null) {
       SelectedItemsMembersToolbar(

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupReportsView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupReportsView.kt
@@ -33,7 +33,7 @@ fun GroupReportsAppBar(
   close: () -> Unit,
   onSearchValueChanged: (String) -> Unit
 ) {
-  val oneHandUI = remember { appPrefs.oneHandUI.state }
+  val oneHandUI = rememberOneHandUIState()
   val showSearch = rememberSaveable { mutableStateOf(false) }
   val onBackClicked = {
     if (!showSearch.value) {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/ChatItemView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/ChatItemView.kt
@@ -247,6 +247,26 @@ fun ChatItemView(
       val buttonActivated = remember { derivedStateOf { buttonHovered.value || buttonPressed.value } }
 
       val fullyVisible = parentActivated.value || buttonActivated.value || hoveredItemId.value == cItem.id
+      if (appPlatform.isDesktop) {
+        IconButton(
+          onClick,
+          Modifier
+            .padding(start = if (alignStart) 0.dp else 7.dp, end = if (alignStart) 7.dp else 0.dp)
+            .alpha(if (fullyVisible) 1f else 0f)
+            .background(MaterialTheme.colors.surface.copy(alpha = 0.96f), CircleShape)
+            .border(1.dp, MaterialTheme.colors.onSurface.copy(alpha = 0.12f), CircleShape)
+            .size(28.dp),
+          interactionSource = buttonInteractionSource
+        ) {
+          Icon(
+            painterResource(icon),
+            null,
+            Modifier.size(iconSize.coerceAtMost(16.dp)),
+            tint = MaterialTheme.colors.secondary
+          )
+        }
+        return
+      }
       val mixAlpha = 0.6f
       val mixedBackgroundColor = if (fullyVisible) {
         if (MaterialTheme.colors.isLight) {
@@ -301,7 +321,10 @@ fun ChatItemView(
       }
     }
 
-    Column(horizontalAlignment = if (cItem.chatDir.sent) Alignment.End else Alignment.Start) {
+    Column(
+      modifier = if (appPlatform.isDesktop) Modifier.widthIn(max = 680.dp) else Modifier,
+      horizontalAlignment = if (cItem.chatDir.sent) Alignment.End else Alignment.Start
+    ) {
       val canReply = (cItem.content is CIContent.SndMsgContent || cItem.content is CIContent.RcvMsgContent) &&
           cInfo !is ChatInfo.Local && !cItem.isReport && !cItem.meta.isLive && cItem.meta.itemDeleted == null
       Box {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/ChatItemView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/ChatItemView.kt
@@ -1093,11 +1093,18 @@ fun showArchiveReportsAlert(ids: List<Long>, allowForAll: Boolean, archiveReport
 }
 
 @Composable
+private fun menuItemModifier(): Modifier = if (appPlatform.isDesktop) Modifier.heightIn(min = 32.dp) else Modifier
+
+private fun menuItemPadding(): PaddingValues = PaddingValues(horizontal = if (appPlatform.isDesktop) 12.dp else DEFAULT_PADDING * 1.5f)
+
+private fun menuItemIconModifier(): Modifier = Modifier.size(if (appPlatform.isDesktop) 17.dp else 24.dp)
+
+@Composable
 fun ItemAction(text: String, icon: Painter, color: Color = Color.Unspecified, onClick: () -> Unit) {
   val finalColor = if (color == Color.Unspecified) {
     MenuTextColor
   } else color
-  DropdownMenuItem(onClick, contentPadding = PaddingValues(horizontal = DEFAULT_PADDING * 1.5f)) {
+  DropdownMenuItem(onClick, modifier = menuItemModifier(), contentPadding = menuItemPadding()) {
     Row(verticalAlignment = Alignment.CenterVertically) {
       Text(
         text,
@@ -1107,7 +1114,7 @@ fun ItemAction(text: String, icon: Painter, color: Color = Color.Unspecified, on
           .padding(end = 15.dp),
         color = finalColor
       )
-      Icon(icon, text, tint = finalColor)
+      Icon(icon, text, menuItemIconModifier(), tint = finalColor)
     }
   }
 }
@@ -1117,7 +1124,7 @@ fun ItemAction(text: String, icon: ImageBitmap, textColor: Color = Color.Unspeci
   val finalColor = if (textColor == Color.Unspecified) {
     MenuTextColor
   } else textColor
-  DropdownMenuItem(onClick, contentPadding = PaddingValues(horizontal = DEFAULT_PADDING * 1.5f)) {
+  DropdownMenuItem(onClick, modifier = menuItemModifier(), contentPadding = menuItemPadding()) {
     Row(verticalAlignment = Alignment.CenterVertically) {
       Text(
         text,
@@ -1130,9 +1137,9 @@ fun ItemAction(text: String, icon: ImageBitmap, textColor: Color = Color.Unspeci
         overflow = TextOverflow.Ellipsis
       )
       if (iconColor == Color.Unspecified) {
-        Image(icon, text, Modifier.size(22.dp))
+        Image(icon, text, menuItemIconModifier())
       } else {
-        Icon(icon, text, Modifier.size(22.dp), tint = iconColor)
+        Icon(icon, text, menuItemIconModifier(), tint = iconColor)
       }
     }
   }
@@ -1149,7 +1156,7 @@ fun ItemAction(
   val finalColor = if (color == Color.Unspecified) {
     MenuTextColor
   } else color
-  DropdownMenuItem(onClick, contentPadding = PaddingValues(horizontal = DEFAULT_PADDING * 1.5f)) {
+  DropdownMenuItem(onClick, modifier = menuItemModifier(), contentPadding = menuItemPadding()) {
     Row(verticalAlignment = Alignment.CenterVertically) {
       Text(
         text,
@@ -1171,7 +1178,7 @@ fun ItemAction(text: String, icon: ImageVector, onClick: () -> Unit, color: Colo
   val finalColor = if (color == Color.Unspecified) {
     MenuTextColor
   } else color
-  DropdownMenuItem(onClick, contentPadding = PaddingValues(horizontal = DEFAULT_PADDING * 1.5f)) {
+  DropdownMenuItem(onClick, modifier = menuItemModifier(), contentPadding = menuItemPadding()) {
     Row(verticalAlignment = Alignment.CenterVertically) {
       Text(
         text,
@@ -1181,7 +1188,7 @@ fun ItemAction(text: String, icon: ImageVector, onClick: () -> Unit, color: Colo
           .padding(end = 15.dp),
         color = finalColor
       )
-      Icon(icon, text, tint = finalColor)
+      Icon(icon, text, menuItemIconModifier(), tint = finalColor)
     }
   }
 }
@@ -1191,7 +1198,7 @@ fun ItemAction(text: String, color: Color = Color.Unspecified, onClick: () -> Un
   val finalColor = if (color == Color.Unspecified) {
     MenuTextColor
   } else color
-  DropdownMenuItem(onClick, contentPadding = PaddingValues(horizontal = DEFAULT_PADDING * 1.5f)) {
+  DropdownMenuItem(onClick, modifier = menuItemModifier(), contentPadding = menuItemPadding()) {
     Text(
       text,
       modifier = Modifier

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
@@ -62,7 +62,7 @@ sealed class ActiveFilter {
   data object Unread: ActiveFilter()
 }
 
-private fun showNewChatSheet(oneHandUI: State<Boolean>) {
+internal fun showNewChatSheet(oneHandUI: State<Boolean>) {
   connectProgressManager.cancelConnectProgress()
   ModalManager.start.closeModals()
   ModalManager.end.closeModals()
@@ -89,6 +89,16 @@ private fun showNewChatSheet(oneHandUI: State<Boolean>) {
     }
   }
 }
+
+internal fun showChatSettings() {
+  ModalManager.start.closeModals()
+  ModalManager.end.closeModals()
+  ModalManager.start.showModalCloseable(cardScreen = true) { close ->
+    SettingsView(chatModel, AppLock::setPerformLA, close)
+  }
+}
+
+internal val chatListSearchFocusRequest = mutableIntStateOf(0)
 
 @Composable
 fun ToggleChatListCard() {
@@ -751,6 +761,12 @@ private fun ChatListSearchBar(listState: LazyListState, searchText: MutableState
     Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
       val focusRequester = remember { FocusRequester() }
       var focused by remember { mutableStateOf(false) }
+      val searchFocusRequest = chatListSearchFocusRequest.intValue
+      LaunchedEffect(searchFocusRequest) {
+        if (searchFocusRequest > 0 && appPlatform.isDesktop) {
+          focusRequester.requestFocus()
+        }
+      }
       Icon(
         painterResource(MR.images.ic_search),
         contentDescription = null,

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
@@ -760,7 +760,14 @@ fun connectIfOpenedViaUri(rhId: Long?, uri: String, chatModel: ChatModel) {
 
 @Composable
 private fun ChatListSearchBar(listState: LazyListState, searchText: MutableState<TextFieldValue>, searchShowingSimplexLink: MutableState<Boolean>, searchChatFilteredBySimplexLink: MutableState<Set<String>>, connectNameCandidate: MutableState<String?>) {
-  Box {
+  val desktopSearchShape = RoundedCornerShape(10.dp)
+  val searchContainerModifier = if (appPlatform.isDesktop) {
+    Modifier
+      .padding(horizontal = 10.dp, vertical = 7.dp)
+      .clip(desktopSearchShape)
+      .background(MaterialTheme.colors.onBackground.copy(alpha = 0.07f))
+  } else Modifier
+  Box(searchContainerModifier) {
     Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
       val focusRequester = remember { FocusRequester() }
       var focused by remember { mutableStateOf(false) }
@@ -773,7 +780,7 @@ private fun ChatListSearchBar(listState: LazyListState, searchText: MutableState
       Icon(
         painterResource(MR.images.ic_search),
         contentDescription = null,
-        Modifier.padding(start = DEFAULT_PADDING, end = DEFAULT_PADDING_HALF).size(22.dp * fontSizeSqrtMultiplier),
+        Modifier.padding(start = if (appPlatform.isDesktop) 10.dp else DEFAULT_PADDING, end = DEFAULT_PADDING_HALF).size(22.dp * fontSizeSqrtMultiplier),
         tint = MaterialTheme.colors.secondary
       )
       SearchTextField(
@@ -860,7 +867,9 @@ private fun ChatListSearchBar(listState: LazyListState, searchText: MutableState
       }
     }
     val oneHandUI = remember { appPrefs.oneHandUI.state }
-    Divider(Modifier.align(if (oneHandUI.value) Alignment.TopStart else Alignment.BottomStart))
+    if (!appPlatform.isDesktop) {
+      Divider(Modifier.align(if (oneHandUI.value) Alignment.TopStart else Alignment.BottomStart))
+    }
   }
 }
 

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
@@ -244,6 +244,9 @@ fun ChatListView(chatModel: ChatModel, userPickerState: MutableStateFlow<Animate
       }
     }
   }
+  if (appPlatform.isDesktop && chatModel.chatRunning.value == true) {
+    SetNotificationsModeAdditions()
+  }
   if (appPlatform.isAndroid) {
     val wasAllowedToSetupNotifications = rememberSaveable { mutableStateOf(false) }
     val canEnableNotifications = remember { derivedStateOf { chatModel.chatRunning.value == true } }
@@ -983,7 +986,7 @@ private fun BoxScope.ChatList(searchText: MutableState<TextFieldValue>, listStat
             }
             IntOffset(0, y)
           }
-          .background(MaterialTheme.colors.background)
+          .background(if (macOSWindowVibrancyAvailable) Color.Transparent else MaterialTheme.colors.background)
         ) {
         if (oneHandUI.value) {
           Column(Modifier.consumeWindowInsets(WindowInsets.navigationBars).consumeWindowInsets(PaddingValues(bottom = AppBarHeight))) {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
@@ -187,7 +187,7 @@ private fun ToolbarSegment(
 // Spec: spec/client/chat-list.md#ChatListView
 @Composable
 fun ChatListView(chatModel: ChatModel, userPickerState: MutableStateFlow<AnimatedViewState>, setPerformLA: (Boolean) -> Unit, stopped: Boolean) {
-  val oneHandUI = remember { appPrefs.oneHandUI.state }
+  val oneHandUI = remember { if (appPlatform.isDesktop) mutableStateOf(false) else appPrefs.oneHandUI.state }
 
   LaunchedEffect(Unit) {
     val showWhatsNew = shouldShowWhatsNew(chatModel)
@@ -230,7 +230,7 @@ fun ChatListView(chatModel: ChatModel, userPickerState: MutableStateFlow<Animate
           setPerformLA,
         )
       }
-      if (searchText.value.text.isEmpty() && !chatModel.desktopNoUserNoRemote && chatModel.chatRunning.value == true) {
+      if (appPlatform.isAndroid && searchText.value.text.isEmpty() && !chatModel.desktopNoUserNoRemote && chatModel.chatRunning.value == true) {
         NewChatSheetFloatingButton(oneHandUI, stopped)
       }
     }
@@ -496,7 +496,7 @@ private fun ChatListToolbar(userPickerState: MutableStateFlow<AnimatedViewState>
   val serversSummary: MutableState<PresentedServersSummary?> = remember { mutableStateOf(null) }
   val barButtons = arrayListOf<@Composable RowScope.() -> Unit>()
   val updatingProgress = remember { chatModel.updatingProgress }.value
-  val oneHandUI = remember { appPrefs.oneHandUI.state }
+  val oneHandUI = remember { if (appPlatform.isDesktop) mutableStateOf(false) else appPrefs.oneHandUI.state }
 
   if (updatingProgress != null) {
     barButtons.add {
@@ -540,7 +540,7 @@ private fun ChatListToolbar(userPickerState: MutableStateFlow<AnimatedViewState>
       }
     }
 
-    if (oneHandUI.value) {
+    if (appPlatform.isDesktop || oneHandUI.value) {
       val sp16 = with(LocalDensity.current) { 16.sp.toDp() }
 
       if (appPlatform.isDesktop && oneHandUI.value) {
@@ -562,18 +562,27 @@ private fun ChatListToolbar(userPickerState: MutableStateFlow<AnimatedViewState>
             showNewChatSheet(oneHandUI)
           },
         ) {
-          Box(
-            contentAlignment = Alignment.Center,
-            modifier = Modifier
-              .background(MaterialTheme.colors.primary, shape = CircleShape)
-              .size(33.dp * fontSizeSqrtMultiplier)
-          ) {
+          if (appPlatform.isDesktop) {
             Icon(
               painterResource(MR.images.ic_edit_filled),
               stringResource(MR.strings.add_contact_or_create_group),
-              Modifier.size(sp16),
-              tint = Color.White
+              Modifier.size(21.dp),
+              tint = MaterialTheme.colors.primary
             )
+          } else {
+            Box(
+              contentAlignment = Alignment.Center,
+              modifier = Modifier
+                .background(MaterialTheme.colors.primary, shape = CircleShape)
+                .size(33.dp * fontSizeSqrtMultiplier)
+            ) {
+              Icon(
+                painterResource(MR.images.ic_edit_filled),
+                stringResource(MR.strings.add_contact_or_create_group),
+                Modifier.size(sp16),
+                tint = Color.White
+              )
+            }
           }
         }
       }
@@ -634,6 +643,7 @@ private fun ChatListToolbar(userPickerState: MutableStateFlow<AnimatedViewState>
     onTitleClick = if (canScrollToZero.value) { { scrollToBottom(scope, listState) } } else null,
     onTop = !oneHandUI.value,
     onSearchValueChanged = {},
+    centeredTitle = !appPlatform.isDesktop,
     buttons = { barButtons.forEach { it() } }
   )
 }
@@ -681,7 +691,7 @@ fun UserProfileButton(image: String?, allRead: Boolean, onButtonClicked: () -> U
       Box {
         ProfileImage(
           image = image,
-          size = 37.dp * fontSizeSqrtMultiplier,
+          size = (if (appPlatform.isDesktop) 30.dp else 37.dp) * fontSizeSqrtMultiplier,
           color = MaterialTheme.colors.secondaryVariant.mixWith(MaterialTheme.colors.onBackground, 0.97f)
         )
         if (!allRead) {
@@ -935,7 +945,7 @@ private fun BoxScope.ChatList(searchText: MutableState<TextFieldValue>, listStat
   var previousIndex by remember { mutableStateOf(0) }
   var previousScrollOffset by remember { mutableStateOf(0) }
   val keyboardState by getKeyboardState()
-  val oneHandUI = remember { appPrefs.oneHandUI.state }
+  val oneHandUI = remember { if (appPlatform.isDesktop) mutableStateOf(false) else appPrefs.oneHandUI.state }
   val oneHandUICardShown = remember { appPrefs.oneHandUICardShown.state }
   val addressCreationCardShown = remember { appPrefs.addressCreationCardShown.state }
   val activeFilter = remember { chatModel.activeChatTagFilter }
@@ -1014,14 +1024,14 @@ private fun BoxScope.ChatList(searchText: MutableState<TextFieldValue>, listStat
           // top toolbar: search bar above, so on desktop the connect row goes above the tags
           TagsOrConnectByName(searchText, connectNameCandidate) { candidate ->
             ConnectByNameRow(candidate, searchText, connectNameCandidate, close = null)
-            Divider()
+            if (!appPlatform.isDesktop) Divider()
             TagsView(searchText)
           }
-          Divider()
+          if (!appPlatform.isDesktop) Divider()
         }
       }
     }
-    if (!oneHandUICardShown.value) {
+    if (!oneHandUICardShown.value && !appPlatform.isDesktop) {
       item {
         ToggleChatListCard()
       }
@@ -1032,7 +1042,7 @@ private fun BoxScope.ChatList(searchText: MutableState<TextFieldValue>, listStat
       } }
       ChatListNavLinkView(chat, nextChatSelected)
     }
-    if (!addressCreationCardShown.value) {
+    if (!addressCreationCardShown.value && !appPlatform.isDesktop) {
       item {
         ChatListFeatureCards()
       }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
@@ -209,7 +209,11 @@ fun ChatListView(chatModel: ChatModel, userPickerState: MutableStateFlow<Animate
   }
   val searchText = rememberSaveable(stateSaver = TextFieldValue.Saver) { mutableStateOf(TextFieldValue("")) }
   val listState = rememberLazyListState(lazyListState.first, lazyListState.second)
-  Box(Modifier.fillMaxSize()) {
+  Box(
+    Modifier
+      .fillMaxSize()
+      .then(if (appPlatform.isDesktop) Modifier.background(MaterialTheme.colors.background) else Modifier)
+  ) {
     if (oneHandUI.value) {
       ChatListWithLoadingScreen(searchText, listState)
       Column(Modifier.align(Alignment.BottomCenter)) {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
@@ -102,7 +102,7 @@ internal val chatListSearchFocusRequest = mutableIntStateOf(0)
 
 @Composable
 fun ToggleChatListCard() {
-  val oneHandUI = remember { appPrefs.oneHandUI.state }
+  val oneHandUI = rememberOneHandUIState()
   val onClose = {
     appPrefs.oneHandUICardShown.set(true)
     AlertManager.shared.showAlertMsg(
@@ -187,7 +187,7 @@ private fun ToolbarSegment(
 // Spec: spec/client/chat-list.md#ChatListView
 @Composable
 fun ChatListView(chatModel: ChatModel, userPickerState: MutableStateFlow<AnimatedViewState>, setPerformLA: (Boolean) -> Unit, stopped: Boolean) {
-  val oneHandUI = remember { if (appPlatform.isDesktop) mutableStateOf(false) else appPrefs.oneHandUI.state }
+  val oneHandUI = rememberOneHandUIState()
 
   LaunchedEffect(Unit) {
     val showWhatsNew = shouldShowWhatsNew(chatModel)
@@ -437,7 +437,7 @@ private fun BoxScope.ChatListWithLoadingScreen(searchText: MutableState<TextFiel
 
 @Composable
 private fun AndroidOnboardingCards() {
-  val oneHandUI = remember { appPrefs.oneHandUI.state }
+  val oneHandUI = rememberOneHandUIState()
   val topPad = topPaddingToContent(false)
   val bottomPad = if (oneHandUI.value) {
     WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + AppBarHeight * fontSizeSqrtMultiplier
@@ -496,7 +496,7 @@ private fun ChatListToolbar(userPickerState: MutableStateFlow<AnimatedViewState>
   val serversSummary: MutableState<PresentedServersSummary?> = remember { mutableStateOf(null) }
   val barButtons = arrayListOf<@Composable RowScope.() -> Unit>()
   val updatingProgress = remember { chatModel.updatingProgress }.value
-  val oneHandUI = remember { if (appPlatform.isDesktop) mutableStateOf(false) else appPrefs.oneHandUI.state }
+  val oneHandUI = rememberOneHandUIState()
 
   if (updatingProgress != null) {
     barButtons.add {
@@ -876,7 +876,7 @@ private fun ChatListSearchBar(listState: LazyListState, searchText: MutableState
           }
       }
     }
-    val oneHandUI = remember { appPrefs.oneHandUI.state }
+    val oneHandUI = rememberOneHandUIState()
     if (!appPlatform.isDesktop) {
       Divider(Modifier.align(if (oneHandUI.value) Alignment.TopStart else Alignment.BottomStart))
     }
@@ -945,7 +945,7 @@ private fun BoxScope.ChatList(searchText: MutableState<TextFieldValue>, listStat
   var previousIndex by remember { mutableStateOf(0) }
   var previousScrollOffset by remember { mutableStateOf(0) }
   val keyboardState by getKeyboardState()
-  val oneHandUI = remember { if (appPlatform.isDesktop) mutableStateOf(false) else appPrefs.oneHandUI.state }
+  val oneHandUI = rememberOneHandUIState()
   val oneHandUICardShown = remember { appPrefs.oneHandUICardShown.state }
   val addressCreationCardShown = remember { appPrefs.addressCreationCardShown.state }
   val activeFilter = remember { chatModel.activeChatTagFilter }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatPreviewView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatPreviewView.kt
@@ -29,6 +29,7 @@ import chat.simplex.common.views.helpers.*
 import chat.simplex.common.model.*
 import chat.simplex.common.model.ChatController.appPrefs
 import chat.simplex.common.model.GroupInfo
+import chat.simplex.common.tokens
 import chat.simplex.common.platform.*
 import chat.simplex.common.views.chat.*
 import chat.simplex.common.views.newchat.planAndConnect
@@ -51,6 +52,15 @@ fun ChatPreviewView(
   defaultClickAction: () -> Unit
 ) {
   val cInfo = chat.chatInfo
+  val desktop = appPlatform.isDesktop
+  val desktopDensity = remember { appPrefs.desktopChatDensity.state }.value.tokens()
+  val hasUnread = chat.chatStats.unreadCount > 0 || chat.chatStats.unreadChat
+  val titleWeight = if (desktop) {
+    if (hasUnread) FontWeight.SemiBold else FontWeight.Medium
+  } else {
+    FontWeight.Bold
+  }
+  val previewMaxLines = if (desktop) desktopDensity.sidebarPreviewMaxLines else 2
 
   @Composable
   fun inactiveIcon() {
@@ -88,7 +98,7 @@ fun ChatPreviewView(
       maxLines = 1,
       overflow = TextOverflow.Ellipsis,
       style = MaterialTheme.typography.h3,
-      fontWeight = FontWeight.Bold,
+      fontWeight = titleWeight,
       color = color
     )
   }
@@ -158,7 +168,7 @@ fun ChatPreviewView(
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             style = MaterialTheme.typography.h3,
-            fontWeight = FontWeight.Bold,
+            fontWeight = titleWeight,
             color = color
           )
         }
@@ -235,7 +245,7 @@ fun ChatPreviewView(
         formattedText,
         toggleSecrets = false,
         linkMode = linkMode,
-        maxLines = 2,
+        maxLines = previewMaxLines,
         overflow = TextOverflow.Ellipsis,
         style = TextStyle(
           fontFamily = Inter,
@@ -289,7 +299,7 @@ fun ChatPreviewView(
         toggleSecrets = false,
         linkMode = linkMode,
         senderBold = true,
-        maxLines = 2,
+        maxLines = previewMaxLines,
         overflow = TextOverflow.Ellipsis,
         style = TextStyle(
           fontFamily = Inter,
@@ -397,12 +407,12 @@ fun ChatPreviewView(
   Box(contentAlignment = Alignment.Center) {
     Row {
       Box(contentAlignment = Alignment.BottomEnd) {
-        ChatInfoImage(cInfo, size = 72.dp * fontSizeSqrtMultiplier)
-        Box(Modifier.padding(end = 6.sp.toDp(), bottom = 6.sp.toDp())) {
+        ChatInfoImage(cInfo, size = (if (desktop) desktopDensity.sidebarAvatarSize else 72.dp) * fontSizeSqrtMultiplier)
+        Box(Modifier.padding(end = if (desktop) 2.dp else 6.sp.toDp(), bottom = if (desktop) 2.dp else 6.sp.toDp())) {
           chatPreviewImageOverlayIcon()
         }
       }
-      Spacer(Modifier.width(8.dp))
+      Spacer(Modifier.width(if (desktop) 10.dp else 8.dp))
       Column(Modifier.weight(1f)) {
         Row {
           Box(Modifier.weight(1f)) {
@@ -412,8 +422,8 @@ fun ChatPreviewView(
           val ts = getTimestampText(chat.chatItems.lastOrNull()?.meta?.itemTs ?: chat.chatInfo.chatTs)
           ChatListTimestampView(ts)
         }
-        Row(Modifier.heightIn(min = 46.sp.toDp()).fillMaxWidth()) {
-          Row(Modifier.padding(top = 3.sp.toDp()).weight(1f)) {
+        Row(Modifier.heightIn(min = if (desktop) desktopDensity.sidebarPreviewMinHeight else 46.sp.toDp()).fillMaxWidth()) {
+          Row(Modifier.padding(top = if (desktop) 1.dp else 3.sp.toDp()).weight(1f)) {
             val activeVoicePreview: MutableState<(ActiveVoicePreview)?> = remember(chat.id) { mutableStateOf(null) }
             val chat = activeVoicePreview.value?.chat ?: chat
             val ci = activeVoicePreview.value?.ci ?: chat.chatItems.lastOrNull()
@@ -450,9 +460,9 @@ fun ChatPreviewView(
             }
           }
 
-          Spacer(Modifier.width(8.sp.toDp()))
+          Spacer(Modifier.width(if (desktop) 5.dp else 8.sp.toDp()))
 
-          Box(Modifier.widthIn(min = 34.sp.toDp()), contentAlignment = Alignment.TopEnd) {
+          Box(Modifier.widthIn(min = if (desktop) 24.dp else 34.sp.toDp()), contentAlignment = Alignment.TopEnd) {
             val n = chat.chatStats.unreadCount
             val ntfsMode = chat.chatInfo.chatSettings?.enableNtfs
             val showNtfsIcon = !chat.chatInfo.ntfsEnabled(false) && (chat.chatInfo is ChatInfo.Direct || chat.chatInfo is ChatInfo.Group)
@@ -515,7 +525,7 @@ fun ChatPreviewView(
               )
             }
             Box(
-              Modifier.offset(y = 28.sp.toDp()),
+              Modifier.offset(y = if (desktop) 18.dp else 28.sp.toDp()),
               contentAlignment = Alignment.Center
             ) {
               chatStatusImage()
@@ -529,7 +539,8 @@ fun ChatPreviewView(
 
 @Composable
 private fun SmallContentPreview(borderColor: Color = MaterialTheme.colors.onSurface.copy(alpha = 0.12f), content: @Composable BoxScope.() -> Unit) {
-  Box(Modifier.padding(top = 2.sp.toDp(), end = 8.sp.toDp()).size(36.sp.toDp()).border(0.5.dp, borderColor, RoundedCornerShape(22)).clip(RoundedCornerShape(22))) {
+  val size = if (appPlatform.isDesktop) 30.dp else 36.sp.toDp()
+  Box(Modifier.padding(top = if (appPlatform.isDesktop) 0.dp else 2.sp.toDp(), end = 8.sp.toDp()).size(size).border(0.5.dp, borderColor, CircleShape).clip(CircleShape)) {
     content()
   }
 }
@@ -617,7 +628,7 @@ fun unreadCountStr(n: Int): String {
     )
     Text(
       ts,
-      Modifier.padding(bottom = 5.sp.toDp()).offset(x = if (appPlatform.isDesktop) 1.5.sp.toDp() else 0.dp),
+      Modifier.padding(bottom = if (appPlatform.isDesktop) 3.dp else 5.sp.toDp()).offset(x = if (appPlatform.isDesktop) 1.5.sp.toDp() else 0.dp),
       color = MaterialTheme.colors.secondary,
       style = MaterialTheme.typography.body2.copy(fontSize = 13.sp),
     )

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ShareListView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ShareListView.kt
@@ -24,7 +24,7 @@ import chat.simplex.res.MR
 @Composable
 fun ShareListView(chatModel: ChatModel, stopped: Boolean) {
   var searchInList by rememberSaveable { mutableStateOf("") }
-  val oneHandUI = remember { appPrefs.oneHandUI.state }
+  val oneHandUI = rememberOneHandUIState()
   Box(Modifier.fillMaxSize().themedBackground(bgLayerSize = LocalAppBarHandler.current?.backgroundGraphicsLayerSize, bgLayer = LocalAppBarHandler.current?.backgroundGraphicsLayer)) {
     val sharedContent = chatModel.sharedContent.value
     var isMediaOrFileAttachment = false
@@ -194,7 +194,7 @@ private fun ShareList(
   isVoice: Boolean,
   hasSimplexLink: Boolean,
 ) {
-  val oneHandUI = remember { appPrefs.oneHandUI.state }
+  val oneHandUI = rememberOneHandUIState()
   val chats by remember(search) {
     derivedStateOf {
       val sorted = chatModel.chats.value.toList().filter { it.chatInfo.ready && it.chatInfo.sendMsgEnabled && !((chatModel.sharedContent.value is SharedContent.ChatLink || chatModel.sharedContent.value is SharedContent.MyAddress) && it.chatInfo is ChatInfo.Local) }.sortedByDescending { it.chatInfo is ChatInfo.Local }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/TagListView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/TagListView.kt
@@ -46,7 +46,7 @@ import kotlinx.coroutines.*
 @Composable
 fun TagListView(rhId: Long?, chat: Chat? = null, close: () -> Unit, reorderMode: Boolean) {
   val userTags = remember { chatModel.userTags }
-  val oneHandUI = remember { appPrefs.oneHandUI.state }
+  val oneHandUI = rememberOneHandUIState()
   val listState = LocalAppBarHandler.current?.listState ?: rememberLazyListState()
   val saving = remember { mutableStateOf(false) }
   val chatTagIds = derivedStateOf { chat?.chatInfo?.chatTags ?: emptyList() }
@@ -179,7 +179,7 @@ fun ModalData.TagListEditor(
   close: () -> Unit
 ) {
   val userTags = remember { chatModel.userTags }
-  val oneHandUI = remember { appPrefs.oneHandUI.state }
+  val oneHandUI = rememberOneHandUIState()
   val newEmoji = remember { stateGetOrPutNullable("chatTagEmoji") { emoji } }
   val newName = remember { stateGetOrPut("chatTagName") { name } }
   val saving = remember { mutableStateOf<Boolean?>(null) }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/UserPicker.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/UserPicker.kt
@@ -139,7 +139,7 @@ fun UserPicker(
     }
   }
 
-  val oneHandUI = remember { appPrefs.oneHandUI.state }
+  val oneHandUI = rememberOneHandUIState()
   val iconColor = MaterialTheme.colors.secondaryVariant
   val background = if (appPlatform.isAndroid) MaterialTheme.colors.background.mixWith(MaterialTheme.colors.onBackground, alpha = 1 - userPickerAlpha()) else MaterialTheme.colors.surface
   PlatformUserPicker(

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/database/DatabaseErrorView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/database/DatabaseErrorView.kt
@@ -4,7 +4,9 @@ import SectionBottomSpacer
 import SectionSpacer
 import SectionView
 import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.material.*
 import androidx.compose.runtime.*
@@ -78,8 +80,28 @@ fun DatabaseErrorView(
     Text(String.format(generalGetString(MR.strings.database_migrations), ms.joinToString(", ")))
   }
 
-  ColumnWithScrollBarNoAppBar(Modifier.fillMaxSize(), verticalArrangement = Arrangement.Center) {
-    val buttonEnabled = validKey(dbKey.value) && !progressIndicator.value
+  val buttonEnabled = validKey(dbKey.value) && !progressIndicator.value
+  val currentStatus = chatDbStatus.value
+  if (appPlatform.isDesktop && currentStatus is DBMigrationResult.ErrorNotADatabase) {
+    DesktopDatabaseUnlockView(
+      status = currentStatus,
+      dbKey = dbKey,
+      buttonEnabled = buttonEnabled,
+      wrongPassphrase = useKeychain && !storedDBKey.isNullOrEmpty(),
+      savePassphrase = useKeychain,
+      openChat = if (useKeychain) ::saveAndRunChatOnClick else { { callRunChat() } },
+      restoreAvailable = restoreDbFromBackup.value,
+      restore = {
+        AlertManager.shared.showAlertDialog(
+          title = generalGetString(MR.strings.restore_database_alert_title),
+          text = generalGetString(MR.strings.restore_database_alert_desc),
+          confirmText = generalGetString(MR.strings.restore_database_alert_confirm),
+          onConfirm = { restoreDb(restoreDbFromBackup, appPreferences) },
+          destructive = true,
+        )
+      }
+    )
+  } else ColumnWithScrollBarNoAppBar(Modifier.fillMaxSize(), verticalArrangement = Arrangement.Center) {
     when (val status = chatDbStatus.value) {
       is DBMigrationResult.ErrorNotADatabase ->
         if (useKeychain && !storedDBKey.isNullOrEmpty()) {
@@ -207,6 +229,89 @@ fun DatabaseErrorView(
         color = MaterialTheme.colors.secondary,
         strokeWidth = 2.5.dp
       )
+    }
+  }
+}
+
+@Composable
+private fun DesktopDatabaseUnlockView(
+  status: DBMigrationResult.ErrorNotADatabase,
+  dbKey: MutableState<String>,
+  buttonEnabled: Boolean,
+  wrongPassphrase: Boolean,
+  savePassphrase: Boolean,
+  openChat: () -> Unit,
+  restoreAvailable: Boolean,
+  restore: () -> Unit,
+) {
+  Box(
+    Modifier.fillMaxSize().padding(horizontal = 40.dp, vertical = 56.dp),
+    contentAlignment = Alignment.Center
+  ) {
+    Surface(
+      modifier = Modifier.widthIn(max = 480.dp).fillMaxWidth(),
+      shape = RoundedCornerShape(18.dp),
+      color = MaterialTheme.colors.surface,
+      contentColor = MaterialTheme.colors.onSurface,
+      border = BorderStroke(1.dp, MaterialTheme.colors.onSurface.copy(alpha = 0.10f)),
+      elevation = 8.dp,
+    ) {
+      Column(Modifier.padding(horizontal = 32.dp, vertical = 30.dp)) {
+        Surface(
+          modifier = Modifier.size(48.dp),
+          shape = RoundedCornerShape(14.dp),
+          color = MaterialTheme.colors.primary.copy(alpha = 0.12f),
+          elevation = 0.dp,
+        ) {
+          Box(contentAlignment = Alignment.Center) {
+            Icon(
+              painterResource(MR.images.ic_lock),
+              contentDescription = null,
+              modifier = Modifier.size(23.dp),
+              tint = MaterialTheme.colors.primary,
+            )
+          }
+        }
+        Spacer(Modifier.height(22.dp))
+        Text(
+          generalGetString(if (wrongPassphrase) MR.strings.wrong_passphrase else MR.strings.encrypted_database),
+          style = MaterialTheme.typography.h2,
+          fontWeight = FontWeight.SemiBold,
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+          generalGetString(if (wrongPassphrase) MR.strings.passphrase_is_different else MR.strings.database_passphrase_is_required),
+          style = MaterialTheme.typography.body1,
+          color = MaterialTheme.colors.secondary,
+        )
+        Spacer(Modifier.height(22.dp))
+        DatabaseKeyField(dbKey, buttonEnabled, openChat)
+        Spacer(Modifier.height(18.dp))
+        Button(
+          onClick = openChat,
+          modifier = Modifier.fillMaxWidth().heightIn(min = 42.dp),
+          enabled = buttonEnabled,
+          shape = RoundedCornerShape(10.dp),
+          elevation = ButtonDefaults.elevation(defaultElevation = 0.dp, pressedElevation = 0.dp),
+        ) {
+          Text(generalGetString(if (savePassphrase) MR.strings.save_passphrase_and_open_chat else MR.strings.open_chat))
+        }
+        if (wrongPassphrase) {
+          Spacer(Modifier.height(14.dp))
+          Text(
+            status.dbFile.substringAfterLast(File.separator),
+            style = MaterialTheme.typography.caption,
+            color = MaterialTheme.colors.secondary,
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+          )
+        }
+        if (restoreAvailable) {
+          Spacer(Modifier.height(10.dp))
+          TextButton(onClick = restore, modifier = Modifier.align(Alignment.CenterHorizontally)) {
+            Text(generalGetString(MR.strings.restore_database), color = MaterialTheme.colors.error)
+          }
+        }
+      }
     }
   }
 }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/AlertManager.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/AlertManager.kt
@@ -65,7 +65,7 @@ class AlertManager {
             buttons()
           }
         },
-        shape = RoundedCornerShape(corner = CornerSize(25.dp))
+        shape = alertDialogShape()
       )
     }
   }
@@ -97,7 +97,7 @@ class AlertManager {
             }
           }
         },
-        shape = RoundedCornerShape(corner = CornerSize(25.dp))
+        shape = alertDialogShape()
       )
     }
   }
@@ -118,7 +118,7 @@ class AlertManager {
             buttons()
           }
         },
-        shape = RoundedCornerShape(corner = CornerSize(25.dp))
+        shape = alertDialogShape()
       )
     }
   }
@@ -144,7 +144,7 @@ class AlertManager {
           val buttonRow: @Composable () -> Unit = {
             Row(
               Modifier.fillMaxWidth().padding(horizontal = DEFAULT_PADDING),
-              horizontalArrangement = Arrangement.SpaceBetween
+              horizontalArrangement = if (appPlatform.isDesktop) Arrangement.spacedBy(8.dp, Alignment.End) else Arrangement.SpaceBetween
             ) {
               val focusRequester = remember { FocusRequester() }
               LaunchedEffect(Unit) {
@@ -152,14 +152,14 @@ class AlertManager {
                 delay(200)
                 focusRequester.requestFocus()
               }
-              TextButton(onClick = {
+              AlertActionButton(dismissText, onClick = {
                 onDismiss?.invoke()
                 hideAlert()
-              }) { Text(dismissText) }
-              TextButton(onClick = {
+              })
+              AlertActionButton(confirmText, onClick = {
                 onConfirm?.invoke()
                 hideAlert()
-              }, Modifier.focusRequester(focusRequester)) { Text(confirmText, color = if (destructive) MaterialTheme.colors.error else Color.Unspecified) }
+              }, modifier = Modifier.focusRequester(focusRequester), emphasized = true, destructive = destructive)
             }
           }
           if (parseHtml) {
@@ -168,7 +168,7 @@ class AlertManager {
             AlertContent(text?.let { AnnotatedString(it) }, hostDevice, true, content = buttonRow)
           }
         },
-        shape = RoundedCornerShape(corner = CornerSize(25.dp))
+        shape = alertDialogShape()
       )
     }
   }
@@ -204,7 +204,7 @@ class AlertManager {
             }
           }
         },
-        shape = RoundedCornerShape(corner = CornerSize(25.dp))
+        shape = alertDialogShape()
       )
     }
   }
@@ -232,28 +232,28 @@ class AlertManager {
             val showShareButton = text != null && (shareText == true || (shareText == null && text.length > 500))
             Row(
               Modifier.fillMaxWidth().padding(horizontal = DEFAULT_PADDING),
-              horizontalArrangement = if (showShareButton) Arrangement.SpaceBetween else Arrangement.Center
+              horizontalArrangement = if (appPlatform.isDesktop) Arrangement.spacedBy(8.dp, Alignment.End) else if (showShareButton) Arrangement.SpaceBetween else Arrangement.Center
             ) {
               val clipboard = LocalClipboardManager.current
               if (showShareButton && text != null) {
-                TextButton(onClick = {
+                AlertActionButton(stringResource(MR.strings.share_verb), onClick = {
                   clipboard.shareText(text)
                   hideAlert()
-                }) { Text(stringResource(MR.strings.share_verb)) }
+                })
               }
-              TextButton(
+              AlertActionButton(
+                text = confirmText,
                 onClick = {
                   onConfirm?.invoke()
                   hideAlert()
                 },
-                Modifier.focusRequester(focusRequester)
-              ) {
-                Text(confirmText, color = Color.Unspecified)
-              }
+                modifier = Modifier.focusRequester(focusRequester),
+                emphasized = true
+              )
             }
           }
         },
-        shape = RoundedCornerShape(corner = CornerSize(25.dp))
+        shape = alertDialogShape()
       )
     }
   }
@@ -273,7 +273,7 @@ class AlertManager {
             }
           }
         },
-        shape = RoundedCornerShape(corner = CornerSize(25.dp))
+        shape = alertDialogShape()
       )
     }
   }
@@ -420,7 +420,7 @@ class AlertManager {
             }
           }
         },
-        shape = RoundedCornerShape(corner = CornerSize(25.dp))
+        shape = alertDialogShape()
       )
     }
   }
@@ -436,13 +436,60 @@ class AlertManager {
   }
 }
 
+@Composable
+private fun alertDialogShape() = RoundedCornerShape(corner = CornerSize(if (appPlatform.isDesktop) 12.dp else 25.dp))
+
+@Composable
+private fun AlertActionButton(
+  text: String,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  emphasized: Boolean = false,
+  destructive: Boolean = false,
+) {
+  if (appPlatform.isDesktop) {
+    val buttonModifier = modifier.height(32.dp).widthIn(min = 72.dp)
+    val shape = RoundedCornerShape(7.dp)
+    if (emphasized) {
+      Button(
+        onClick = onClick,
+        modifier = buttonModifier,
+        shape = shape,
+        elevation = null,
+        colors = if (destructive) {
+          ButtonDefaults.buttonColors(backgroundColor = MaterialTheme.colors.error, contentColor = MaterialTheme.colors.onPrimary)
+        } else {
+          ButtonDefaults.buttonColors()
+        },
+        contentPadding = PaddingValues(horizontal = 14.dp, vertical = 0.dp)
+      ) {
+        Text(text, fontSize = 13.sp, maxLines = 1)
+      }
+    } else {
+      OutlinedButton(
+        onClick = onClick,
+        modifier = buttonModifier,
+        shape = shape,
+        contentPadding = PaddingValues(horizontal = 14.dp, vertical = 0.dp)
+      ) {
+        Text(text, fontSize = 13.sp, maxLines = 1)
+      }
+    }
+  } else {
+    TextButton(onClick = onClick, modifier = modifier) {
+      Text(text, color = if (destructive) MaterialTheme.colors.error else Color.Unspecified)
+    }
+  }
+}
+
 private fun alertTitle(title: String): (@Composable () -> Unit)? {
   return {
     Text(
       title,
       Modifier.fillMaxWidth(),
       textAlign = TextAlign.Center,
-      fontSize = 20.sp
+      fontSize = if (appPlatform.isDesktop) 17.sp else 20.sp,
+      fontWeight = if (appPlatform.isDesktop) FontWeight.SemiBold else FontWeight.Normal
     )
   }
 }
@@ -476,9 +523,9 @@ private fun AlertContent(
               Text(
                 escapedHtmlToAnnotatedString(text, LocalDensity.current),
                 Modifier.fillMaxWidth(),
-                fontSize = 16.sp,
+                fontSize = if (appPlatform.isDesktop) 14.sp else 16.sp,
                 textAlign = textAlign,
-                color = MaterialTheme.colors.secondary
+                color = if (appPlatform.isDesktop) MaterialTheme.colors.onSurface.copy(alpha = 0.78f) else MaterialTheme.colors.secondary
               )
             }
             belowTextContent()
@@ -514,9 +561,9 @@ private fun AlertContent(text: AnnotatedString?, hostDevice: Pair<Long?, String>
               Text(
                 text,
                 Modifier.fillMaxWidth().padding(start = DEFAULT_PADDING, end = DEFAULT_PADDING, bottom = DEFAULT_PADDING * 1.5f),
-                fontSize = 16.sp,
+                fontSize = if (appPlatform.isDesktop) 14.sp else 16.sp,
                 textAlign = TextAlign.Center,
-                color = MaterialTheme.colors.secondary
+                color = if (appPlatform.isDesktop) MaterialTheme.colors.onSurface.copy(alpha = 0.78f) else MaterialTheme.colors.secondary
               )
             }
           }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/DefaultDropdownMenu.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/DefaultDropdownMenu.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import chat.simplex.common.platform.appPlatform
 
 @Composable
 fun DefaultDropdownMenu(
@@ -18,16 +20,25 @@ fun DefaultDropdownMenu(
   onClosed: State<() -> Unit> = remember { mutableStateOf({}) },
   dropdownMenuItems: (@Composable () -> Unit)?
 ) {
+  val desktop = appPlatform.isDesktop
   MaterialTheme(
-    shapes = MaterialTheme.shapes.copy(medium = RoundedCornerShape(corner = CornerSize(25.dp)))
+    shapes = MaterialTheme.shapes.copy(medium = RoundedCornerShape(corner = CornerSize(if (desktop) 10.dp else 25.dp))),
+    typography = if (desktop) {
+      MaterialTheme.typography.copy(
+        body1 = MaterialTheme.typography.body1.copy(fontSize = 13.sp),
+        body2 = MaterialTheme.typography.body2.copy(fontSize = 12.sp)
+      )
+    } else {
+      MaterialTheme.typography
+    }
   ) {
     DropdownMenu(
       expanded = showMenu.value,
       onDismissRequest = { showMenu.value = false },
       modifier = modifier
-        .widthIn(min = 250.dp)
+        .widthIn(min = if (desktop) 180.dp else 250.dp)
         .background(MaterialTheme.colors.surface)
-        .padding(vertical = 4.dp),
+        .padding(vertical = if (desktop) 2.dp else 4.dp),
       offset = offset,
     ) {
       dropdownMenuItems?.invoke()
@@ -46,12 +57,14 @@ fun ExposedDropdownMenuBoxScope.DefaultExposedDropdownMenu(
   modifier: Modifier = Modifier,
   dropdownMenuItems: (@Composable () -> Unit)?
 ) {
+  val desktop = appPlatform.isDesktop
   MaterialTheme(
-    shapes = MaterialTheme.shapes.copy(medium = RoundedCornerShape(corner = CornerSize(25.dp)))
+    shapes = MaterialTheme.shapes.copy(medium = RoundedCornerShape(corner = CornerSize(if (desktop) 10.dp else 25.dp))),
+    typography = if (desktop) MaterialTheme.typography.copy(body1 = MaterialTheme.typography.body1.copy(fontSize = 13.sp)) else MaterialTheme.typography
   ) {
     ExposedDropdownMenu(
       modifier = Modifier
-        .widthIn(min = 200.dp)
+        .widthIn(min = if (desktop) 180.dp else 200.dp)
         .background(MaterialTheme.colors.surface)
         .then(modifier),
       expanded = expanded.value,

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/DefaultTopAppBar.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/DefaultTopAppBar.kt
@@ -32,6 +32,7 @@ fun DefaultAppBar(
   searchPlaceholder: String? = null,
   onSearchValueChanged: (String) -> Unit = {},
   searchTrailingContent: @Composable (() -> Unit)? = null,
+  centeredTitle: Boolean? = null,
   buttons: @Composable RowScope.() -> Unit = {},
 ) {
   // If I just disable clickable modifier when don't need it, it will stop passing clicks to search. Replacing the whole modifier
@@ -102,7 +103,7 @@ fun DefaultAppBar(
         },
         navigationIcon = navigationButton,
         buttons = if (!showSearch) buttons else {{}},
-        centered = !showSearch && (title != null || !onTop),
+        centered = !showSearch && (centeredTitle ?: (title != null || !onTop)),
         onTop = onTop,
       )
       AppBarDivider(onTop, title != null || fixedTitleText != null, connection)

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/DefaultTopAppBar.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/DefaultTopAppBar.kt
@@ -15,10 +15,15 @@ import androidx.compose.ui.unit.*
 import dev.icerock.moko.resources.compose.painterResource
 import dev.icerock.moko.resources.compose.stringResource
 import chat.simplex.common.model.ChatController.appPrefs
+import chat.simplex.common.platform.appPlatform
 import chat.simplex.common.ui.theme.*
 import chat.simplex.common.views.chat.item.CenteredRowLayout
 import chat.simplex.res.MR
 import kotlin.math.absoluteValue
+
+@Composable
+fun rememberOneHandUIState(): State<Boolean> =
+  remember { if (appPlatform.isDesktop) mutableStateOf(false) else appPrefs.oneHandUI.state }
 
 @Composable
 fun DefaultAppBar(

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/ModalView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/helpers/ModalView.kt
@@ -40,7 +40,8 @@ fun ModalView(
   if (showClose && showAppBar) {
     BackHandler(enabled = enableClose, onBack = close)
   }
-  val oneHandUI = remember { derivedStateOf { if (appPrefs.onboardingStage.state.value == OnboardingStage.OnboardingComplete) appPrefs.oneHandUI.state.value else false } }
+  val oneHandUIPreference = rememberOneHandUIState()
+  val oneHandUI = remember { derivedStateOf { appPrefs.onboardingStage.state.value == OnboardingStage.OnboardingComplete && oneHandUIPreference.value } }
   Surface(Modifier.fillMaxSize(), contentColor = LocalContentColor.current) {
     val bgOverride = if (cardScreen) canvasColorForCurrentTheme() else if (background != Color.Unspecified) background else null
     CompositionLocalProvider(LocalCardScreen provides cardScreen) {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatSheet.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatSheet.kt
@@ -47,7 +47,7 @@ fun ModalData.NewChatSheet(rh: RemoteHostInfo?, close: () -> Unit) {
     }
   }
 
-  val oneHandUI = remember { appPrefs.oneHandUI.state }
+  val oneHandUI = rememberOneHandUIState()
 
   Box {
     val closeAll = { ModalManager.start.closeModals() }
@@ -116,7 +116,7 @@ private fun ModalData.NewChatSheetLayout(
   createChannel: () -> Unit,
   close: () -> Unit,
 ) {
-  val oneHandUI = remember { appPrefs.oneHandUI.state }
+  val oneHandUI = rememberOneHandUIState()
   val listState = remember { appBarHandler.listState }
   // This is workaround of an issue when position of a list is not restored (when going back to that screen) when a header exists.
   // Upon returning back, this code returns correct index and position if number of items is the same
@@ -667,7 +667,7 @@ private fun contactTypesSearchTargets(baseContactTypes: List<ContactType>, searc
 
 @Composable
 private fun ModalData.DeletedContactsView(rh: RemoteHostInfo?, closeDeletedChats: () -> Unit, close: () -> Unit) {
-  val oneHandUI = remember { appPrefs.oneHandUI.state }
+  val oneHandUI = rememberOneHandUIState()
   Box {
     val listState = remember { appBarHandler.listState }
     val searchText = rememberSaveable(stateSaver = TextFieldValue.Saver) { mutableStateOf(TextFieldValue("")) }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatView.kt
@@ -412,7 +412,7 @@ fun ActiveProfilePicker(
     ) {
       LazyColumnWithScrollBar(Modifier.padding(top = topPaddingToContent(false)), userScrollEnabled = !switchingProfile.value) {
         item {
-          val oneHandUI = remember { appPrefs.oneHandUI.state }
+          val oneHandUI = rememberOneHandUIState()
           if (oneHandUI.value) {
             Spacer(Modifier.padding(top = DEFAULT_PADDING + 5.dp))
           }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/onboarding/SimpleXInfo.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/onboarding/SimpleXInfo.kt
@@ -105,7 +105,7 @@ fun SimpleXInfoLayout(
   user: User?,
   onboardingStage: SharedPreference<OnboardingStage>?
 ) {
-  val topBar = onboardingStage == null && !appPrefs.oneHandUI.state.value
+  val topBar = onboardingStage == null && !rememberOneHandUIState().value
   val modifier = Modifier.fillMaxSize().systemBarsPadding().padding(horizontal = DEFAULT_ONBOARDING_HORIZONTAL_PADDING)
   Column(if (topBar) modifier.padding(top = AppBarHeight * fontSizeSqrtMultiplier) else modifier, horizontalAlignment = Alignment.CenterHorizontally) {
     Box(Modifier.padding(top = DEFAULT_PADDING * 2).widthIn(max = if (appPlatform.isAndroid) 185.dp else 160.dp), contentAlignment = Alignment.Center) {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/NotificationsSettingsView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/NotificationsSettingsView.kt
@@ -26,6 +26,13 @@ fun NotificationsSettingsView(
 ) {
   NotificationsSettingsLayout(
     notificationsMode = remember { chatModel.controller.appPrefs.notificationsMode.state },
+    notificationSound = remember { chatModel.controller.appPrefs.desktopNotificationSound.state },
+    notificationPreviewMode = remember { chatModel.notificationPreviewMode },
+    setNotificationSound = { chatModel.controller.appPrefs.desktopNotificationSound.set(it) },
+    setNotificationPreviewMode = {
+      chatModel.controller.appPrefs.notificationPreviewMode.set(it.name)
+      chatModel.notificationPreviewMode.value = it
+    },
     showNotificationsMode = {
       ModalManager.start.showModalCloseable(true) {
         NotificationsModeView(chatModel.controller.appPrefs.notificationsMode.state) { changeNotificationsMode(it, chatModel) }
@@ -37,6 +44,10 @@ fun NotificationsSettingsView(
 @Composable
 fun NotificationsSettingsLayout(
   notificationsMode: State<NotificationsMode>,
+  notificationSound: State<Boolean>,
+  notificationPreviewMode: State<NotificationPreviewMode>,
+  setNotificationSound: (Boolean) -> Unit,
+  setNotificationPreviewMode: (NotificationPreviewMode) -> Unit,
   showNotificationsMode: () -> Unit,
 ) {
   val modes = remember { notificationModes() }
@@ -53,6 +64,22 @@ fun NotificationsSettingsLayout(
             color = MaterialTheme.colors.secondary
           )
         }
+      } else if (appPlatform.isDesktop) {
+        val previewModes = remember { notificationPreviewModes() }
+        SettingsActionItemWithContent(null, "Notification previews", click = {
+          ModalManager.start.showModalCloseable(true) {
+            NotificationPreviewView(notificationPreviewMode, setNotificationPreviewMode)
+          }
+        }) {
+          Text(
+            previewModes.firstOrNull { it.value == notificationPreviewMode.value }?.title ?: "",
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            color = MaterialTheme.colors.secondary,
+          )
+        }
+        PreferenceToggle("Play notification sounds", checked = notificationSound.value, onChange = setNotificationSound)
+        SettingsActionItemWithContent(null, "Open Mac Notification Settings", click = { openSystemNotificationSettings() }) {}
       }
     }
     if (platform.androidIsXiaomiDevice() && (notificationsMode.value == NotificationsMode.PERIODIC || notificationsMode.value == NotificationsMode.SERVICE)) {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/networkAndServers/OperatorView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/usersettings/networkAndServers/OperatorView.kt
@@ -840,7 +840,7 @@ private fun ConditionsAppliedToOtherOperatorsText(userServers: List<UserOperator
 fun ConditionsLinkButton() {
   val showMenu = remember { mutableStateOf(false) }
   val uriHandler = LocalUriHandler.current
-  val oneHandUI = remember { appPrefs.oneHandUI.state }
+  val oneHandUI = rememberOneHandUIState()
   Column {
     DefaultDropdownMenu(showMenu, offset = if (oneHandUI.value) DpOffset(0.dp, -AppBarHeight * fontSizeSqrtMultiplier * 3) else DpOffset.Zero) {
       val commit = chatModel.conditions.value.currentConditions.conditionsCommit

--- a/apps/multiplatform/common/src/commonTest/kotlin/chat/simplex/app/DesktopInterfaceTest.kt
+++ b/apps/multiplatform/common/src/commonTest/kotlin/chat/simplex/app/DesktopInterfaceTest.kt
@@ -40,6 +40,14 @@ class DesktopInterfaceTest {
   }
 
   @Test
+  fun sidebarVibrancyRequiresMatchingAppAndSystemAppearance() {
+    assertFalse(useOpaqueDesktopSidebar(vibrancyAvailable = true, appDark = false, systemDark = false))
+    assertFalse(useOpaqueDesktopSidebar(vibrancyAvailable = true, appDark = true, systemDark = true))
+    assertTrue(useOpaqueDesktopSidebar(vibrancyAvailable = true, appDark = true, systemDark = false))
+    assertTrue(useOpaqueDesktopSidebar(vibrancyAvailable = false, appDark = false, systemDark = false))
+  }
+
+  @Test
   fun rangeSelectionKeepsOrderAndSkipsUnselectableItems() {
     val items = listOf(1L to true, 2L to false, 3L to true, 4L to true)
     assertEquals(linkedSetOf(1L, 3L, 4L), desktopRangeSelection(items, 4L, 1L))

--- a/apps/multiplatform/common/src/commonTest/kotlin/chat/simplex/app/DesktopInterfaceTest.kt
+++ b/apps/multiplatform/common/src/commonTest/kotlin/chat/simplex/app/DesktopInterfaceTest.kt
@@ -31,6 +31,10 @@ class DesktopInterfaceTest {
     val spacious = DesktopChatDensity.Spacious.tokens()
     assertTrue(compact.chatRowVerticalPadding < comfortable.chatRowVerticalPadding)
     assertTrue(comfortable.chatRowVerticalPadding < spacious.chatRowVerticalPadding)
+    assertTrue(compact.sidebarAvatarSize < comfortable.sidebarAvatarSize)
+    assertTrue(comfortable.sidebarAvatarSize < spacious.sidebarAvatarSize)
+    assertTrue(compact.sidebarPreviewMinHeight < spacious.sidebarPreviewMinHeight)
+    assertTrue(compact.sidebarPreviewMaxLines <= spacious.sidebarPreviewMaxLines)
     assertTrue(compact.messageVerticalPadding < comfortable.messageVerticalPadding)
     assertTrue(comfortable.composerVerticalPadding < spacious.composerVerticalPadding)
   }

--- a/apps/multiplatform/common/src/commonTest/kotlin/chat/simplex/app/DesktopInterfaceTest.kt
+++ b/apps/multiplatform/common/src/commonTest/kotlin/chat/simplex/app/DesktopInterfaceTest.kt
@@ -1,0 +1,83 @@
+package chat.simplex.app
+
+import chat.simplex.common.*
+import chat.simplex.common.platform.*
+import chat.simplex.common.model.NotificationPreviewMode
+import chat.simplex.common.views.chat.*
+import java.net.URI
+import kotlin.test.*
+
+class DesktopInterfaceTest {
+  @AfterTest
+  fun resetLayout() {
+    DesktopLayoutState.resetSidebarWidth()
+    DesktopLayoutState.sidebarCollapsed.value = false
+  }
+
+  @Test
+  fun sidebarWidthIsClampedAndResettable() {
+    DesktopLayoutState.setSidebarWidth(100f)
+    assertEquals(240f, DesktopLayoutState.sidebarWidth.floatValue)
+    DesktopLayoutState.setSidebarWidth(900f)
+    assertEquals(480f, DesktopLayoutState.sidebarWidth.floatValue)
+    DesktopLayoutState.resetSidebarWidth()
+    assertEquals(320f, DesktopLayoutState.sidebarWidth.floatValue)
+  }
+
+  @Test
+  fun desktopDensityOnlyExpandsSpacing() {
+    val compact = DesktopChatDensity.Compact.tokens()
+    val comfortable = DesktopChatDensity.Comfortable.tokens()
+    val spacious = DesktopChatDensity.Spacious.tokens()
+    assertTrue(compact.chatRowVerticalPadding < comfortable.chatRowVerticalPadding)
+    assertTrue(comfortable.chatRowVerticalPadding < spacious.chatRowVerticalPadding)
+    assertTrue(compact.messageVerticalPadding < comfortable.messageVerticalPadding)
+    assertTrue(comfortable.composerVerticalPadding < spacious.composerVerticalPadding)
+  }
+
+  @Test
+  fun rangeSelectionKeepsOrderAndSkipsUnselectableItems() {
+    val items = listOf(1L to true, 2L to false, 3L to true, 4L to true)
+    assertEquals(linkedSetOf(1L, 3L, 4L), desktopRangeSelection(items, 4L, 1L))
+    assertTrue(desktopRangeSelection(items, 99L, 1L).isEmpty())
+  }
+
+  @Test
+  fun attachmentReorderingAndPartialFailurePreserveOrder() {
+    val attachments = listOf("one", "two", "three").map {
+      PendingAttachment(it, URI("file:///$it"), it, PendingAttachmentKind.File)
+    }
+    val reordered = reorderPendingAttachments(attachments, 2, 0)
+    assertEquals(listOf("three", "one", "two"), reordered.map { it.id })
+    assertEquals(listOf("one", "two"), pendingAttachmentsAfterFailure(reordered, 1).map { it.id })
+  }
+
+  @Test
+  fun notificationSuppressionRequiresExactActiveRoute() {
+    val route = NotificationRoute(7, 9, "@42", 100)
+    assertTrue(suppressDesktopNotification(true, 7, 9, "@42", route))
+    assertFalse(suppressDesktopNotification(true, 7, 9, "@43", route))
+    assertFalse(suppressDesktopNotification(false, 7, 9, "@42", route))
+  }
+
+  @Test
+  fun notificationPrivacyModesExposeOnlyAllowedContent() {
+    val message = desktopNotificationPreview(NotificationPreviewMode.MESSAGE, "Alice", "hello", "Somebody", "New message")
+    assertEquals(DesktopNotificationPreview("Alice", "hello"), message)
+    val contact = desktopNotificationPreview(NotificationPreviewMode.CONTACT, "Alice", "hello", "Somebody", "New message")
+    assertEquals(DesktopNotificationPreview("Alice", "New message"), contact)
+    val hidden = desktopNotificationPreview(NotificationPreviewMode.HIDDEN, "Alice", "hello", "Somebody", "New message")
+    assertEquals(DesktopNotificationPreview("Somebody", "New message"), hidden)
+  }
+
+  @Test
+  fun notificationIdentifiersAreStableAndRouteQueueWaitsUntilReady() {
+    val route = NotificationRoute(7, null, "#team chat", 100)
+    assertEquals("simplex.7.-1._team_chat.100", desktopNotificationIdentifier(route, 999))
+    val queue = NotificationRouteQueue()
+    queue.enqueue(route)
+    assertTrue(queue.consumeIfReady(false).isEmpty())
+    assertEquals(listOf(route), queue.consumeIfReady(true))
+    assertTrue(queue.consumeIfReady(true).isEmpty())
+  }
+}

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/DesktopApp.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/DesktopApp.kt
@@ -18,7 +18,12 @@ import chat.simplex.common.platform.*
 import chat.simplex.common.ui.theme.DEFAULT_START_MODAL_WIDTH
 import chat.simplex.common.ui.theme.SimpleXTheme
 import chat.simplex.common.views.TerminalView
+import chat.simplex.common.views.chat.chatSearchRequest
+import chat.simplex.common.views.chatlist.chatListSearchFocusRequest
+import chat.simplex.common.views.chatlist.showChatSettings
+import chat.simplex.common.views.chatlist.showNewChatSheet
 import chat.simplex.common.views.helpers.*
+import chat.simplex.common.views.onboarding.OnboardingStage
 import chat.simplex.res.MR
 import dev.icerock.moko.resources.compose.painterResource
 import dev.icerock.moko.resources.compose.stringResource
@@ -123,12 +128,9 @@ private fun ApplicationScope.AppWindow(closedByError: MutableState<Boolean>) {
   // Reload all strings in all @Composable's after language change at runtime
   if (remember { ChatController.appPrefs.appLanguage.state }.value != "") {
     Window(state = windowState, visible = simplexWindowState.windowVisible.value, icon = painterResource(MR.images.ic_simplex), onCloseRequest = { handleCloseRequest(closedByError) }, onKeyEvent = {
-      if (it.key == Key.Escape && it.type == KeyEventType.KeyUp) {
-        simplexWindowState.backstack.lastOrNull()?.invoke() != null
-      } else {
-        false
-      }
+      handleDesktopKeyEvent(it)
     }, title = "SimpleX") {
+      SimplexMenuBar()
 //      val hardwareAccelerationDisabled = remember { listOf(GraphicsApi.SOFTWARE_FAST, GraphicsApi.SOFTWARE_COMPAT, GraphicsApi.UNKNOWN).contains(window.renderApi) }
       simplexWindowState.window = window
       AppScreen()
@@ -230,6 +232,102 @@ private fun ApplicationScope.AppWindow(closedByError: MutableState<Boolean>) {
     }
   }
 }
+
+@Composable
+private fun FrameWindowScope.SimplexMenuBar() {
+  MenuBar {
+    Menu("File") {
+      Item(
+        text = generalGetString(MR.strings.new_chat),
+        shortcut = desktopShortcut(Key.N),
+        onClick = ::openNewChatFromDesktop
+      )
+    }
+    Menu("Edit") {
+      Item(
+        text = generalGetString(MR.strings.search_verb),
+        shortcut = desktopShortcut(Key.F),
+        onClick = ::focusCurrentSearch
+      )
+      Item(
+        text = generalGetString(MR.strings.your_chats),
+        shortcut = desktopShortcut(Key.K),
+        onClick = ::focusChatSearch
+      )
+    }
+    Menu("SimpleX") {
+      Item(
+        text = generalGetString(MR.strings.settings_section_title_settings),
+        shortcut = desktopShortcut(Key.Comma),
+        onClick = ::showSettingsFromDesktop
+      )
+    }
+  }
+}
+
+private fun handleDesktopKeyEvent(event: KeyEvent): Boolean {
+  val commandPressed = if (desktopPlatform.isMac()) event.isMetaPressed else event.isCtrlPressed
+  if (event.type == KeyEventType.KeyDown && commandPressed) {
+    return when (event.key) {
+      Key.N -> {
+        openNewChatFromDesktop()
+        true
+      }
+      Key.F -> {
+        focusCurrentSearch()
+        true
+      }
+      Key.K -> {
+        focusChatSearch()
+        true
+      }
+      Key.Comma -> {
+        showSettingsFromDesktop()
+        true
+      }
+      else -> false
+    }
+  }
+  return event.key == Key.Escape && event.type == KeyEventType.KeyUp &&
+      simplexWindowState.backstack.lastOrNull()?.invoke() != null
+}
+
+private fun desktopShortcut(key: Key) = KeyShortcut(
+  key,
+  meta = desktopPlatform.isMac(),
+  ctrl = !desktopPlatform.isMac()
+)
+
+private fun openNewChatFromDesktop() {
+  if (desktopCommandsAvailable() && chatModel.chatRunning.value == true && !chatModel.desktopNoUserNoRemote()) {
+    showNewChatSheet(ChatController.appPrefs.oneHandUI.state)
+  }
+}
+
+private fun focusChatSearch() {
+  if (!desktopCommandsAvailable()) return
+  ModalManager.start.closeModals()
+  chatListSearchFocusRequest.intValue++
+}
+
+private fun focusCurrentSearch() {
+  if (!desktopCommandsAvailable()) return
+  if (chatModel.chatId.value == null) {
+    focusChatSearch()
+  } else {
+    chatSearchRequest.intValue++
+  }
+}
+
+private fun showSettingsFromDesktop() {
+  if (desktopCommandsAvailable()) {
+    showChatSettings()
+  }
+}
+
+private fun desktopCommandsAvailable() =
+  AppLock.userAuthorized.value == true &&
+      ChatController.appPrefs.onboardingStage.get() == OnboardingStage.OnboardingComplete
 
 // Not invoked for macOS Cmd+Q — that goes through AWT's default QuitHandler and
 // exits the process directly. Intentional: Cmd+Q is canonical "always quit" on macOS.

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/DesktopApp.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/DesktopApp.kt
@@ -95,7 +95,12 @@ fun showApp() {
 @Composable
 private fun ApplicationScope.AppWindow(closedByError: MutableState<Boolean>) {
   // Creates file if not exists; comes with proper defaults
-  val state = getStoredWindowState()
+  val state = remember { getStoredWindowState() }
+  remember(state) {
+    DesktopLayoutState.setSidebarWidth(state.sidebarWidth)
+    DesktopLayoutState.sidebarCollapsed.value = state.sidebarCollapsed
+    true
+  }
   val windowState: WindowState = rememberWindowState(
     placement = WindowPlacement.Floating,
     width = state.width.dp,
@@ -108,7 +113,9 @@ private fun ApplicationScope.AppWindow(closedByError: MutableState<Boolean>) {
     windowState.position.x.value,
     windowState.position.y.value,
     windowState.size.width.value,
-    windowState.size.height.value
+    windowState.size.height.value,
+    DesktopLayoutState.sidebarWidth.floatValue,
+    DesktopLayoutState.sidebarCollapsed.value,
   ) {
     storingJob.value.cancel()
     storingJob.value = launch {
@@ -118,7 +125,9 @@ private fun ApplicationScope.AppWindow(closedByError: MutableState<Boolean>) {
           x = windowState.position.x.value.toInt(),
           y = windowState.position.y.value.toInt(),
           width = windowState.size.width.value.toInt(),
-          height = windowState.size.height.value.toInt()
+          height = windowState.size.height.value.toInt(),
+          sidebarWidth = DesktopLayoutState.sidebarWidth.floatValue,
+          sidebarCollapsed = DesktopLayoutState.sidebarCollapsed.value,
         )
       )
     }
@@ -133,6 +142,10 @@ private fun ApplicationScope.AppWindow(closedByError: MutableState<Boolean>) {
       SimplexMenuBar()
 //      val hardwareAccelerationDisabled = remember { listOf(GraphicsApi.SOFTWARE_FAST, GraphicsApi.SOFTWARE_COMPAT, GraphicsApi.UNKNOWN).contains(window.renderApi) }
       simplexWindowState.window = window
+      DisposableEffect(window) {
+        if (desktopPlatform.isMac()) configureMacOSWindow(window)
+        onDispose {}
+      }
       AppScreen()
       if (simplexWindowState.openDialog.isAwaiting) {
         FileDialogChooser(
@@ -255,6 +268,15 @@ private fun FrameWindowScope.SimplexMenuBar() {
         onClick = ::focusChatSearch
       )
     }
+    if (desktopPlatform.isMac()) {
+      Menu("View") {
+        Item(
+          text = if (DesktopLayoutState.sidebarCollapsed.value) "Show Sidebar" else "Hide Sidebar",
+          shortcut = KeyShortcut(Key.S, meta = true, ctrl = true),
+          onClick = DesktopLayoutState::toggleSidebar
+        )
+      }
+    }
     Menu("SimpleX") {
       Item(
         text = generalGetString(MR.strings.settings_section_title_settings),
@@ -266,6 +288,13 @@ private fun FrameWindowScope.SimplexMenuBar() {
 }
 
 private fun handleDesktopKeyEvent(event: KeyEvent): Boolean {
+  if (
+    desktopPlatform.isMac() && event.type == KeyEventType.KeyDown &&
+    event.isMetaPressed && event.isCtrlPressed && event.key == Key.S
+  ) {
+    DesktopLayoutState.toggleSidebar()
+    return true
+  }
   val commandPressed = if (desktopPlatform.isMac()) event.isMetaPressed else event.isCtrlPressed
   if (event.type == KeyEventType.KeyDown && commandPressed) {
     return when (event.key) {

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/DesktopApp.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/DesktopApp.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.window.*
 import chat.simplex.common.model.*
 import chat.simplex.common.platform.*
 import chat.simplex.common.ui.theme.DEFAULT_START_MODAL_WIDTH
+import chat.simplex.common.ui.theme.CurrentColors
 import chat.simplex.common.ui.theme.SimpleXTheme
 import chat.simplex.common.views.TerminalView
 import chat.simplex.common.views.chat.chatSearchRequest
@@ -142,8 +143,9 @@ private fun ApplicationScope.AppWindow(closedByError: MutableState<Boolean>) {
       SimplexMenuBar()
 //      val hardwareAccelerationDisabled = remember { listOf(GraphicsApi.SOFTWARE_FAST, GraphicsApi.SOFTWARE_COMPAT, GraphicsApi.UNKNOWN).contains(window.renderApi) }
       simplexWindowState.window = window
-      DisposableEffect(window) {
-        if (desktopPlatform.isMac()) configureMacOSWindow(window)
+      val desktopChromeColor = CurrentColors.collectAsState().value.colors.background
+      DisposableEffect(window, desktopChromeColor) {
+        if (desktopPlatform.isMac()) configureMacOSWindow(window, desktopChromeColor)
         onDispose {}
       }
       AppScreen()

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/MacOSPlatform.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/MacOSPlatform.kt
@@ -1,0 +1,36 @@
+package chat.simplex.common
+
+import androidx.compose.ui.awt.ComposeWindow
+import chat.simplex.common.platform.Log
+import chat.simplex.common.platform.TAG
+import org.jetbrains.skiko.SkiaLayer
+import java.awt.Component
+import java.awt.Container
+import java.awt.SystemColor
+
+private external fun macOSConfigureWindow(windowHandle: Long): Boolean
+
+fun configureMacOSWindow(window: ComposeWindow) {
+  val skiaLayers = findSkiaLayers(window)
+  try {
+    skiaLayers.forEach { it.transparency = true }
+    if (!macOSConfigureWindow(window.windowHandle)) {
+      useOpaqueFallback(window, skiaLayers)
+      Log.w(TAG, "macOS window vibrancy was unavailable; using the opaque fallback")
+    }
+  } catch (e: Throwable) {
+    useOpaqueFallback(window, skiaLayers)
+    Log.w(TAG, "Unable to configure macOS window vibrancy: ${e.message}")
+  }
+}
+
+private fun useOpaqueFallback(window: ComposeWindow, skiaLayers: List<SkiaLayer>) {
+  skiaLayers.forEach { it.transparency = false }
+  window.background = SystemColor.window
+}
+
+private fun findSkiaLayers(component: Component): List<SkiaLayer> {
+  val own = if (component is SkiaLayer) listOf(component) else emptyList()
+  val children = if (component is Container) component.components.flatMap(::findSkiaLayers) else emptyList()
+  return own + children
+}

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/MacOSPlatform.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/MacOSPlatform.kt
@@ -3,6 +3,7 @@ package chat.simplex.common
 import androidx.compose.ui.awt.ComposeWindow
 import chat.simplex.common.platform.Log
 import chat.simplex.common.platform.TAG
+import chat.simplex.common.platform.setMacOSWindowVibrancyAvailable
 import org.jetbrains.skiko.SkiaLayer
 import java.awt.Component
 import java.awt.Container
@@ -14,11 +15,14 @@ fun configureMacOSWindow(window: ComposeWindow) {
   val skiaLayers = findSkiaLayers(window)
   try {
     skiaLayers.forEach { it.transparency = true }
-    if (!macOSConfigureWindow(window.windowHandle)) {
+    val configured = macOSConfigureWindow(window.windowHandle)
+    setMacOSWindowVibrancyAvailable(configured)
+    if (!configured) {
       useOpaqueFallback(window, skiaLayers)
       Log.w(TAG, "macOS window vibrancy was unavailable; using the opaque fallback")
     }
   } catch (e: Throwable) {
+    setMacOSWindowVibrancyAvailable(false)
     useOpaqueFallback(window, skiaLayers)
     Log.w(TAG, "Unable to configure macOS window vibrancy: ${e.message}")
   }

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/MacOSPlatform.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/MacOSPlatform.kt
@@ -1,6 +1,7 @@
 package chat.simplex.common
 
 import androidx.compose.ui.awt.ComposeWindow
+import androidx.compose.ui.graphics.Color
 import chat.simplex.common.platform.Log
 import chat.simplex.common.platform.TAG
 import chat.simplex.common.platform.setMacOSWindowVibrancyAvailable
@@ -9,13 +10,25 @@ import java.awt.Component
 import java.awt.Container
 import java.awt.SystemColor
 
-private external fun macOSConfigureWindow(windowHandle: Long): Boolean
+private external fun macOSConfigureWindow(
+  windowHandle: Long,
+  chromeRed: Float,
+  chromeGreen: Float,
+  chromeBlue: Float,
+  chromeAlpha: Float,
+): Boolean
 
-fun configureMacOSWindow(window: ComposeWindow) {
+fun configureMacOSWindow(window: ComposeWindow, chromeColor: Color) {
   val skiaLayers = findSkiaLayers(window)
   try {
     skiaLayers.forEach { it.transparency = true }
-    val configured = macOSConfigureWindow(window.windowHandle)
+    val configured = macOSConfigureWindow(
+      window.windowHandle,
+      chromeColor.red,
+      chromeColor.green,
+      chromeColor.blue,
+      chromeColor.alpha,
+    )
     setMacOSWindowVibrancyAvailable(configured)
     if (!configured) {
       useOpaqueFallback(window, skiaLayers)

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/StoreWindowState.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/StoreWindowState.kt
@@ -12,6 +12,8 @@ data class WindowPositionSize(
   val height: Int = 768,
   val x: Int = 0,
   val y: Int = 0,
+  val sidebarWidth: Float = DesktopLayoutState.DEFAULT_SIDEBAR_WIDTH,
+  val sidebarCollapsed: Boolean = false,
 )
 
 fun getStoredWindowState(): WindowPositionSize =

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/model/MacOSNotifications.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/model/MacOSNotifications.kt
@@ -1,0 +1,110 @@
+package chat.simplex.common.model
+
+import chat.simplex.common.showWindow
+import chat.simplex.common.platform.*
+import java.awt.EventQueue
+import kotlinx.coroutines.*
+
+private external fun macOSInitializeNotifications(): Boolean
+private external fun macOSRequestNotificationPermission()
+private external fun macOSNotificationPermissionState(): Int
+private external fun macOSDeliverNotification(
+  identifier: String,
+  userId: Long,
+  remoteHostId: Long,
+  chatId: String,
+  messageId: Long,
+  title: String,
+  body: String,
+  category: String,
+  playSound: Boolean,
+  imagePath: String?,
+): Boolean
+private external fun macOSRemoveNotificationsForChat(userId: Long, remoteHostId: Long, chatId: String)
+private external fun macOSRemoveNotificationsForUser(userId: Long)
+private external fun macOSRemoveAllNotifications()
+private external fun macOSOpenNotificationSettings()
+
+private const val NO_ID = -1L
+
+internal object MacOSNotifications {
+  private data class PendingResponse(val route: NotificationRoute, val action: String)
+  private val responseQueue = ArrayDeque<PendingResponse>()
+  private val routingScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+  private var routingJob: Job? = null
+
+  fun initialize(): Boolean = macOSInitializeNotifications()
+
+  fun requestPermission() = macOSRequestNotificationPermission()
+
+  fun permissionState(): NotificationPermissionState = when (macOSNotificationPermissionState()) {
+    0 -> NotificationPermissionState.NOT_DETERMINED
+    1 -> NotificationPermissionState.DENIED
+    2 -> NotificationPermissionState.AUTHORIZED
+    3 -> NotificationPermissionState.PROVISIONAL
+    else -> NotificationPermissionState.UNKNOWN
+  }
+
+  fun deliver(payload: DesktopNotificationPayload): Boolean = macOSDeliverNotification(
+    identifier = payload.identifier,
+    userId = payload.route.userId ?: NO_ID,
+    remoteHostId = payload.route.remoteHostId ?: NO_ID,
+    chatId = payload.route.chatId,
+    messageId = payload.route.messageId ?: NO_ID,
+    title = payload.title,
+    body = payload.preview,
+    category = payload.category.name,
+    playSound = payload.playSound,
+    imagePath = payload.imagePath,
+  )
+
+  fun removeChat(userId: Long?, remoteHostId: Long?, chatId: String) =
+    macOSRemoveNotificationsForChat(userId ?: NO_ID, remoteHostId ?: NO_ID, chatId)
+
+  fun removeUser(userId: Long) = macOSRemoveNotificationsForUser(userId)
+
+  fun removeAll() = macOSRemoveAllNotifications()
+
+  fun openSettings() = macOSOpenNotificationSettings()
+
+  fun enqueueResponse(route: NotificationRoute, action: String) {
+    synchronized(responseQueue) { responseQueue.addLast(PendingResponse(route, action)) }
+    if (routingJob?.isActive == true) return
+    routingJob = routingScope.launch {
+      while (true) {
+        while (chatModel.chatRunning.value != true) delay(100)
+        val response = synchronized(responseQueue) {
+          if (responseQueue.isEmpty()) {
+            routingJob = null
+            null
+          } else responseQueue.removeFirst()
+        } ?: break
+        dispatchResponse(response.route, response.action)
+        // Profile and remote-host transitions are asynchronous; route responses serially.
+        delay(500)
+      }
+    }
+  }
+
+  private fun dispatchResponse(route: NotificationRoute, action: String) {
+    EventQueue.invokeLater { showWindow() }
+    when (action) {
+      NotificationAction.ACCEPT_CONTACT_REQUEST.name ->
+        ntfManager.acceptContactRequestAction(route.userId, route.remoteHostId, incognito = false, route.chatId)
+      NotificationAction.ACCEPT_CALL.name -> ntfManager.acceptCallAction(route.userId, route.remoteHostId, route.chatId)
+      NotificationAction.REJECT_CALL.name -> chatModel.callInvitations[route.chatId]?.let { chatModel.callManager.endCall(invitation = it) }
+      else -> ntfManager.openChatAction(route.userId, route.remoteHostId, route.chatId, route.messageId)
+    }
+  }
+}
+
+@Suppress("unused") // Called by UNUserNotificationCenterDelegate through JNI.
+fun onMacOSNotificationResponse(userId: Long, remoteHostId: Long, chatId: String, messageId: Long, action: String) {
+  val route = NotificationRoute(
+    userId = userId.takeUnless { it == NO_ID },
+    remoteHostId = remoteHostId.takeUnless { it == NO_ID },
+    chatId = chatId,
+    messageId = messageId.takeUnless { it == NO_ID },
+  )
+  MacOSNotifications.enqueueResponse(route, action)
+}

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/model/NtfManager.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/model/NtfManager.desktop.kt
@@ -10,18 +10,26 @@ import chat.simplex.res.MR
 import com.sshtools.twoslices.*
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import java.awt.*
-import java.awt.TrayIcon.MessageType
 import java.io.File
 import javax.imageio.ImageIO
 
 object NtfManager {
   private val prevNtfs = arrayListOf<Pair<Pair<Long, ChatId>, Slice>>()
   private val prevNtfsMutex: Mutex = Mutex()
+  private val nativeRoutes = mutableSetOf<NotificationRoute>()
+
+  fun initializeNativeNotifications() {
+    if (desktopPlatform.isMac()) MacOSNotifications.initialize()
+  }
 
   fun notifyCallInvitation(invitation: RcvCallInvitation): Boolean {
-    if (simplexWindowState.windowFocused.value) return false
     val contactId = invitation.contact.id
+    if (
+      simplexWindowState.windowFocused.value &&
+      chatModel.currentUser.value?.userId == invitation.user.userId &&
+      chatModel.remoteHostId() == invitation.remoteHostId &&
+      chatModel.chatId.value == contactId
+    ) return false
     Log.d(TAG, "notifyCallInvitation $contactId")
     val image = invitation.contact.image
     val text = generalGetString(
@@ -45,19 +53,33 @@ object NtfManager {
       generalGetString(MR.strings.accept) to { ntfManager.acceptCallAction(invitation.contact.id) },
       generalGetString(MR.strings.reject) to { ChatModel.callManager.endCall(invitation = invitation) }
     )
-    displayNotificationViaLib(invitation.user.userId, contactId, title, text, prepareIconPath(largeIcon), actions) {
-      ntfManager.openChatAction(invitation.user.userId, contactId)
+    if (desktopPlatform.isMac()) {
+      val route = NotificationRoute(invitation.user.userId, invitation.remoteHostId, contactId)
+      deliverMacNotification(route, title, text, DesktopNotificationCategory.INCOMING_CALL, prepareIconPath(largeIcon))
+    } else {
+      displayNotificationViaLib(invitation.user.userId, contactId, title, text, prepareIconPath(largeIcon), actions) {
+        ntfManager.openChatAction(invitation.user.userId, contactId)
+      }
     }
     return true
   }
 
   fun showMessage(title: String, text: String) {
-    displayNotificationViaLib(-1, "MESSAGE", title, text, null, emptyList()) {}
+    if (desktopPlatform.isMac()) {
+      deliverMacNotification(NotificationRoute(null, null, "MESSAGE"), title, text, DesktopNotificationCategory.MESSAGE, null)
+    } else {
+      displayNotificationViaLib(-1, "MESSAGE", title, text, null, emptyList()) {}
+    }
   }
 
-  fun hasNotificationsForChat(chatId: ChatId) = false//prevNtfs.any { it.first == chatId }
+  fun hasNotificationsForChat(chatId: ChatId) = if (desktopPlatform.isMac()) synchronized(nativeRoutes) { nativeRoutes.any { it.chatId == chatId } } else false
 
   fun cancelNotificationsForChat(chatId: ChatId) {
+    if (desktopPlatform.isMac()) {
+      val matches = synchronized(nativeRoutes) { nativeRoutes.filter { it.chatId == chatId }.also(nativeRoutes::removeAll) }
+      matches.forEach { MacOSNotifications.removeChat(it.userId, it.remoteHostId, it.chatId) }
+      return
+    }
     withBGApi {
       prevNtfsMutex.withLock {
         val ntf = prevNtfs.firstOrNull { (userChat) -> userChat.second == chatId }
@@ -75,6 +97,11 @@ object NtfManager {
   }
 
   fun cancelNotificationsForUser(userId: Long) {
+    if (desktopPlatform.isMac()) {
+      synchronized(nativeRoutes) { nativeRoutes.removeAll { it.userId == userId } }
+      MacOSNotifications.removeUser(userId)
+      return
+    }
     withBGApi {
       prevNtfsMutex.withLock {
         prevNtfs.filter { (userChat) -> userChat.first == userId }.forEach {
@@ -85,6 +112,11 @@ object NtfManager {
   }
 
   fun cancelAllNotifications() {
+    if (desktopPlatform.isMac()) {
+      synchronized(nativeRoutes) { nativeRoutes.clear() }
+      MacOSNotifications.removeAll()
+      return
+    }
 //    prevNtfs.forEach { try { it.second.close() } catch (e: Exception) { Log.e(TAG, "Failed to close notification: ${e
     //    .stackTraceToString()}") } }
     withBGApi {
@@ -94,21 +126,53 @@ object NtfManager {
     }
   }
 
-  fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String?, actions: List<Pair<NotificationAction, () -> Unit>>) {
+  fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String?, actions: List<Pair<NotificationAction, () -> Unit>>, remoteHostId: Long?, messageId: Long?) {
     if (!user.showNotifications) return
     Log.d(TAG, "notifyMessageReceived $chatId")
-    val previewMode = appPreferences.notificationPreviewMode.get()
-    val title = if (previewMode == NotificationPreviewMode.HIDDEN.name) generalGetString(MR.strings.notification_preview_somebody) else displayName
-    val content = if (previewMode != NotificationPreviewMode.MESSAGE.name) generalGetString(MR.strings.notification_preview_new_message) else msgText
+    val previewMode = runCatching {
+      NotificationPreviewMode.valueOf(appPreferences.notificationPreviewMode.get() ?: NotificationPreviewMode.default.name)
+    }.getOrDefault(NotificationPreviewMode.default)
+    val preview = desktopNotificationPreview(
+      previewMode,
+      displayName,
+      msgText,
+      generalGetString(MR.strings.notification_preview_somebody),
+      generalGetString(MR.strings.notification_preview_new_message),
+    )
     val largeIcon = when {
       actions.isEmpty() -> null
-      image == null || previewMode == NotificationPreviewMode.HIDDEN.name -> MR.images.icon_foreground_common.image.toComposeImageBitmap()
+      image == null || previewMode == NotificationPreviewMode.HIDDEN -> MR.images.icon_foreground_common.image.toComposeImageBitmap()
       else -> base64ToBitmap(image)
     }
 
-    displayNotificationViaLib(user.userId, chatId, title, content, prepareIconPath(largeIcon), actions.map { it.first.name to it.second }) {
-      ntfManager.openChatAction(user.userId, chatId)
+    if (desktopPlatform.isMac()) {
+      val category = if (actions.any { it.first == NotificationAction.ACCEPT_CONTACT_REQUEST }) DesktopNotificationCategory.CONTACT_REQUEST else DesktopNotificationCategory.MESSAGE
+      deliverMacNotification(NotificationRoute(user.userId, remoteHostId, chatId, messageId), preview.title, preview.body, category, prepareIconPath(largeIcon))
+    } else {
+      displayNotificationViaLib(user.userId, chatId, preview.title, preview.body, prepareIconPath(largeIcon), actions.map { it.first.name to it.second }) {
+        ntfManager.openChatAction(user.userId, chatId)
+      }
     }
+  }
+
+  private fun deliverMacNotification(
+    route: NotificationRoute,
+    title: String,
+    content: String,
+    category: DesktopNotificationCategory,
+    imagePath: String?,
+  ) {
+    val identifier = desktopNotificationIdentifier(route, System.currentTimeMillis())
+    val payload = DesktopNotificationPayload(
+      identifier = identifier,
+      route = route,
+      title = title,
+      preview = content,
+      category = category,
+      playSound = appPreferences.desktopNotificationSound.get(),
+      imagePath = imagePath,
+    )
+    if (MacOSNotifications.deliver(payload)) synchronized(nativeRoutes) { nativeRoutes.add(route) }
   }
 
   private fun displayNotificationViaLib(
@@ -159,35 +223,4 @@ object NtfManager {
     }
   } else null
 
-  private fun displayNotification(title: String, text: String, icon: ImageBitmap?) = when (desktopPlatform) {
-    DesktopPlatform.LINUX_X86_64, DesktopPlatform.LINUX_AARCH64 -> linuxDisplayNotification(title, text, prepareIconPath(icon))
-    DesktopPlatform.WINDOWS_X86_64 -> windowsDisplayNotification(title, text, icon)
-    DesktopPlatform.MAC_X86_64, DesktopPlatform.MAC_AARCH64 -> macDisplayNotification(title, text, prepareIconPath(icon))
-  }
-
-  private fun linuxDisplayNotification(title: String, text: String, iconPath: String?) {
-    if (iconPath != null) {
-      Runtime.getRuntime().exec(arrayOf("notify-send", "-i", iconPath, title, text))
-    } else {
-      Toast.toast(ToastType.INFO, title, text)
-      Runtime.getRuntime().exec(arrayOf("notify-send", title, text))
-    }
-  }
-
-  private fun windowsDisplayNotification(title: String, text: String, icon: ImageBitmap?) {
-    if (SystemTray.isSupported()) {
-      val tray = SystemTray.getSystemTray()
-      tray.remove(tray.trayIcons.firstOrNull { it.toolTip == "SimpleX" })
-      val trayIcon = TrayIcon(icon?.toAwtImage(), "SimpleX")
-      trayIcon.isImageAutoSize = true
-      tray.add(trayIcon)
-      trayIcon.displayMessage(title, text, MessageType.INFO)
-    } else {
-      Log.e(TAG, "System tray not supported!")
-    }
-  }
-
-  private fun macDisplayNotification(title: String, text: String, iconPath: String?) {
-    Runtime.getRuntime().exec(arrayOf("osascript", "-e", """display notification "${text.replace("\"", "\\\"")}" with title "${title.replace("\"", "\\\"")}""""))
-  }
 }

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/AppCommon.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/AppCommon.desktop.kt
@@ -24,12 +24,13 @@ fun initApp() {
     override fun hasNotificationsForChat(chatId: String): Boolean = chat.simplex.common.model.NtfManager.hasNotificationsForChat(chatId)
     override fun cancelNotificationsForChat(chatId: String) = chat.simplex.common.model.NtfManager.cancelNotificationsForChat(chatId)
     override fun cancelNotificationsForUser(userId: Long) = chat.simplex.common.model.NtfManager.cancelNotificationsForUser(userId)
-    override fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String?, actions: List<Pair<NotificationAction, () -> Unit>>) = chat.simplex.common.model.NtfManager.displayNotification(user, chatId, displayName, msgText, image, actions)
+    override fun displayNotification(user: UserLike, chatId: String, displayName: String, msgText: String, image: String?, actions: List<Pair<NotificationAction, () -> Unit>>, remoteHostId: Long?, messageId: Long?) = chat.simplex.common.model.NtfManager.displayNotification(user, chatId, displayName, msgText, image, actions, remoteHostId, messageId)
     override fun androidCreateNtfChannelsMaybeShowAlert() {}
     override fun cancelCallNotification() {}
     override fun cancelAllNotifications() = chat.simplex.common.model.NtfManager.cancelAllNotifications()
     override fun showMessage(title: String, text: String) = chat.simplex.common.model.NtfManager.showMessage(title, text)
   }
+  chat.simplex.common.model.NtfManager.initializeNativeNotifications()
   applyAppLocale()
   deleteOldChatArchive()
   if (DatabaseUtils.ksSelfDestructPassword.get() == null) {

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/Modifier.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/Modifier.desktop.kt
@@ -3,6 +3,7 @@ package chat.simplex.common.platform
 import androidx.compose.foundation.contextMenuOpenDetector
 import androidx.compose.foundation.draganddrop.dragAndDropTarget
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.*
 import androidx.compose.ui.draganddrop.*
@@ -92,7 +93,14 @@ actual fun Modifier.desktopPointerHoverIconHand(): Modifier = Modifier.pointerHo
 actual fun Modifier.desktopPointerHoverIconResize(): Modifier =
   this then Modifier.pointerHoverIcon(PointerIcon(Cursor.getPredefinedCursor(Cursor.E_RESIZE_CURSOR)))
 
-actual val macOSWindowVibrancyAvailable: Boolean = desktopPlatform.isMac()
+private val macOSWindowVibrancyState = mutableStateOf(false)
+
+actual val macOSWindowVibrancyAvailable: Boolean
+  get() = macOSWindowVibrancyState.value
+
+internal fun setMacOSWindowVibrancyAvailable(available: Boolean) {
+  macOSWindowVibrancyState.value = desktopPlatform.isMac() && available
+}
 
 actual fun openSystemNotificationSettings() {
   if (desktopPlatform.isMac()) chat.simplex.common.model.MacOSNotifications.openSettings()

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/Modifier.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/Modifier.desktop.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.draganddrop.*
 import androidx.compose.ui.draganddrop.DragData
 import androidx.compose.ui.input.pointer.*
 import java.awt.Image
+import java.awt.Cursor
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.Transferable
 import java.awt.image.BufferedImage
@@ -20,11 +21,18 @@ actual fun Modifier.desktopOnExternalDrag(
   enabled: Boolean,
   onFiles: (List<File>) -> Unit,
   onImage: (File) -> Unit,
-  onText: (String) -> Unit
+  onText: (String) -> Unit,
+  onDragging: (Boolean) -> Unit,
 ): Modifier {
-  val callback = remember {
+  val callback = remember(enabled, onFiles, onImage, onText, onDragging) {
     object : DragAndDropTarget {
+      override fun onStarted(event: DragAndDropEvent) { onDragging(enabled) }
+      override fun onEntered(event: DragAndDropEvent) { onDragging(enabled) }
+      override fun onExited(event: DragAndDropEvent) { onDragging(false) }
+      override fun onEnded(event: DragAndDropEvent) { onDragging(false) }
+
       override fun onDrop(event: DragAndDropEvent): Boolean {
+        if (!enabled) return false
         when (val data = event.dragData()) {
           // data.readFiles() returns filePath in URI format (where spaces replaces with %20). But it's an error-prone idea to work later
           // with such format when everywhere we use absolutePath in File() format
@@ -54,7 +62,7 @@ actual fun Modifier.desktopOnExternalDrag(
       }
     }
   }
-  return dragAndDropTarget(shouldStartDragAndDrop = { true }, target = callback)
+  return dragAndDropTarget(shouldStartDragAndDrop = { enabled }, target = callback)
 }
 
 // Copied from AwtDragData and modified
@@ -80,6 +88,27 @@ private class DragDataImageImpl(private val transferable: Transferable) {
 actual fun Modifier.onRightClick(action: () -> Unit): Modifier = contextMenuOpenDetector { action() }
 
 actual fun Modifier.desktopPointerHoverIconHand(): Modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)
+
+actual fun Modifier.desktopPointerHoverIconResize(): Modifier =
+  this then Modifier.pointerHoverIcon(PointerIcon(Cursor.getPredefinedCursor(Cursor.E_RESIZE_CURSOR)))
+
+actual val macOSWindowVibrancyAvailable: Boolean = desktopPlatform.isMac()
+
+actual fun openSystemNotificationSettings() {
+  if (desktopPlatform.isMac()) chat.simplex.common.model.MacOSNotifications.openSettings()
+}
+
+@Composable
+actual fun Modifier.desktopMessageSelection(enabled: Boolean, onToggle: () -> Unit, onRange: () -> Unit): Modifier =
+  if (!enabled) this else this.then(
+    Modifier.onPointerEvent(PointerEventType.Press, PointerEventPass.Initial) { event ->
+      val modifiers = event.keyboardModifiers
+      if (modifiers.isShiftPressed || modifiers.isMetaPressed) {
+        event.changes.forEach { it.consume() }
+        if (modifiers.isShiftPressed) onRange() else onToggle()
+      }
+    }
+  )
 
 actual fun Modifier.desktopOnHovered(action: (Boolean) -> Unit): Modifier =
   this then Modifier

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/PlatformTextField.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/PlatformTextField.desktop.kt
@@ -110,7 +110,7 @@ actual fun PlatformTextField(
       }
     },
     textStyle = textStyle.value,
-    maxLines = 16,
+    maxLines = 8,
     keyboardOptions = KeyboardOptions.Default.copy(
       capitalization = KeyboardCapitalization.Sentences,
       autoCorrectEnabled = true

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/PlatformTextField.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/platform/PlatformTextField.desktop.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.*
-import androidx.compose.material.TextFieldDefaults.textFieldWithLabelPadding
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -85,10 +84,10 @@ actual fun PlatformTextField(
   val isLtrGlobally = LocalLayoutDirection.current == LayoutDirection.Ltr
   // Different padding here is for a text that is considered RTL with non-RTL locale set globally.
   // In this case padding from right side should be bigger
-  val startEndPadding = if (cs.message.text.isEmpty() && showVoiceButton && isRtlByCharacters && isLtrGlobally) 95.dp else 50.dp
+  val startEndPadding = if (cs.message.text.isEmpty() && showVoiceButton && isRtlByCharacters && isLtrGlobally) 88.dp else 46.dp
   val startPadding = 0.dp
   val endPadding = startEndPadding
-  val padding = PaddingValues(startPadding, 12.dp, endPadding, 0.dp)
+  val padding = PaddingValues(startPadding, 8.dp, endPadding, 8.dp)
   var textFieldValueState by remember { mutableStateOf(TextFieldValue(text = cs.message.text, selection = cs.message.selection)) }
   val textFieldValue = textFieldValueState.copy(text = cs.message.text, selection = cs.message.selection)
   val clipboard = LocalClipboardManager.current
@@ -117,7 +116,6 @@ actual fun PlatformTextField(
     ),
     modifier = Modifier
       .padding(start = startPadding, end = endPadding)
-      .offset(y = (-5).dp)
       .fillMaxWidth()
       .focusRequester(focusReq)
       .onPreviewKeyEvent {
@@ -180,7 +178,7 @@ actual fun PlatformTextField(
           }
         else false
       },
-    cursorBrush = SolidColor(MaterialTheme.colors.secondary),
+    cursorBrush = SolidColor(MaterialTheme.colors.primary),
     decorationBox = { innerTextField ->
         CompositionLocalProvider(
           LocalLayoutDirection provides if (isRtlByCharacters) LayoutDirection.Rtl else LocalLayoutDirection.current
@@ -194,7 +192,7 @@ actual fun PlatformTextField(
             isError = false,
             trailingIcon = null,
             interactionSource = remember { MutableInteractionSource() },
-            contentPadding = textFieldWithLabelPadding(start = 0.dp, end = 0.dp),
+            contentPadding = PaddingValues(vertical = 8.dp),
             visualTransformation = VisualTransformation.None,
             colors = TextFieldDefaults.textFieldColors(backgroundColor = Color.Unspecified)
           )

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/views/chat/ComposeView.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/views/chat/ComposeView.desktop.kt
@@ -18,8 +18,8 @@ actual fun AttachmentSelection(
   val videoLauncher = rememberFileChooserMultipleLauncher {
     processPickedMedia(it, null)
   }
-  val filesLauncher = rememberFileChooserLauncher(true) {
-    if (it != null) processPickedFile(it, null)
+  val filesLauncher = rememberFileChooserMultipleLauncher {
+    it.forEach { uri -> processPickedFile(uri, null) }
   }
   LaunchedEffect(attachmentOption.value) {
     when (attachmentOption.value) {

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/views/chatlist/ChatListNavLinkView.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/views/chatlist/ChatListNavLinkView.desktop.kt
@@ -7,10 +7,21 @@ import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.input.key.*
 import androidx.compose.ui.node.DelegatableNode
 import androidx.compose.ui.node.DrawModifierNode
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.shape.RoundedCornerShape
+import chat.simplex.common.tokens
+import chat.simplex.common.model.ChatController.appPrefs
 import chat.simplex.common.platform.onRightClick
 import chat.simplex.common.views.helpers.*
 
@@ -34,10 +45,38 @@ actual fun ChatListNavLinkLayout(
   selectedChat: State<Boolean>,
   nextChatSelected: State<Boolean>,
 ) {
-  var modifier = Modifier.fillMaxWidth()
+  val density = remember { appPrefs.desktopChatDensity.state }.value.tokens()
+  val focusManager = LocalFocusManager.current
+  var focused by remember { mutableStateOf(false) }
+  var modifier = Modifier
+    .padding(horizontal = 6.dp, vertical = 1.dp)
+    .fillMaxWidth()
+    .clip(RoundedCornerShape(8.dp))
+    .background(
+      when {
+        selectedChat.value -> MaterialTheme.colors.primary.copy(alpha = 0.16f)
+        focused -> MaterialTheme.colors.onBackground.copy(alpha = 0.08f)
+        else -> Color.Transparent
+      }
+    )
   if (!disabled) modifier = modifier
     .combinedClickable(onClick = click, onLongClick = { showMenu.value = true })
     .onRightClick { showMenu.value = true }
+    .onFocusChanged { focused = it.isFocused }
+    .focusable()
+    .onPreviewKeyEvent { event ->
+      if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+      when (event.key) {
+        Key.Enter, Key.NumPadEnter, Key.Spacebar -> {
+          click()
+          true
+        }
+        Key.DirectionUp -> focusManager.moveFocus(FocusDirection.Up)
+        Key.DirectionDown -> focusManager.moveFocus(FocusDirection.Down)
+        else -> false
+      }
+    }
+    .semantics { selected = selectedChat.value }
   CompositionLocalProvider(
     LocalIndication provides if (selectedChat.value && !disabled) NoIndication else LocalIndication.current
   ) {
@@ -45,13 +84,10 @@ actual fun ChatListNavLinkLayout(
       Row(
         modifier = Modifier
           .fillMaxWidth()
-          .padding(start = 8.dp, top = 8.dp, end = 12.dp, bottom = 8.dp),
+          .padding(start = 8.dp, top = density.chatRowVerticalPadding, end = 12.dp, bottom = density.chatRowVerticalPadding),
         verticalAlignment = Alignment.Top
       ) {
         chatLinkPreview()
-      }
-      if (selectedChat.value) {
-        Box(Modifier.matchParentSize().background(MaterialTheme.colors.onBackground.copy(0.05f)))
       }
       if (dropdownMenuItems != null) {
         DefaultDropdownMenu(showMenu, dropdownMenuItems = dropdownMenuItems)

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/views/chatlist/ChatListNavLinkView.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/views/chatlist/ChatListNavLinkView.desktop.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import androidx.compose.ui.input.key.*
@@ -23,6 +24,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import chat.simplex.common.tokens
 import chat.simplex.common.model.ChatController.appPrefs
 import chat.simplex.common.platform.onRightClick
+import chat.simplex.common.platform.desktopOnHovered
 import chat.simplex.common.views.helpers.*
 
 object NoIndication : IndicationNodeFactory {
@@ -48,21 +50,30 @@ actual fun ChatListNavLinkLayout(
   val density = remember { appPrefs.desktopChatDensity.state }.value.tokens()
   val focusManager = LocalFocusManager.current
   var focused by remember { mutableStateOf(false) }
+  var hovered by remember { mutableStateOf(false) }
+  val rowShape = RoundedCornerShape(9.dp)
   var modifier = Modifier
-    .padding(horizontal = 6.dp, vertical = 1.dp)
+    .padding(horizontal = 7.dp, vertical = 2.dp)
     .fillMaxWidth()
-    .clip(RoundedCornerShape(8.dp))
+    .clip(rowShape)
     .background(
       when {
-        selectedChat.value -> MaterialTheme.colors.primary.copy(alpha = 0.16f)
-        focused -> MaterialTheme.colors.onBackground.copy(alpha = 0.08f)
+        selectedChat.value -> MaterialTheme.colors.primary.copy(alpha = 0.18f)
+        focused -> MaterialTheme.colors.primary.copy(alpha = 0.10f)
+        hovered -> MaterialTheme.colors.onBackground.copy(alpha = 0.07f)
         else -> Color.Transparent
       }
     )
+    .then(
+      if (focused) Modifier.border(1.dp, MaterialTheme.colors.primary.copy(alpha = 0.55f), rowShape)
+      else Modifier
+    )
+    .alpha(if (disabled) 0.55f else 1f)
   if (!disabled) modifier = modifier
     .combinedClickable(onClick = click, onLongClick = { showMenu.value = true })
     .onRightClick { showMenu.value = true }
     .onFocusChanged { focused = it.isFocused }
+    .desktopOnHovered { hovered = it }
     .focusable()
     .onPreviewKeyEvent { event ->
       if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
@@ -84,19 +95,25 @@ actual fun ChatListNavLinkLayout(
       Row(
         modifier = Modifier
           .fillMaxWidth()
-          .padding(start = 8.dp, top = density.chatRowVerticalPadding, end = 12.dp, bottom = density.chatRowVerticalPadding),
+          .padding(start = 10.dp, top = density.chatRowVerticalPadding, end = 12.dp, bottom = density.chatRowVerticalPadding),
         verticalAlignment = Alignment.Top
       ) {
         chatLinkPreview()
+      }
+      if (selectedChat.value) {
+        Box(
+          Modifier
+            .align(Alignment.CenterStart)
+            .padding(start = 3.dp)
+            .width(3.dp)
+            .height(28.dp)
+            .clip(RoundedCornerShape(2.dp))
+            .background(MaterialTheme.colors.primary)
+        )
       }
       if (dropdownMenuItems != null) {
         DefaultDropdownMenu(showMenu, dropdownMenuItems = dropdownMenuItems)
       }
     }
-  }
-  if (selectedChat.value || nextChatSelected.value) {
-    Divider()
-  } else {
-    Divider(Modifier.padding(horizontal = 8.dp))
   }
 }

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/views/helpers/DefaultDialog.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/views/helpers/DefaultDialog.desktop.kt
@@ -38,9 +38,12 @@ actual fun DefaultDialog(
       } else false
     }
   ) {
+    val shape = RoundedCornerShape(12.dp)
     Surface(
       Modifier
-        .border(border = BorderStroke(1.dp, MaterialTheme.colors.secondary.copy(alpha = 0.3F)), shape = RoundedCornerShape(8)),
+        .border(border = BorderStroke(1.dp, MaterialTheme.colors.onSurface.copy(alpha = 0.16f)), shape = shape),
+      shape = shape,
+      elevation = 18.dp,
       contentColor = LocalContentColor.current
     ) {
       content()

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/views/onboarding/SetNotificationsMode.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/views/onboarding/SetNotificationsMode.desktop.kt
@@ -1,6 +1,26 @@
 package chat.simplex.common.views.onboarding
 
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
+import chat.simplex.common.model.ChatController.appPrefs
+import chat.simplex.common.model.MacOSNotifications
+import chat.simplex.common.platform.*
+import chat.simplex.common.views.helpers.AlertManager
 
 @Composable
-actual fun SetNotificationsModeAdditions() {}
+actual fun SetNotificationsModeAdditions() {
+  if (!desktopPlatform.isMac()) return
+  LaunchedEffect(Unit) {
+    if (!appPrefs.desktopNotificationExplanationShown.get() &&
+      MacOSNotifications.permissionState() == NotificationPermissionState.NOT_DETERMINED
+    ) {
+      appPrefs.desktopNotificationExplanationShown.set(true)
+      AlertManager.shared.showAlertDialog(
+        title = "Stay up to date",
+        text = "SimpleX can use native Mac notifications for new messages and calls. Previews follow your privacy setting, and alerts are suppressed while you are looking at that exact chat.",
+        confirmText = "Allow Notifications",
+        onConfirm = { MacOSNotifications.requestPermission() },
+        dismissText = "Not Now",
+      )
+    }
+  }
+}

--- a/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/views/usersettings/Appearance.desktop.kt
+++ b/apps/multiplatform/common/src/desktopMain/kotlin/chat/simplex/common/views/usersettings/Appearance.desktop.kt
@@ -8,6 +8,7 @@ import SectionView
 import itemHPadding
 import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.runtime.*
@@ -17,7 +18,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.*
+import chat.simplex.common.DesktopChatDensity
 import chat.simplex.common.model.ChatController.appPrefs
 import chat.simplex.common.model.ChatModel
 import chat.simplex.common.model.CloseBehavior
@@ -87,10 +90,44 @@ fun AppearanceScope.AppearanceLayout(
     FontScaleSection()
 
     SectionDividerSpaced()
+    DesktopChatDensitySection()
+
+    SectionDividerSpaced()
     DensityScaleSection()
 
     SectionBottomSpacer()
   }
+}
+
+@Composable
+private fun DesktopChatDensitySection() {
+  val preference = appPrefs.desktopChatDensity
+  val selected = remember { preference.state }
+  SectionView("Chat density", contentPadding = PaddingValues(horizontal = CARD_PADDING, vertical = 4.dp)) {
+    DesktopChatDensity.entries.forEach { density ->
+      val title = when (density) {
+        DesktopChatDensity.Compact -> "Compact"
+        DesktopChatDensity.Comfortable -> "Comfortable"
+        DesktopChatDensity.Spacious -> "Spacious"
+      }
+      Row(
+        Modifier
+          .fillMaxWidth()
+          .selectable(
+            selected = selected.value == density,
+            role = Role.RadioButton,
+            onClick = { preference.set(density) }
+          )
+          .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+      ) {
+        RadioButton(selected = selected.value == density, onClick = null)
+        Spacer(Modifier.width(10.dp))
+        Text(title, style = MaterialTheme.typography.body1)
+      }
+    }
+  }
+  SectionTextFooter("Changes spacing without changing text size.")
 }
 
 @Composable

--- a/apps/multiplatform/settings.gradle.kts
+++ b/apps/multiplatform/settings.gradle.kts
@@ -18,4 +18,9 @@ pluginManagement {
 
 rootProject.name = "app"
 
-include(":android", ":desktop", ":common")
+val desktopOnly = providers.gradleProperty("desktopOnly").map(String::toBoolean).getOrElse(false)
+
+include(":desktop", ":common")
+if (!desktopOnly) {
+    include(":android")
+}


### PR DESCRIPTION
## Summary

This introduces a native SwiftUI macOS frontend for SimpleX Chat and substantially improves the existing desktop experience.

### Native macOS app

- adds a standalone native SwiftUI chat interface backed by the existing SimpleX core
- uses native macOS windowing, sidebar, toolbar, composer, menus, Quick Look, Keychain, and notification APIs
- preserves the existing database, transport, and wire protocol
- supports database unlock and optional passphrase storage in Keychain
- prevents concurrent native and legacy frontends from opening the same database

### Conversations and media

- adds Compact, Comfortable, and Spacious density modes
- improves keyboard navigation, message selection, copying, replies, deletion, search, and unread handling
- supports mixed pending attachments, validation, ordering, retries, and partial-send recovery
- opens original images and video in Quick Look
- renders native link previews and inline YouTube playback
- plays audio attachments inline while preserving explicit pause state during scrolling
- improves long-message sizing, quote navigation, reply context, and hover controls

### Notifications

- routes macOS notifications through UserNotifications
- preserves preview privacy modes and sound preferences
- suppresses notifications only for the exact active conversation
- queues click-through routing across startup, unlock, profile, and remote-host transitions

### Existing desktop UI

- improves desktop-only layout, window-state persistence, sidebar sizing, composer behavior, attachment previews, dialogs, and macOS notification settings
- keeps Android-specific behavior isolated and avoids backend or protocol changes

## Why

The existing desktop app is functional but does not behave like a polished Mac application. This change gives macOS users a native interface, predictable keyboard behavior, better media handling, reliable notification routing, and more resilient conversation state without replacing the SimpleX backend.

## Validation

- 119 native macOS Swift tests pass with strict concurrency checking
- native release app builds successfully
- the packaged app passes deep strict code-signature verification
- manual testing covered conversation navigation, replies, selection/copy, unread state, images, Quick Look, inline YouTube/audio playback, notification routing, and database unlock
