### PR TITLE
ui: fix the first chat profile's avatar stored as its description

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/WelcomeView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/WelcomeView.kt
@@ -355,7 +355,7 @@ private fun CreateFirstProfileDesktop(chatModel: ChatModel, close: () -> Unit) {
 
 fun createProfileInNoProfileSetup(displayName: String, image: String? = null, close: () -> Unit) {
   withBGApi {
-    val user = controller.apiCreateActiveUser(null, Profile(displayName.trim(), "", null, image)) ?: return@withBGApi
+    val user = controller.apiCreateActiveUser(null, Profile(displayName.trim(), "", null, image = image)) ?: return@withBGApi
     if (!chatModel.connectedToRemote()) {
       chatModel.localUserCreated.value = true
     }

--- a/plans/2026-09-05-first-profile-avatar.md
+++ b/plans/2026-09-05-first-profile-avatar.md
@@ -1,0 +1,79 @@
+# The first chat profile's avatar is stored as its description
+
+`createProfileInNoProfileSetup` in `views/WelcomeView.kt`.
+
+## The defect
+
+Choosing a profile picture when creating the first chat profile silently loses it. The
+image is written to the profile's **description** instead, so the avatar never appears and
+the bio holds a base64 image that is never displayed either.
+
+## The cause
+
+`Profile`'s parameter order is:
+
+```kotlin
+data class Profile(
+  override val displayName: String,
+  override val fullName: String,
+  override val shortDescr: String?,
+  val description: String? = null,
+  override val image: String? = null,
+  ...
+```
+
+so the fourth positional argument is `description`, not `image`:
+
+```kotlin
+Profile(displayName.trim(), "", null, image)   // -> description = image
+```
+
+Both are `String?`, so this type-checks and there is no warning. Nothing downstream
+validates that a description looks like a description, and the UI simply renders no avatar
+— there is no error to notice.
+
+## Why it survived
+
+The path is awkward to reach. `createProfileInNoProfileSetup` is selected only by the
+`else` branch of `CreateProfile`'s submit, i.e. when `chatModel.localUserCreated.value` is
+not `true`:
+
+```kotlin
+if (chatModel.localUserCreated.value == true) {
+  createProfileInProfiles(...)     // named `image =` — correct
+} else {
+  createProfileInNoProfileSetup(...)   // positional — the bug
+}
+```
+
+Its only caller is the user picker's **"Create chat profile"** row, which is shown when
+`chatModel.desktopNoUserNoRemote` — desktop, with a database but no local user, not
+connected to a remote host. Ordinary onboarding does not go through it, and neither does
+Settings → Add profile.
+
+The sibling constructions are all correct, which is why the bug is isolated:
+`createProfileInProfiles` passes `image = image`, and `createProfileOnboarding` passes no
+image at all.
+
+## The fix
+
+Use the named argument:
+
+```kotlin
+- Profile(displayName.trim(), "", null, image)
++ Profile(displayName.trim(), "", null, image = image)
+```
+
+One word. No behaviour change on any other path.
+
+## Testing
+
+On desktop, with a database but no local chat profile, open the user picker and use
+"Create chat profile". Set a picture and a bio, create, then check the profile: the picture
+must be the avatar and the bio must be the bio. Before the fix the avatar is absent.
+
+## Notes
+
+Found while writing #7329, which adds a fourth `Profile` construction on this screen; that
+one uses `image =` from the start. Kept separate because this defect is pre-existing and
+independent of that feature.


### PR DESCRIPTION
**Problem:** choosing a profile picture when creating the first chat profile silently loses it — the avatar never appears, and the image ends up in the profile's description where it is never displayed either.

**Cause:** `Profile`'s fourth positional parameter is `description`, not `image`, so `Profile(displayName.trim(), "", null, image)` stores the image as the description. Both are `String?`, so it type-checks with no warning.

**Fix:** use the named argument, `image = image`. One word, no other path affected.

Reachable only from the user picker's "Create chat profile" row (desktop, database present but no local user), which is why it survived — ordinary onboarding and Settings → Add profile both take the sibling path that already passes `image =`. Detail in [`plans/2026-09-05-first-profile-avatar.md`](plans/2026-09-05-first-profile-avatar.md).
