### PR TITLE
android, desktop: fix chat console crash on duplicate list keys

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/SimpleXAPI.kt
@@ -59,6 +59,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.*
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.util.Date
@@ -7222,7 +7223,7 @@ abstract class TerminalItem {
   val date: Instant = Clock.System.now()
   abstract val label: String
   abstract val details: String
-  val createdAtNanos: Long = System.nanoTime()
+  val itemNo: Long = itemNoGenerator.incrementAndGet()
 
   class Cmd(override val id: Long, override val remoteHostId: Long?, val cmd: CC): TerminalItem() {
     override val label get() = "> ${cmd.cmdString}"
@@ -7235,6 +7236,8 @@ abstract class TerminalItem {
   }
 
   companion object {
+    private val itemNoGenerator = AtomicLong(0)
+
     val sampleData = listOf(
         Cmd(0, null, CC.ShowActiveUser()),
         Resp(1, null, API.Result(null, CR.ActiveUser(User.sampleData)))

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/TerminalView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/TerminalView.kt
@@ -165,7 +165,7 @@ fun TerminalLog(floating: Boolean, composeViewHeight: State<Dp>) {
     reverseLayout = true,
     additionalBarOffset = composeViewHeight
   ) {
-    items(reversedTerminalItems, key = { item -> item.id to item.createdAtNanos }) { item ->
+    items(reversedTerminalItems, key = { item -> item.itemNo }) { item ->
       val clipboard = LocalClipboardManager.current
       val rhId = item.remoteHostId
       val rhIdStr = if (rhId == null) "" else "$rhId "


### PR DESCRIPTION
Chat console crashes on scroll with:

```
java.lang.IllegalArgumentException: Key "(1787580965792, 190444122134166)" was already used.
If you are using LazyColumn/Row please make sure you provide a unique key for each item.
    at androidx.compose.ui.layout.LayoutNodeSubcompositionsState.subcompose(SubcomposeLayout.kt:1052)
    at androidx.compose.foundation.lazy.LazyListMeasuredItemProvider.getAndMeasure(LazyListMeasuredItemProvider.kt:55)
    ...
```

## Cause

Terminal items were keyed by `item.id to item.createdAtNanos`, i.e. `(System.currentTimeMillis(), System.nanoTime())`.

`System.nanoTime()` guarantees monotonicity, not uniqueness. Measured on one machine:

| | nanoTime ties | `(millis, nanos)` pair ties |
|---|---|---|
| 1 thread, 2M samples | 0 (min delta 43ns) | 0 |
| 4 threads, 1.2M samples | 29993 (~2.5%) | 29993 |

Every cross-thread `nanoTime` tie was also a `currentTimeMillis` tie, so the full key collides.

`TerminalItem`s are constructed concurrently on several threads - `sendCmd` runs inside `withContext(Dispatchers.IO)` and `processReceivedMsg` runs on the receiver thread - so two items born in the same instant on different cores get identical keys, and the next measure pass throws. The busier the console, the more often it happens.

This is also why #4812, which added `createdAtNanos` for the earlier version of this crash, did not hold: single-threaded, `nanoTime` never repeats.

## Fix

Key by a per-item sequence number from an `AtomicLong`. The generator is declared before `sampleData` so the sample items constructed during companion initialisation read an already assigned generator. `createdAtNanos` had no other reader and is removed.

## Verification

Reproduced in a standalone Compose Desktop harness mirroring `TerminalLog`: same `derivedStateOf` + `asReversed()`, `reverseLayout`, 500-item cap with the same trim-and-append, `scrollToItem(0)` on every append, continuous mouse-wheel scrolling, and items produced concurrently from several threads.

One build, key scheme selected at runtime, identical load:

| | old key `(millis, nanos)` | new key `itemNo` |
|---|---|---|
| appends before failure | 28726 | 261045 (no failure) |
| item content compositions | 17745 | 267488 |
| visible items | 33 | 32-33 |
| duplicate keys in data | 1 | 0 |
| outcome | `IllegalArgumentException` at `SubcomposeLayout.kt:1052` | no exception |

With the old key the harness reproduces the reported exception:

```
!!! DUPLICATE IN DATA: dup n=2010772 addCount=1 sameInstanceIndices=[486]
!!! UNCAUGHT on AWT-EventQueue-0: java.lang.IllegalArgumentException:
    Key "(1787587915479, 1549575349307311)" was already used...
    at androidx.compose.ui.layout.LayoutNodeSubcompositionsState.subcompose(SubcomposeLayout.kt:1052)
```

`addCount=1` with a single occupied index shows the item was appended exactly once, so it collided with a *different* item rather than being duplicated in the list. The composition and visible-item counters confirm the list was genuinely measuring in both runs.

Companion initialisation order was checked separately: touching `sampleData` first, so instances are constructed during companion init, gives `sampleData itemNos = [1, 2]` with no NPE, and 1000 runtime items produce 1000 distinct keys.
