### PR TITLE
linux: fix Flatpak window resizing under non-reparenting WMs

### DIFF
--- a/scripts/flatpak/chat.simplex.simplex.desktop
+++ b/scripts/flatpak/chat.simplex.simplex.desktop
@@ -5,6 +5,6 @@ Name=SimpleX Chat
 Comment=A private & encrypted open-source messenger without any user IDs (not even random ones)!
 Keywords=chat;message;private;secure;simplex;
 Categories=Utility;Chat;InstantMessaging;
-Exec=simplex %U
+Exec=env _JAVA_AWT_WM_NONREPARENTING=1 simplex %U
 Icon=chat.simplex.simplex
 StartupWMClass=simplex-chat


### PR DESCRIPTION
## Summary

Set _JAVA_AWT_WM_NONREPARENTING=1 in the Flatpak desktop launcher.

This helps Java/AWT desktop applications work with non-reparenting window managers such as Sway when running through XWayland. It addresses the resizing behavior reported in #2889 without changing the application UI or data handling.

## Testing

- Validated the desktop entry with desktop-file-validate.
- Tested SimpleX Chat 7.0.1 from Flathub on Sway 1.12 / Wayland.
- Without the variable, tiled resizing kept the application's original large geometry and the UI became unusable.
- With the variable, the window followed the compositor geometry correctly and remained tiled/resizable.

Refs #2889