### PR TITLE
support bot: add crowdfunding announcement to welcome message

### DIFF
--- a/apps/simplex-support-bot/src/messages.ts
+++ b/apps/simplex-support-bot/src/messages.ts
@@ -2,7 +2,10 @@ import {isWeekend} from "./util.js"
 
 export const welcomeMessage = `Hello! This is a *SimpleX team* support bot - not an AI.
 *Join public groups* at https://simplex.chat/directory or [via directory bot](https://smp4.simplex.im/a#lXUjJW5vHYQzoLYgmi8GbxkGP41_kjefFvBrdwg-0Ok)
-Please ask any questions about SimpleX Chat.`
+
+We just launched [equity crowdfunding on Wefunder](https://wefunder.com/simplex.chat)!
+
+Please ask any questions about SimpleX Chat and about our crowdfunding.`
 
 export function queueMessage(timezone: string, grokEnabled: boolean): string {
   const hours = isWeekend(timezone) ? "48" : "24"


### PR DESCRIPTION
Adds the Wefunder equity crowdfunding announcement to the business address welcome message, and extends the closing line to invite questions about it.

The two existing directory links are unchanged.

Deploying: the welcome message is part of the address settings, so `npm run build` and a bot restart are required — `bot.run()` deep-compares the stored address settings on start and calls `apiSetAddressSettings` when they differ, which rewrites the local row and re-uploads the address link data. The address link itself does not change, and nothing is sent to existing business chats.