### PR TITLE
ui: don't commit profile picker state when the change failed

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ComposeContextProfilePickerView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ComposeContextProfilePickerView.kt
@@ -79,6 +79,7 @@ fun ComposeContextProfilePickerView(
 
   fun changeProfile(newUser: User) {
     withApi {
+      var chatMoved = false
       if (chat.chatInfo is ChatInfo.Direct) {
         val updatedContact = chatModel.controller.apiChangePreparedContactUser(rhId, chat.chatInfo.contact.contactId, newUser.userId)
         if (updatedContact != null) {
@@ -86,6 +87,7 @@ fun ComposeContextProfilePickerView(
           chatModel.controller.appPrefs.incognito.set(false)
           listExpanded.value = false
           chatModel.chatsContext.updateContact(rhId, updatedContact)
+          chatMoved = true
         }
       } else if (chat.chatInfo is ChatInfo.Group) {
         val updatedGroup = chatModel.controller.apiChangePreparedGroupUser(rhId, chat.chatInfo.groupInfo.groupId, newUser.userId)
@@ -94,8 +96,10 @@ fun ComposeContextProfilePickerView(
           chatModel.controller.appPrefs.incognito.set(false)
           listExpanded.value = false
           chatModel.chatsContext.updateGroup(rhId, updatedGroup)
+          chatMoved = true
         }
       }
+      if (!chatMoved) return@withApi
       chatModel.controller.changeActiveUser_(
         rhId = newUser.remoteHostId,
         toUserId = newUser.userId,

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/newchat/NewChatView.kt
@@ -326,7 +326,6 @@ fun ActiveProfilePicker(
         switchingProfile.value = true
         withApi {
           try {
-            appPreferences.incognito.set(false)
             var updatedConn: PendingContactConnection? = null;
 
             if (contactConnection != null) {
@@ -340,6 +339,7 @@ fun ActiveProfilePicker(
             }
 
             if ((contactConnection != null && updatedConn != null) || contactConnection == null) {
+              appPreferences.incognito.set(false)
               controller.changeActiveUser_(
                 rhId = user.remoteHostId,
                 toUserId = user.userId,
@@ -352,15 +352,15 @@ fun ActiveProfilePicker(
                   String.format(generalGetString(MR.strings.switching_profile_error_message), user.chatViewName)
                 )
               }
-            }
 
-            if (updatedConn != null) {
-              withContext(Dispatchers.Main) {
-                chatModel.chatsContext.updateContactConnection(user.remoteHostId, updatedConn)
+              if (updatedConn != null) {
+                withContext(Dispatchers.Main) {
+                  chatModel.chatsContext.updateContactConnection(user.remoteHostId, updatedConn)
+                }
               }
-            }
 
-            close()
+              close()
+            }
           } finally {
             switchingProfile.value = false
           }
@@ -383,9 +383,9 @@ fun ActiveProfilePicker(
         switchingProfile.value = true
         withApi {
           try {
-            appPreferences.incognito.set(true)
             val conn = controller.apiSetConnectionIncognito(rhId, contactConnection.pccConnId, true)
             if (conn != null) {
+              appPreferences.incognito.set(true)
               withContext(Dispatchers.Main) {
                 chatModel.chatsContext.updateContactConnection(rhId, conn)
                 updateShownConnection(conn)


### PR DESCRIPTION
Split out of #7329, where these were found. All pre-existing on master. One theme: **the picker commits state before the call that can fail, and doesn't undo it.**

### 1. The app-wide incognito preference is written before the call that can fail

`newchat/NewChatView.kt`, `ActiveProfilePicker` — both directions, neither rolls back:

```kotlin
appPreferences.incognito.set(false)                   // written unconditionally
updatedConn = controller.apiChangeConnectionUser(...) // returns null on any error
```
```kotlin
appPreferences.incognito.set(true)                    // written unconditionally
val conn = controller.apiSetConnectionIncognito(...)  // returns null on any error
```

Nothing looks wrong at the time, which is why it survived: the row reads `chatModel.showingInvitation.value?.conn?.incognito ?: appPrefs.incognito.get()`, consulting the *connection* first — and that wasn't changed, so the row stays correct. It surfaces on the **next** connection started with `showingInvitation` null, which falls through to the preference. So a failed profile change silently turns the incognito default **off**, and a failed incognito change silently turns it **on**.

### 2. Selecting a profile closes the picker even when the connection didn't move

`close()` and the trailing `updateContactConnection` sat outside the `(contactConnection != null && updatedConn != null) || contactConnection == null` guard that already, correctly, skips the user switch. A failed `apiChangeConnectionUser` — reachable today by tapping a row offline — left the connection on the old profile with the picker dismissed as though it had worked.

### 3. The prepared-chat picker switches profile even when the chat didn't move

`chat/ComposeContextProfilePickerView.kt`, `changeProfile` — `changeActiveUser_` was called outside **both** `updated != null` branches. When `apiChangePreparedContactUser` / `apiChangePreparedGroupUser` returns null, the chat stays on the old profile but the active user is switched anyway, and the post-switch check then passes so no error is shown either. The user is silently moved away from the invitation they were trying to accept, and `changeActiveUser_` reloads chats for the new profile so it disappears from view.

Kotlin only — the iOS twin `throws` rather than returning null, so its outer `catch` already skips the switch.

### Fix

Move each of these inside the branch that runs only when the change actually landed. No behaviour change on any success path. All the APIs involved alert on error themselves, so the failures were already reported; what was wrong is that the picker committed state regardless.

---

**Conflicts with #7329** in `newchat/NewChatView.kt` only (verified with `git merge-tree`): that PR moves this same lambda body into a `selectProfile(user)` function (a pure move) while this one edits it in place. `ComposeContextProfilePickerView.kt` auto-merges cleanly. Resolution is mechanical — apply the same guard inside `selectProfile`. Happy to rebase #7329 on top of this if you'd rather land the bugfix first.

**Not included:** the iOS twins of (2) in `NewChat/NewChatView.swift`. `.onChange(of: selectedProfile)` and `.onChange(of: incognitoEnabled)` do their work inside `if let contactConn = ..., let conn = try await ...` with no `else`, so a nil return leaves `profileSwitchStatus` non-idle **forever** and the picker is stuck behind its spinner and `allowsHitTesting(false)`. Worse symptom than the Kotlin side. Say the word and I'll add them.
