### PR TITLE
core: fix unread support items left behind when pending member leaves group

### DIFF
--- a/src/Simplex/Chat/Library/Subscriber.hs
+++ b/src/Simplex/Chat/Library/Subscriber.hs
@@ -3680,11 +3680,13 @@ processAgentMessageConn cxt user@User {userId} corrId agentConnId agentMessage =
       -- member record is not deleted to allow creation of "member left" chat item
       gInfo' <- updateMemberRecordDeleted user gInfo m GSMemLeft
       gInfo'' <- updatePublicGroupData user gInfo'
-      unless (muteEventInChannel gInfo'' m) $ do
-        (gInfo''', m', scopeInfo) <- mkGroupChatScope gInfo'' m
+      -- support chat was deleted with the member record above, so the item has to be created in the group scope
+      let mLeft = m {memberStatus = GSMemLeft, supportChat = Nothing}
+      unless (muteEventInChannel gInfo'' mLeft) $ do
+        (gInfo''', m', scopeInfo) <- mkGroupChatScope gInfo'' mLeft
         (ci, cInfo) <- saveRcvChatItemNoParse user (CDGroupRcv gInfo''' scopeInfo m') msg brokerTs (CIRcvGroupEvent RGEMemberLeft)
         groupMsgToView cInfo ci
-        toView $ CEvtLeftMember user gInfo''' m' {memberStatus = GSMemLeft} msgSigned
+        toView $ CEvtLeftMember user gInfo''' m' msgSigned
       pure $ memberEventDeliveryScope m
 
     xGrpDel :: GroupInfo -> GroupMember -> RcvMessage -> UTCTime -> CM ()

--- a/tests/ChatTests/Groups.hs
+++ b/tests/ChatTests/Groups.hs
@@ -128,6 +128,7 @@ chatGroupTests = do
     it "accept member - only moderators review" testGLinkReviewMember
     it "accept member - host approval, then moderators review" testGLinkApproveThenReviewMember
     it "delete pending approval member" testGLinkDeletePendingApprovalMember
+    it "pending approval member leaves the group" testGLinkPendingApprovalMemberLeaves
     it "admin that joined via link introduces member for moderator review" testGLinkReviewIntroduce
   describe "group link connection plan" $ do
     it "ok to connect; known group" testPlanGroupLinkKnown
@@ -3618,6 +3619,37 @@ testGLinkDeletePendingApprovalMember =
       alice <## "#team: you removed cath from the group"
       cath <## "#team: alice removed you from the group"
       cath <## "use /d #team to delete the group"
+  where
+    cfg = testCfg {chatHooks = defaultChatHooks {acceptMember = Just (\_ _ _ -> pure $ Right (GAPendingApproval, GRObserver))}}
+
+testGLinkPendingApprovalMemberLeaves :: HasCallStack => TestParams -> IO ()
+testGLinkPendingApprovalMemberLeaves =
+  testChatCfg3 cfg aliceProfile bobProfile cathProfile $
+    \alice bob cath -> do
+      createGroup2 "team" alice bob
+
+      alice ##> "/create link #team"
+      gLink <- getGroupLink alice "team" GRMember True
+      cath ##> ("/c " <> gLink)
+      cath <## "connection request sent!"
+      alice <## "cath (Catherine): accepting request to join group #team..."
+      concurrentlyN_
+        [ alice <## "#team: cath connected and pending approval, use /_accept member #1 3 <role> to accept member",
+          do
+            cath <## "#team: joining the group..."
+            cath <## "#team: you joined the group, pending approval"
+        ]
+
+      cath ##> "/leave #team"
+      concurrentlyN_
+        [ do
+            cath <## "#team: you left the group"
+            cath <## "use /d #team to delete the group",
+          alice <## "#team: cath left the group"
+        ]
+
+      alice ##> "/member support chats #team"
+      alice <## "members require attention: 0"
   where
     cfg = testCfg {chatHooks = defaultChatHooks {acceptMember = Just (\_ _ _ -> pure $ Right (GAPendingApproval, GRObserver))}}
 


### PR DESCRIPTION
## Problem

A member pending approval or review who leaves the group leaves behind an unread chat item that can never be read. It counts towards the profile unread total in the profile picker forever, and the only way to clear it is `/read user`.

`xGrpLeave` deletes the leaving member's support chat first, including every chat item in it:

```haskell
gInfo' <- updateMemberRecordDeleted user gInfo m GSMemLeft   -- deleteSupportChatIfExists
gInfo'' <- updatePublicGroupData user gInfo'
unless (muteEventInChannel gInfo'' m) $ do
  (gInfo''', m', scopeInfo) <- mkGroupChatScope gInfo'' m    -- pre-leave m
```

but then passes the *pre-leave* member value to `mkGroupChatScope`, which decides the scope with `memberPending m`. The status update went to the database, not to `m`, so a pending member still reads as pending and the "member left" item is written straight back into the support scope that was just deleted. `mkMemberSupportChatInfo` and `updateChatTsStats` then recreate the support chat around it and bump `members_require_attention` again.

The item is received, so it is unread, and the group query in `getUsersInfo` has no `group_scope_tag` filter, so it counts towards the profile total. But the member is now `GSMemLeft`, and clients filter left and removed members out of the member support chat list, so the item is not reachable from any view. `members_require_attention` also stays at 1, which lights up the flag on the chat list row while the support list behind it is empty.

## Fix

Pass the member with the status it was just given, so the event lands in the group scope — the same place it already goes when a member is removed rather than leaving.

## Test

`pending approval member leaves the group` — a pending-approval member joins via group link and leaves. Before the fix `alice` reports `members require attention: 1` with the support chat resurrected on a member who is gone; after it, `0`.

## Note

This stops new occurrences. Items already stranded in existing databases stay until the profile is marked read with `/read user`; happy to add a migration that clears them if you want one.