### PR TITLE
ui: show own support chat after leaving or being removed from the group

### DIFF
--- a/apps/ios/Shared/Views/Chat/Group/GroupChatInfoView.swift
+++ b/apps/ios/Shared/Views/Chat/Group/GroupChatInfoView.swift
@@ -103,9 +103,10 @@ struct GroupChatInfoView: View {
                         }
                     }
 
-                    let showUserSupportChat = groupInfo.membership.memberActive
-                        && ((groupInfo.fullGroupPreferences.support.on && groupInfo.membership.memberRole < .moderator)
-                            || groupInfo.membership.supportChat != nil)
+                    let showUserSupportChat = groupInfo.membership.supportChat != nil
+                        || (groupInfo.membership.memberActive
+                            && groupInfo.fullGroupPreferences.support.on
+                            && groupInfo.membership.memberRole < .moderator)
 
                     if groupInfo.useRelays {
                         Section {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupChatInfoView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/group/GroupChatInfoView.kt
@@ -629,9 +629,10 @@ fun ModalData.GroupChatInfoLayout(
 
       var anyTopSectionRowShow = false
       val channelLink = groupInfo.groupProfile.publicGroup?.groupLink
-      val showUserSupportChat = groupInfo.membership.memberActive &&
-        ((groupInfo.fullGroupPreferences.support.on && groupInfo.membership.memberRole < GroupMemberRole.Moderator)
-          || groupInfo.membership.supportChat != null)
+      val showUserSupportChat = groupInfo.membership.supportChat != null ||
+        (groupInfo.membership.memberActive
+          && groupInfo.fullGroupPreferences.support.on
+          && groupInfo.membership.memberRole < GroupMemberRole.Moderator)
 
       if (groupInfo.useRelays) {
         SectionView {


### PR DESCRIPTION
## Problem

Unread messages in the user's own support chat ("chat with admins") become permanently unreadable once the user stops being an active member of the group. They keep inflating the profile unread count in the profile picker, and the only way to clear them is `/read user`.

`getUsersInfo` (`Store/Profiles.hs:190-200`) counts every `rcv_new` item joined on `groups`, with no `group_scope_tag` filter, so support-scope messages count towards the profile total. The only place to read them is the "chat with admins" row in the group info screen, gated on:

```kotlin
val showUserSupportChat = groupInfo.membership.memberActive && ...
```

`memberActive` is false for `MemLeft`, `MemRemoved`, `MemRejected`, `MemGroupDeleted`, `MemUnknown` and `MemInvited`. The row disappears, the messages stay unread, and nothing else offers that scope — `ChatView` opens it automatically only while `membership.memberPending`.

## Reproduction

Two CLI clients. Alice creates a group with `/set admission review #team all` and a group link; Bob joins and lands pending review; Alice sends `/_send #1(_support:2) text hello-from-admin`; Alice runs `/rm team bob`. Bob's database then holds:

```
group_member_id  local_display_name  member_status  has_support  unread
2                bob                 removed        1            2

chat_item_id  item_status  item_content_tag  group_scope_tag  scope_member
14            rcv_new      rcvMsgContent     member_support   (NULL)
15            rcv_new      rcvGroupEvent     member_support   (NULL)
```

and the `getUsersInfo` group query returns 2. The scope member id is NULL because `toChatScope` (`Messages.hs:182`) stores `Nothing` for the user's own support chat, which also makes these items hard to find by hand — there is no member row to join against.

Running `/_read chat #1(_support)` on Bob's client afterwards takes the count to 0, so the items are reachable and clearable through the API. Only the UI hides them.

## Fix

Show the support chat whenever one exists, and apply the active-member, group-preference and role checks only to *offering to start* a new one. The truth table changes in exactly one cell: an inactive member who has a support chat now sees it. Active members, moderators and members with no support chat are unaffected.

## Note

The two client edits are a re-association of the existing boolean expression using the same symbols; they have not been compiled here, and the runtime behaviour of the row itself was verified by reading both clients rather than by running them. The core-side facts above are all from an actual reproduction.