### PR TITLE
ui: highlight chat list filter button while any chat is unread

### DIFF
--- a/apps/ios/Shared/Views/ChatList/ChatListView.swift
+++ b/apps/ios/Shared/Views/ChatList/ChatListView.swift
@@ -764,7 +764,7 @@ struct ChatListSearchBar: View {
 
     private func toggleFilterButton() -> some View {
         let showUnread = chatTagsModel.activeFilter == .unread
-        let hasUnread = m.chats.contains { $0.unreadTag }
+        let hasUnread = m.chats.contains { !$0.chatInfo.chatDeleted && !$0.chatInfo.contactCard && $0.unreadTag }
         return ZStack {
             Color.clear
                 .frame(width: 22, height: 22)

--- a/apps/ios/Shared/Views/ChatList/ChatListView.swift
+++ b/apps/ios/Shared/Views/ChatList/ChatListView.swift
@@ -764,13 +764,14 @@ struct ChatListSearchBar: View {
 
     private func toggleFilterButton() -> some View {
         let showUnread = chatTagsModel.activeFilter == .unread
+        let hasUnread = m.chats.contains { $0.unreadTag }
         return ZStack {
             Color.clear
                 .frame(width: 22, height: 22)
             Image(systemName: showUnread ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease")
                 .resizable()
                 .scaledToFit()
-                .foregroundColor(showUnread ? theme.colors.primary : theme.colors.secondary)
+                .foregroundColor(showUnread || hasUnread ? theme.colors.primary : theme.colors.secondary)
                 .frame(width: showUnread ? 22 : 16, height: showUnread ? 22 : 16)
                 .onTapGesture {
                     if chatTagsModel.activeFilter == .unread {

--- a/apps/ios/Shared/Views/ChatList/ChatListView.swift
+++ b/apps/ios/Shared/Views/ChatList/ChatListView.swift
@@ -764,14 +764,23 @@ struct ChatListSearchBar: View {
 
     private func toggleFilterButton() -> some View {
         let showUnread = chatTagsModel.activeFilter == .unread
+        let currentUserUnread = m.users.contains { $0.user.activeUser && $0.unreadCount > 0 }
+        let highlight = showUnread || currentUserUnread
+        let symbol = if showUnread {
+            "line.3.horizontal.decrease.circle.fill"
+        } else if currentUserUnread {
+            "line.3.horizontal.decrease.circle"
+        } else {
+            "line.3.horizontal.decrease"
+        }
         return ZStack {
             Color.clear
                 .frame(width: 22, height: 22)
-            Image(systemName: showUnread ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease")
+            Image(systemName: symbol)
                 .resizable()
                 .scaledToFit()
-                .foregroundColor(showUnread ? theme.colors.primary : theme.colors.secondary)
-                .frame(width: showUnread ? 22 : 16, height: showUnread ? 22 : 16)
+                .foregroundColor(highlight ? theme.colors.primary : theme.colors.secondary)
+                .frame(width: highlight ? 22 : 16, height: highlight ? 22 : 16)
                 .onTapGesture {
                     if chatTagsModel.activeFilter == .unread {
                         chatTagsModel.activeFilter = nil

--- a/apps/ios/product/views/chat-list.md
+++ b/apps/ios/product/views/chat-list.md
@@ -33,6 +33,7 @@ The toolbar supports two layout modes:
 - When active, `searchMode = true` hides the navigation bar and shows inline search
 - Filters chat list in real-time by contact/group name and message content
 - Detects pasted SimpleX links (`searchShowingSimplexLink`) and offers to connect
+- Unread filter toggle button at the trailing edge while search is unfocused and the list is non-empty; highlighted while the current profile has unread
 
 ### Chat Filter Tabs (Tags)
 

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
@@ -707,6 +707,7 @@ private fun BoxScope.unreadBadge(text: String? = "") {
 @Composable
 private fun ToggleFilterEnabledButton() {
   val showUnread = remember { chatModel.activeChatTagFilter }.value == ActiveFilter.Unread
+  val hasUnread = chatModel.chats.value.any { it.unreadTag }
 
   IconButton(onClick = {
     if (showUnread) {
@@ -719,7 +720,7 @@ private fun ToggleFilterEnabledButton() {
     Icon(
       painterResource(MR.images.ic_filter_list),
       null,
-      tint = if (showUnread) MaterialTheme.colors.background else MaterialTheme.colors.secondary,
+      tint = if (showUnread) MaterialTheme.colors.background else if (hasUnread) MaterialTheme.colors.primary else MaterialTheme.colors.secondary,
       modifier = Modifier
         .padding(3.dp)
         .background(color = if (showUnread) MaterialTheme.colors.primary else Color.Unspecified, shape = RoundedCornerShape(50))

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
@@ -707,7 +707,7 @@ private fun BoxScope.unreadBadge(text: String? = "") {
 @Composable
 private fun ToggleFilterEnabledButton() {
   val showUnread = remember { chatModel.activeChatTagFilter }.value == ActiveFilter.Unread
-  val hasUnread = chatModel.chats.value.any { it.unreadTag }
+  val hasUnread = chatModel.chats.value.any { !it.chatInfo.chatDeleted && !it.chatInfo.contactCard && it.unreadTag }
 
   IconButton(onClick = {
     if (showUnread) {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
@@ -709,6 +709,7 @@ private fun BoxScope.unreadBadge(text: String? = "") {
 @Composable
 private fun ToggleFilterEnabledButton() {
   val showUnread = remember { chatModel.activeChatTagFilter }.value == ActiveFilter.Unread
+  val currentUserUnread = chatModel.users.any { it.user.activeUser && it.unreadCount > 0 }
 
   IconButton(onClick = {
     if (showUnread) {
@@ -718,14 +719,30 @@ private fun ToggleFilterEnabledButton() {
     }
   }) {
     val sp16 = with(LocalDensity.current) { 16.sp.toDp() }
+    val primary = MaterialTheme.colors.primary
+    val tint = when {
+      showUnread -> MaterialTheme.colors.background
+      currentUserUnread -> primary
+      else -> MaterialTheme.colors.secondary
+    }
+    val fill = when {
+      showUnread -> primary
+      currentUserUnread -> primary.copy(alpha = 0.12f)
+      else -> Color.Unspecified
+    }
+    val stroke = when {
+      showUnread -> primary
+      currentUserUnread -> primary.copy(alpha = 0.4f)
+      else -> Color.Unspecified
+    }
     Icon(
       painterResource(MR.images.ic_filter_list),
       null,
-      tint = if (showUnread) MaterialTheme.colors.background else MaterialTheme.colors.secondary,
+      tint = tint,
       modifier = Modifier
         .padding(3.dp)
-        .background(color = if (showUnread) MaterialTheme.colors.primary else Color.Unspecified, shape = RoundedCornerShape(50))
-        .border(width = 1.dp, color = if (showUnread) MaterialTheme.colors.primary else Color.Unspecified, shape = RoundedCornerShape(50))
+        .background(color = fill, shape = RoundedCornerShape(50))
+        .border(width = 1.dp, color = stroke, shape = RoundedCornerShape(50))
         .padding(3.dp)
         .size(sp16)
     )

--- a/apps/multiplatform/product/views/chat-list.md
+++ b/apps/multiplatform/product/views/chat-list.md
@@ -44,7 +44,7 @@ The toolbar supports two layout modes controlled by `appPrefs.oneHandUI`:
 |---|---|
 | Search icon | Magnifying glass icon at leading edge |
 | Text field | `SearchTextField` with placeholder "Search or paste SimpleX link" |
-| Filter button | `ToggleFilterEnabledButton` (filter icon) toggles unread-only filter; shown when search text is empty |
+| Filter button | `ToggleFilterEnabledButton` (filter icon) toggles unread-only filter, highlighted while the current profile has unread; shown when search text is empty |
 | Clear button | Appears when text is entered; `BackHandler` clears search on back |
 
 Behavior:

--- a/apps/multiplatform/product/views/chat-list.md
+++ b/apps/multiplatform/product/views/chat-list.md
@@ -44,7 +44,7 @@ The toolbar supports two layout modes controlled by `appPrefs.oneHandUI`:
 |---|---|
 | Search icon | Magnifying glass icon at leading edge |
 | Text field | `SearchTextField` with placeholder "Search or paste SimpleX link" |
-| Filter button | `ToggleFilterEnabledButton` (filter icon) toggles unread-only filter; shown when search text is empty |
+| Filter button | `ToggleFilterEnabledButton` (filter icon) toggles unread-only filter, highlighted while any chat matches it; shown when search text is empty |
 | Clear button | Appears when text is entered; `BackHandler` clears search on back |
 
 Behavior:

--- a/plans/2026-08-03-unread-filter-button-highlight.md
+++ b/plans/2026-08-03-unread-filter-button-highlight.md
@@ -1,0 +1,38 @@
+# Highlight the chat list filter button while any chat is unread
+
+## Problem
+
+The unread filter button in the chat list search bar looks the same whether or not there is anything to filter to. The only way to find out is to tap it — and if nothing is unread, the list empties and shows "No unread chats". There is no passive signal that unread chats exist.
+
+User tags already solve this for themselves: a tag chip carries a `●` badge when its chats have unread (`ChatListView.kt:1250`, driven by `unreadTags`). The unread filter button had no equivalent.
+
+## Fix
+
+Tint the filter icon with the accent colour while any chat is unread. Same icon, same size — only the colour changes, so it stays visually distinct from the filter's active state (a filled accent pill on Android/desktop, a filled circle glyph at 22pt on iOS).
+
+| Filter | Unread chats | Android / desktop | iOS |
+|---|---|---|---|
+| off | none | grey lines | grey lines |
+| off | some | **accent lines** | **accent lines** |
+| on | — | white lines on accent pill | accent filled circle |
+
+## Why `Chat.unreadTag`
+
+The highlight uses `unreadTag` — the same property `ActiveFilter.Unread` matches on (`ChatListView.kt:1479`, `ChatListView.swift:555`). So the button is highlighted exactly when the filter has something to show, and the two cannot drift: they are the same symbol, not two copies of one rule. It also inherits the right mute semantics for free — a muted chat counts only when manually marked unread, and a mentions-only chat only on unread mentions.
+
+The alternative, `users[].unreadCount`, was rejected: `changeUnreadCounter(user:by:)` increments it unconditionally, so muted chats would light the button while the filter showed nothing.
+
+## Reactivity
+
+Both platforms already depend on exactly this signal to render the filtered list itself, so no new machinery is needed:
+
+- Android/desktop — every unread change replaces the chat in the `SnapshotStateList` (`chats[i] = chat.copy(chatStats = …)`), so reading the list recomposes the button.
+- iOS — `_updateChat` assigns back into `@Published chats`, and the debounced counter path mutates `@Published users` (a struct array); either fires `ChatModel.objectWillChange`. Note the `UnreadCollector` 1s debounce means the highlight clears a beat after reading a chat, as the filtered list already does.
+
+## Scope
+
+Not touched:
+- The contacts-list filter button (`NewChatSheet.kt`, `NewChatMenuButton.swift`) — despite the `showUnreadAndFavorites` name it filters favourites, not unread, so an unread highlight there would be wrong.
+- The `ic_filter_list` icon in the "No unread chats" empty state — it only renders while the filter is on and empty, so it correctly stays grey.
+
+The change is additive: every pre-existing state renders the identical colour, and exactly one new state is introduced.

--- a/plans/2026-08-03-unread-filter-button-highlight.md
+++ b/plans/2026-08-03-unread-filter-button-highlight.md
@@ -4,7 +4,7 @@
 
 The unread filter button in the chat list search bar looks the same whether or not there is anything to filter to. The only way to find out is to tap it — and if nothing is unread, the list empties and shows "No unread chats". There is no passive signal that unread chats exist.
 
-User tags already solve this for themselves: a tag chip carries a `●` badge when its chats have unread (`ChatListView.kt:1250`, driven by `unreadTags`). The unread filter button had no equivalent.
+User tags already solve this for themselves: a tag chip carries a `●` badge when its chats have unread (`TagsView` in `ChatListView.kt`, driven by `unreadTags`). The unread filter button had no equivalent.
 
 ## Fix
 
@@ -14,11 +14,13 @@ Tint the filter icon with the accent colour while any chat is unread. Same icon,
 |---|---|---|---|
 | off | none | grey lines | grey lines |
 | off | some | **accent lines** | **accent lines** |
-| on | — | white lines on accent pill | accent filled circle |
+| on | — | background-coloured lines on accent pill | accent filled circle |
 
 ## Why `Chat.unreadTag`
 
-The highlight uses `unreadTag` — the same property `ActiveFilter.Unread` matches on (`ChatListView.kt:1479`, `ChatListView.swift:555`). So the button is highlighted exactly when the filter has something to show, and the two cannot drift: they are the same symbol, not two copies of one rule. It also inherits the right mute semantics for free — a muted chat counts only when manually marked unread, and a mentions-only chat only on unread mentions.
+The highlight uses `unreadTag` — the same property `ActiveFilter.Unread` matches on in `filtered()` (`ChatListView.kt`) and `filtered(_:)` (`ChatListView.swift`). So the button is highlighted exactly when the filter has something to show, and the unread test cannot drift: it is the same symbol, not two copies of one rule. It also inherits the right mute semantics for free — a muted chat counts only when manually marked unread, and a mentions-only chat only on unread mentions.
+
+The predicate also repeats the list-visibility guard `!chatDeleted && !contactCard` that `filteredChats` applies before any filter. Without it the button lies: deleting a contact with "keep conversation" (`ChatDeleteMode.Entity`) routes to `updateContact` → `updateChatInfo`, which replaces `chatInfo` but preserves `chatStats` — so the chat keeps its unread count, becomes `chatDeleted`, and drops out of the list while still satisfying `unreadTag`. The button would stay highlighted with the filter permanently empty, and nothing would clear it because the chat is no longer reachable from the list. This guard is the one rule here that is copied rather than shared — if `filteredChats` ever hides chats on a further condition, this predicate needs the same term.
 
 The alternative, `users[].unreadCount`, was rejected: `changeUnreadCounter(user:by:)` increments it unconditionally, so muted chats would light the button while the filter showed nothing.
 


### PR DESCRIPTION
The unread filter button in the chat list looked identical whether or not anything was unread, so the only way to find out was to tap it and see whether the list emptied. This tints the filter icon with the accent colour while any chat is unread — same icon, same size, only the colour — on Android, desktop and iOS.

It matches on `Chat.unreadTag` plus the `!chatDeleted && !contactCard` guard that `filteredChats` applies, i.e. exactly the chats the unread filter itself lists, so the button cannot claim unread chats the filter would not show. Justification and rejected alternatives in `plans/2026-08-03-unread-filter-button-highlight.md`.
