### PR TITLE
android, desktop: fix pop chat collector reading the primary chat list

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
@@ -779,10 +779,9 @@ object ChatModel {
       }
     }
 
-    val popChatCollector = PopChatCollector(this)
+    val popChatCollector = PopChatCollector()
 
-    // TODO [contexts] no reason for this to be nested?
-    class PopChatCollector(chatsCtx: ChatsContext) {
+    inner class PopChatCollector {
       private val subject = MutableSharedFlow<Unit>()
       private var remoteHostId: Long? = null
       private val chatsToPop = mutableMapOf<ChatId, Instant>()
@@ -793,7 +792,7 @@ object ChatModel {
             .throttleLatest(2000)
             .collect {
               withContext(Dispatchers.Main) {
-                chatsCtx.chats.replaceAll(popCollectedChats())
+                chats.replaceAll(popCollectedChats())
               }
             }
         }


### PR DESCRIPTION
`PopChatCollector` is created one per `ChatsContext` (`ChatModel.kt:786`), but it was a **nested** class taking the context as a constructor **parameter** — so only its `init` closure held a reference to it:

```kotlin
val popChatCollector = PopChatCollector(this)
class PopChatCollector(chatsCtx: ChatsContext) {
  init { … chatsCtx.chats.replaceAll(popCollectedChats()) … }   // correct target

  private fun popCollectedChats(): List<Chat> {
    val ch = getChat(chatId)                                     // :826  unqualified
    newChats.addAll(chats.value.filter { … })                    // :834  unqualified
```

`popCollectedChats()` is a separate method, and a nested (non-`inner`) class has no enclosing `ChatsContext` instance — so `getChat` and `chats` there cannot bind to `ChatsContext.getChat` (:392) / `ChatsContext.chats` (:368). They resolve outward to `object ChatModel`, whose members need no instance: `ChatModel.getChat` (:344) and `ChatModel.chats` (:134), and the latter is defined as `= chatsContext.chats` — the **primary** list.

So the method assembles a reordered copy of the primary chat list, and `init` installs it as the **secondary** context's list.

### Reproduction

The pop only fires when `throttlePopChat` sees `currentPosition > 0` (:806-812), which needs ≥2 chats in the secondary list. It gets them because `SimpleXAPI.kt` dispatches every incoming item to the secondary context regardless of which chat it belongs to, and `addChatItem` calls `addChat` for any chat not already there.

1. Open a group's reports view or a member-support chat.
2. Receive a message from contact **A** → secondary list `[A]`; `currentPosition = 0`, no pop scheduled.
3. Receive a message from contact **B** → `addChat` inserts at 0 → `[B, A]`; still 0, no pop.
4. Receive a **second message from A** → index 1 → pop scheduled → within 2 s the secondary context's chat list is replaced by the primary one.

`ChatView.kt:249` derives the open chat's unread count from `chatsCtx.chats`, which is the secondary list in these views (`MemberSupportChatView.kt:48`, `GroupReportsView.kt:27`). After the replacement that lookup matches the **primary's** entry for the same group — `ChatInfo.Group.id` ignores the scope, so the ids collide — and the value feeds the scroll-to-bottom counter (:2610) and the unread-divider placement via `MergedItems.create` (:1797). The reports / member-support view then shows the group's main-chat unread count instead of its own.

### The fix

Make the class `inner`. `getChat` and `chats` then resolve to the context that owns the collector, and the same mistake cannot be reintroduced by adding another method to the class — which is why this is preferred over qualifying the two call sites with a `private val chatsCtx`.

`ChatsContext` declares none of the collector's own member names (`subject`, `remoteHostId`, `chatsToPop`, `clear`, `throttlePopChat`, `popCollectedChats`), so `inner` rebinds exactly two identifiers and nothing else.

Nothing changes for the primary context, where `chats === chatsContext.chats` and the two resolutions coincide. Only the secondary context's behaviour changes, and only to stop reading the wrong list.

The `// TODO [contexts] no reason for this to be nested?` above the class is removed — after this change the nesting is load-bearing.

### Relationship to #7072

Same defect class — a per-context routine reaching the primary list — reached by a different route: #7072's was an explicit `chatsContext.` qualifier, this one is silent scope resolution, which is why it survived that fix. It is independent of #7072 and #7394 (no overlapping lines) and can land in any order.

Note the symptom differs: this one corrupts only the secondary context's list, so it is **not** a second cause of the wrong-chat preview/unread in the main list that #7072 fixes.

### Verification

Found by review, not by a report. Not compiled — the machine ran out of memory for the Kotlin daemon. The symptom described above is traced through the code, not observed at runtime.