### PR TITLE
ios: reconnect servers when network changes

### DIFF
--- a/apps/ios/Shared/Model/NetworkObserver.swift
+++ b/apps/ios/Shared/Model/NetworkObserver.swift
@@ -35,8 +35,12 @@ class NetworkObserver {
             online: path.status == .satisfied
         )
         if (prevInfo != info) {
+            // iOS does not report the sockets of the previous network as broken, so the servers have to
+            // be reconnected. There is nothing to reconnect before the first network info is set.
+            let shouldReconnect = prevInfo != nil && info.online
             prevInfo = info
             setNetworkInfo(info)
+            if shouldReconnect { reconnectServers() }
         }
     }
 
@@ -67,6 +71,17 @@ class NetworkObserver {
                 try apiSetNetworkInfo(info)
             } catch let err {
                 logger.error("setNetworkInfo error: \(responseError(err))")
+            }
+        }
+    }
+
+    private func reconnectServers() {
+        Task {
+            if !hasChatCtrl() { return }
+            do {
+                try await reconnectAllServers()
+            } catch let err {
+                logger.error("reconnectAllServers error: \(responseError(err))")
             }
         }
     }


### PR DESCRIPTION
iOS does not report the sockets of the previous network as broken, so after switching between Wi-Fi and mobile the agent keeps using dead sessions - setting network info does not drop them. Recovery only happened when the OS finally failed the socket, via TCP keep-alive or the SMP ping monitor, taking from ~90 seconds to tens of minutes.

Reconnect the servers on every network change after the first one, when the network is online. Changes that keep the same network type, e.g. switching between Wi-Fi networks, are not detected, as network info only has the network type.