### PR TITLE
fix: maintain the profile unread count by the same rule that seeds it

### DIFF
--- a/apps/ios/Shared/Model/ChatModel.swift
+++ b/apps/ios/Shared/Model/ChatModel.swift
@@ -1412,6 +1412,8 @@ final class Chat: ObservableObject, Identifiable, ChatLike {
         }
     }
 
+    var hasUnread: Bool { unreadTag || (chatInfo.chatSettings?.enableNtfs != MsgFilter.none && supportUnreadCount > 0) }
+
     public static var sampleData: Chat = Chat(chatInfo: ChatInfo.sampleData.direct, chatItems: [])
 }
 

--- a/apps/ios/Shared/Model/ChatModel.swift
+++ b/apps/ios/Shared/Model/ChatModel.swift
@@ -942,7 +942,7 @@ final class ChatModel: ObservableObject {
     func markAllChatItemsRead(_ chatIM: ItemsModel, _ cInfo: ChatInfo) {
         // update preview
         _updateChat(cInfo.id) { chat in
-            self.decreaseUnreadCounter(user: self.currentUser!, chat: chat)
+            self.changeUserUnreadCounter(before: chat.userUnreadCount, after: 0)
             ChatTagsModel.shared.markChatTagRead(chat)
             chat.chatStats = ChatStats()
         }
@@ -967,7 +967,7 @@ final class ChatModel: ObservableObject {
     func clearChat(_ cInfo: ChatInfo) {
         // clear preview
         if let chat = getChat(cInfo.id) {
-            self.decreaseUnreadCounter(user: self.currentUser!, chat: chat)
+            self.changeUserUnreadCounter(before: chat.userUnreadCount, after: 0)
             chat.chatItems = []
             ChatTagsModel.shared.markChatTagRead(chat)
             chat.chatStats = ChatStats()
@@ -1103,26 +1103,26 @@ final class ChatModel: ObservableObject {
 
     func changeUnreadCounter(_ chatIndex: Int, by count: Int, unreadMentions: Int) {
         let wasUnread = chats[chatIndex].unreadTag
+        let userUnreadBefore = chats[chatIndex].userUnreadCount
         let stats = chats[chatIndex].chatStats
         chats[chatIndex].chatStats.unreadCount = stats.unreadCount + count
         chats[chatIndex].chatStats.unreadMentions = stats.unreadMentions + unreadMentions
         ChatTagsModel.shared.updateChatTagRead(chats[chatIndex], wasUnread: wasUnread)
-        changeUnreadCounter(user: currentUser!, by: count)
+        changeUserUnreadCounter(before: userUnreadBefore, after: chats[chatIndex].userUnreadCount)
+    }
+
+    func changeUserUnreadCounter(before: Int, after: Int) {
+        if before != after, let user = currentUser {
+            changeUnreadCounter(user: user, by: after - before)
+        }
     }
 
     func increaseUnreadCounter(user: any UserLike) {
         changeUnreadCounter(user: user, by: 1)
     }
 
-    func decreaseUnreadCounter(user: any UserLike, chat: Chat) {
-        let by = chat.chatInfo.chatSettings?.enableNtfs == .mentions
-                ? chat.chatStats.unreadMentions
-                : chat.chatStats.unreadCount
-        decreaseUnreadCounter(user: user, by: by)
-    }
-
-    func decreaseUnreadCounter(user: any UserLike, by: Int = 1) {
-        changeUnreadCounter(user: user, by: -by)
+    func decreaseUnreadCounter(user: any UserLike) {
+        changeUnreadCounter(user: user, by: -1)
     }
 
     private func changeUnreadCounter(user: any UserLike, by: Int) {
@@ -1136,11 +1136,7 @@ final class ChatModel: ObservableObject {
     func totalUnreadCountForAllUsers() -> Int {
         var unread: Int = 0
         for chat in chats {
-            switch chat.chatInfo.chatSettings?.enableNtfs {
-            case .all: unread += chat.chatStats.unreadCount
-            case .mentions: unread += chat.chatStats.unreadMentions
-            default: ()
-            }
+            unread += chat.userUnreadCount
         }
         for u in users {
             if !u.user.activeUser {
@@ -1272,6 +1268,7 @@ final class ChatModel: ObservableObject {
             if let i = getChatIndex(id) {
                 let removed = chats.remove(at: i)
                 groupId = removed.chatInfo.groupInfo?.groupId
+                changeUserUnreadCounter(before: removed.userUnreadCount, after: 0)
                 ChatTagsModel.shared.removePresetChatTags(removed.chatInfo, removed.chatStats)
                 removeWallpaperFilesFromChat(removed)
             }
@@ -1388,6 +1385,14 @@ final class Chat: ObservableObject, Identifiable, ChatLike {
         case .all: chatStats.unreadChat || chatStats.unreadCount > 0
         case .mentions: chatStats.unreadChat || chatStats.unreadMentions > 0
         default: chatStats.unreadChat
+        }
+    }
+
+    var userUnreadCount: Int {
+        switch chatInfo.chatSettings?.enableNtfs {
+        case .all: chatStats.unreadCount
+        case .mentions: chatStats.unreadMentions
+        default: 0
         }
     }
 

--- a/apps/ios/Shared/Model/SimpleXAPI.swift
+++ b/apps/ios/Shared/Model/SimpleXAPI.swift
@@ -1303,10 +1303,13 @@ func deleteContactChat(_ chat: Chat, chatDeleteMode: ChatDeleteMode = .full(noti
                 ChatModel.shared.removeChat(cInfo.id)
             case .entity:
                 ChatModel.shared.removeChat(cInfo.id)
-                ChatModel.shared.addChat(Chat(
+                let keptChat = Chat(
                     chatInfo: .direct(contact: ct),
-                    chatItems: chat.chatItems
-                ))
+                    chatItems: chat.chatItems,
+                    chatStats: chat.chatStats
+                )
+                ChatModel.shared.addChat(keptChat)
+                ChatModel.shared.changeUserUnreadCounter(before: 0, after: keptChat.userUnreadCount)
             case .messages:
                 ChatModel.shared.removeChat(cInfo.id)
                 ChatModel.shared.addChat(Chat(

--- a/apps/ios/Shared/SimpleXApp.swift
+++ b/apps/ios/Shared/SimpleXApp.swift
@@ -157,7 +157,11 @@ struct SimpleXApp: App {
     private func updateChats() async {
         do {
             let chats = try await apiGetChatsAsync()
-            await MainActor.run { chatModel.updateChats(chats) }
+            let users = try? await listUsersAsync()
+            await MainActor.run {
+                if let users { chatModel.users = users }
+                chatModel.updateChats(chats)
+            }
             if let id = chatModel.chatId,
                let chat = chatModel.getChat(id),
                !NtfManager.shared.navigatingToChat {

--- a/apps/ios/Shared/Views/Chat/ChatView.swift
+++ b/apps/ios/Shared/Views/Chat/ChatView.swift
@@ -3242,6 +3242,7 @@ func updateChatSettings(_ chat: Chat, chatSettings: ChatSettings) {
                 let wasFavorite = chat.chatInfo.chatSettings?.favorite ?? false
                 ChatTagsModel.shared.updateChatFavorite(favorite: chatSettings.favorite, wasFavorite: wasFavorite)
                 let wasUnread = chat.unreadTag
+                let userUnreadBefore = chat.userUnreadCount
                 switch chat.chatInfo {
                 case var .direct(contact):
                     contact.chatSettings = chatSettings
@@ -3252,6 +3253,7 @@ func updateChatSettings(_ chat: Chat, chatSettings: ChatSettings) {
                 default: ()
                 }
                 ChatTagsModel.shared.updateChatTagRead(chat, wasUnread: wasUnread)
+                ChatModel.shared.changeUserUnreadCounter(before: userUnreadBefore, after: chat.userUnreadCount)
             }
         } catch let error {
             logger.error("apiSetChatSettings error \(responseError(error))")

--- a/apps/ios/Shared/Views/ChatList/ChatListView.swift
+++ b/apps/ios/Shared/Views/ChatList/ChatListView.swift
@@ -552,7 +552,7 @@ struct ChatListView: View {
             switch chatTagsModel.activeFilter {
             case let .presetTag(tag): presetTagMatchesChat(tag, chat.chatInfo, chat.chatStats)
             case let .userTag(tag): chat.chatInfo.chatTags?.contains(tag.chatTagId) == true
-            case .unread: chat.unreadTag
+            case .unread: chat.hasUnread
             case .none: true
             }
         }

--- a/apps/ios/Shared/Views/Database/DatabaseView.swift
+++ b/apps/ios/Shared/Views/Database/DatabaseView.swift
@@ -602,6 +602,7 @@ struct DatabaseView: View {
         appFilesCountAndSize = directoryFileCountAndSize(getAppFilesDirectory())
         do {
             let chats = try apiGetChats()
+            if let users = try? listUsers() { m.users = users }
             m.updateChats(chats)
         } catch let error {
             logger.error("apiGetChats: cannot update chats \(responseError(error))")

--- a/apps/ios/Shared/Views/LocalAuth/LocalAuthView.swift
+++ b/apps/ios/Shared/Views/LocalAuth/LocalAuthView.swift
@@ -69,8 +69,8 @@ struct LocalAuthView: View {
                 ItemsModel.shared.chatState.clear()
                 ChatModel.shared.secondaryIM?.reversedChatItems = []
                 ChatModel.shared.secondaryIM?.chatState.clear()
-                m.updateChats([])
                 m.users = []
+                m.updateChats([])
                 _ = kcAppPassword.set(password)
                 _ = kcSelfDestructPassword.remove()
                 await NtfManager.shared.removeAllNotifications()

--- a/apps/ios/product/views/chat-list.md
+++ b/apps/ios/product/views/chat-list.md
@@ -41,7 +41,7 @@ Managed by `ChatTagsModel` and `TagListView`:
 | Filter | PresetTag | Description |
 |---|---|---|
 | All | (none) | No filter, shows all chats |
-| Unread | `.unread` | Chats with unread messages |
+| Unread | `.unread` | Chats with unread messages, or unread support chats unless muted to "mute all" |
 | Favorites | `.favorites` | User-favorited chats |
 | Groups | `.groups` | Group conversations only |
 | Contacts | `.contacts` | Direct contacts only |

--- a/apps/ios/spec/client/chat-list.md
+++ b/apps/ios/spec/client/chat-list.md
@@ -163,7 +163,7 @@ Horizontal scrolling tab bar below the navigation bar. Tabs:
 | Tab | Filter | Shows |
 |-----|--------|-------|
 | All | `nil` | All conversations |
-| Unread | `.unread` | Conversations with unread messages |
+| Unread | `.unread` | Conversations with unread messages, or unread support chats unless muted to "mute all" |
 | Favorites | `.presetTag(.favorites)` | Favorited conversations |
 | Groups | `.presetTag(.groups)` | Group conversations |
 | Contacts | `.presetTag(.contacts)` | Direct conversations |

--- a/apps/multiplatform/android/src/main/java/chat/simplex/app/SimplexApp.kt
+++ b/apps/multiplatform/android/src/main/java/chat/simplex/app/SimplexApp.kt
@@ -97,6 +97,7 @@ class SimplexApp: Application(), LifecycleEventObserver {
               kotlin.runCatching {
                 val currentUserId = chatModel.currentUser.value?.userId
                 val chats = ArrayList(chatController.apiGetChats(chatModel.remoteHostId()))
+                val users = kotlin.runCatching { chatController.listUsers(chatModel.remoteHostId()) }.getOrNull()
                 /** Active user can be changed in background while [ChatController.apiGetChats] is executing */
                 if (chatModel.currentUser.value?.userId == currentUserId) {
                   val currentChatId = chatModel.chatId.value
@@ -105,6 +106,10 @@ class SimplexApp: Application(), LifecycleEventObserver {
                     val indexOfCurrentChat = chats.indexOfFirst { it.id == currentChatId }
                     /** Pass old chatStats because unreadCounter can be changed already while [ChatController.apiGetChats] is executing */
                     if (indexOfCurrentChat >= 0) chats[indexOfCurrentChat] = chats[indexOfCurrentChat].copy(chatStats = oldStats)
+                  }
+                  if (users != null) {
+                    chatModel.users.clear()
+                    chatModel.users.addAll(users)
                   }
                   chatModel.chatsContext.updateChats(chats)
                 }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
@@ -1456,6 +1456,8 @@ data class Chat(
     else -> 0
   }
 
+  val hasUnread: Boolean get() = unreadTag || (chatInfo.chatSettings?.enableNtfs != None && supportUnreadCount > 0)
+
   fun groupFeatureEnabled(feature: GroupFeature): Boolean =
     if (chatInfo is ChatInfo.Group) {
       chatInfo.groupInfo.groupFeatureEnabled(feature)

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/model/ChatModel.kt
@@ -553,15 +553,16 @@ object ChatModel {
             else -> cItem
           }
           val wasUnread = chat.unreadTag
+          val userUnreadBefore = chat.userUnreadCount
           chatsContext.chats[i] = chat.copy(
             chatItems = arrayListOf(newPreviewItem),
             chatStats =
-            if (cItem.meta.itemStatus is CIStatus.RcvNew) {
-              increaseUnreadCounter(rhId, currentUser.value!!)
+            if (cItem.meta.itemStatus is CIStatus.RcvNew)
               chat.chatStats.copy(unreadCount = chat.chatStats.unreadCount + 1, unreadMentions = if (cItem.meta.userMention) chat.chatStats.unreadMentions + 1 else chat.chatStats.unreadMentions)
-            } else
+            else
               chat.chatStats
           )
+          changeUserUnreadCounter(rhId, userUnreadBefore, chatsContext.chats[i].userUnreadCount)
           updateChatTagReadInPrimaryContext(chatsContext.chats[i], wasUnread)
         }
         // pop chat
@@ -621,7 +622,7 @@ object ChatModel {
             chats[i] = chat.copy(chatItems = arrayListOf(cItem))
             if (pItem.isRcvNew && !cItem.isRcvNew) {
               // status changed from New to Read, update counter
-              decreaseCounterInPrimaryContext(rhId, cInfo.id)
+              decreaseCounterInPrimaryContext(rhId, cInfo.id, cItem.meta.userMention)
             }
           }
         } else {
@@ -671,7 +672,7 @@ object ChatModel {
       // update chat list
       if (cInfo.groupChatScope() == null) {
         if (cItem.isRcvNew) {
-          decreaseCounterInPrimaryContext(rhId, cInfo.id)
+          decreaseCounterInPrimaryContext(rhId, cInfo.id, cItem.meta.userMention)
         }
         // update preview
         val i = getChatIndex(rhId, cInfo.id)
@@ -723,7 +724,7 @@ object ChatModel {
           for (item in chatItems.value) {
             if (isRemovedMemberItem(item)) {
               if (item.isRcvNew) {
-                decreaseCounterInPrimaryContext(rhId, groupInfo.id)
+                decreaseCounterInPrimaryContext(rhId, groupInfo.id, item.meta.userMention)
               }
               if (item.isActiveReport) {
                 decreaseGroupReportsCounter(rhId, groupInfo.id)
@@ -768,9 +769,9 @@ object ChatModel {
       // clear preview
       val i = getChatIndex(rhId, cInfo.id)
       if (i >= 0) {
-        decreaseUnreadCounter(rhId, currentUser.value!!, chats[i].chatStats.unreadCount)
         val chatBefore = chats[i]
         chats[i] = chats[i].copy(chatItems = arrayListOf(), chatStats = Chat.ChatStats(), chatInfo = cInfo)
+        changeUserUnreadCounter(rhId, chatBefore.userUnreadCount, chats[i].userUnreadCount)
         markChatTagRead(chatBefore)
       }
       // clear current chat
@@ -841,10 +842,10 @@ object ChatModel {
           val wasUnread = chat.unreadTag
           val unreadCount = if (itemIds != null) chat.chatStats.unreadCount - markedRead else 0
           val unreadMentions = if (itemIds != null) chat.chatStats.unreadMentions - mentionsMarkedRead else 0
-          decreaseUnreadCounter(remoteHostId, currentUser.value!!, chat.chatStats.unreadCount - unreadCount)
           chats[chatIdx] = chat.copy(
             chatStats = chat.chatStats.copy(unreadCount = unreadCount, unreadMentions = unreadMentions)
           )
+          changeUserUnreadCounter(remoteHostId, chat.userUnreadCount, chats[chatIdx].userUnreadCount)
           updateChatTagReadInPrimaryContext(chats[chatIdx], wasUnread)
         }
       }
@@ -886,7 +887,7 @@ object ChatModel {
       return markedRead to mentionsMarkedRead
     }
 
-    private fun decreaseCounterInPrimaryContext(rhId: Long?, chatId: ChatId) {
+    private fun decreaseCounterInPrimaryContext(rhId: Long?, chatId: ChatId, userMention: Boolean) {
       // updates anything only in main ChatView, not GroupReportsView or anything else from the future
       if (secondaryContextFilter != null) return
 
@@ -895,13 +896,15 @@ object ChatModel {
 
       val chat = chats[chatIndex]
       val unreadCount = kotlin.math.max(chat.chatStats.unreadCount - 1, 0)
+      val unreadMentions = if (userMention) kotlin.math.max(chat.chatStats.unreadMentions - 1, 0) else chat.chatStats.unreadMentions
       val wasUnread = chat.unreadTag
-      decreaseUnreadCounter(rhId, currentUser.value!!, chat.chatStats.unreadCount - unreadCount)
       chats[chatIndex] = chat.copy(
         chatStats = chat.chatStats.copy(
           unreadCount = unreadCount,
+          unreadMentions = unreadMentions,
         )
       )
+      changeUserUnreadCounter(rhId, chat.userUnreadCount, chats[chatIndex].userUnreadCount)
       updateChatTagReadInPrimaryContext(chats[chatIndex], wasUnread)
     }
 
@@ -911,6 +914,7 @@ object ChatModel {
       if (i != -1) {
         val chat = chats.removeAt(i)
         groupId = (chat.chatInfo as? ChatInfo.Group)?.groupInfo?.groupId
+        changeUserUnreadCounter(rhId, chat.userUnreadCount, 0)
         removePresetChatTags(chat.chatInfo, chat.chatStats)
         removeWallpaperFilesFromChat(chat)
       }
@@ -984,8 +988,15 @@ object ChatModel {
       changeUnreadCounterInPrimaryContext(rhId, user, 1)
     }
 
-    fun decreaseUnreadCounter(rhId: Long?, user: UserLike, by: Int = 1) {
-      changeUnreadCounterInPrimaryContext(rhId, user, -by)
+    fun changeUserUnreadCounter(rhId: Long?, before: Int, after: Int) {
+      val user = currentUser.value
+      if (user != null && before != after) {
+        changeUnreadCounterInPrimaryContext(rhId, user, after - before)
+      }
+    }
+
+    fun decreaseUnreadCounter(rhId: Long?, user: UserLike) {
+      changeUnreadCounterInPrimaryContext(rhId, user, -1)
     }
 
     private fun changeUnreadCounterInPrimaryContext(rhId: Long?, user: UserLike, by: Int) {
@@ -1425,6 +1436,12 @@ data class Chat(
     All -> chatStats.unreadChat || chatStats.unreadCount > 0
     Mentions -> chatStats.unreadChat || chatStats.unreadMentions > 0
     else -> chatStats.unreadChat
+  }
+
+  val userUnreadCount: Int get() = when (chatInfo.chatSettings?.enableNtfs) {
+    All -> chatStats.unreadCount
+    Mentions -> chatStats.unreadMentions
+    else -> 0
   }
 
   val id: String get() = chatInfo.id

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListNavLinkView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListNavLinkView.kt
@@ -977,21 +977,19 @@ fun updateChatSettings(remoteHostId: Long?, chatInfo: ChatInfo, chatSettings: Ch
       else -> false
     }
     if (res && newChatInfo != null) {
-      val chat = chatModel.getChat(chatInfo.id)
-      val wasUnread = chat?.unreadTag ?: false
       val wasFavorite = chatInfo.chatSettings?.favorite ?: false
       chatModel.updateChatFavorite(favorite = chatSettings.favorite, wasFavorite)
       withContext(Dispatchers.Main) {
+        val chat = chatModel.getChat(chatInfo.id)
         chatModel.chatsContext.updateChatInfo(remoteHostId, newChatInfo)
+        val updatedChat = chatModel.getChat(chatInfo.id)
+        if (chat != null && updatedChat != null) {
+          chatModel.chatsContext.changeUserUnreadCounter(remoteHostId, chat.userUnreadCount, updatedChat.userUnreadCount)
+          chatModel.chatsContext.updateChatTagReadInPrimaryContext(updatedChat, chat.unreadTag)
+        }
       }
       if (chatSettings.enableNtfs == MsgFilter.None) {
         ntfManager.cancelNotificationsForChat(chatInfo.id)
-      }
-      val updatedChat = chatModel.getChat(chatInfo.id)
-      if (updatedChat != null) {
-        withContext(Dispatchers.Main) {
-          chatModel.chatsContext.updateChatTagReadInPrimaryContext(updatedChat, wasUnread)
-        }
       }
       val current = currentState?.value
       if (current != null) {

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/ChatListView.kt
@@ -1476,7 +1476,7 @@ private fun filtered(chat: Chat, activeFilter: ActiveFilter?): Boolean =
   when (activeFilter) {
     is ActiveFilter.PresetTag -> presetTagMatchesChat(activeFilter.tag, chat.chatInfo, chat.chatStats)
     is ActiveFilter.UserTag -> chat.chatInfo.chatTags?.contains(activeFilter.tag.chatTagId) ?: false
-    is ActiveFilter.Unread -> chat.unreadTag
+    is ActiveFilter.Unread -> chat.hasUnread
     else -> true
   }
 

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/UserPicker.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chatlist/UserPicker.kt
@@ -105,7 +105,7 @@ fun UserPicker(
             for (i in 0 until minOf(users.size, updatedUsers.size)) {
               val prev = updatedUsers[i].user
               val next = users[i].user
-              if (prev.userId != next.userId || prev.activeUser != next.activeUser || prev.chatViewName != next.chatViewName || prev.image != next.image) {
+              if (prev.userId != next.userId || prev.activeUser != next.activeUser || prev.chatViewName != next.chatViewName || prev.image != next.image || updatedUsers[i].unreadCount != users[i].unreadCount) {
                 same = false
                 break
               }

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/database/DatabaseView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/database/DatabaseView.kt
@@ -834,6 +834,11 @@ private fun afterSetCiTTL(
       withContext(Dispatchers.Main) {
         // this is using current remote host on purpose - if it changes during update, it will load correct chats
         val chats = m.controller.apiGetChats(m.remoteHostId())
+        val users = kotlin.runCatching { m.controller.listUsers(m.remoteHostId()) }.getOrNull()
+        if (users != null) {
+          chatModel.users.clear()
+          chatModel.users.addAll(users)
+        }
         chatModel.chatsContext.updateChats(chats)
       }
     } catch (e: Exception) {

--- a/apps/multiplatform/product/views/chat-list.md
+++ b/apps/multiplatform/product/views/chat-list.md
@@ -65,7 +65,7 @@ Managed by `chatModel.userTags`, `chatModel.presetTags`, and `chatModel.activeCh
 | Business | `BUSINESS` | Work | Business chat conversations |
 | Notes | `NOTES` | Folder | Notes to self |
 | Custom tags | `UserTag(ChatTag)` | Label/emoji | User-created tags with custom emoji and name |
-| Unread | `ActiveFilter.Unread` | Filter list icon | Chats with unread messages (toggle via filter button) |
+| Unread | `ActiveFilter.Unread` | Filter list icon | Chats with unread messages, or unread support chats unless muted to "mute all" (toggle via filter button) |
 
 Display logic:
 - When collapsible preset tags exceed 3 total (with user tags), they collapse into a `CollapsedTagsFilterView` dropdown menu

--- a/apps/multiplatform/spec/client/chat-list.md
+++ b/apps/multiplatform/spec/client/chat-list.md
@@ -143,7 +143,7 @@ The `filteredChats` function (line ~1188) applies filters in this order:
 3. **Active filter:**
    - `PresetTag`: Matches chat type and characteristics (e.g., `CONTACTS` filters `ChatInfo.Direct`, `GROUPS` filters `ChatInfo.Group`).
    - `UserTag`: Matches chats whose `chatTags` contain the tag ID.
-   - `Unread`: Matches chats with `unreadCount > 0` or `unreadChat == true`.
+   - `Unread`: Matches `Chat.hasUnread` — a chat marked unread by hand, unread messages as the chat's notification setting counts them, or unread support chats unless the chat is muted to "mute all".
 
 ### Search Bar
 


### PR DESCRIPTION
Split out of #7340, which is now the filter button highlight alone.

## Problem

The per-profile unread count in the profile picker is seeded by `getUsersInfo` and then maintained client-side, but the two use different rules, so the badge drifts from what the chats actually hold and never recovers until the count is re-seeded (app restart or user switch).

`getUsersInfo` (`Store/Profiles.hs`) counts a group's unread items when the group is unmuted, or its mentions when it is set to mentions-only. The client incremented and decremented on different conditions, so muting, unmuting, marking read, deleting a chat and switching scopes each moved the badge by an amount the seed would not have produced.

## Fix

Give the rule one name and report it consistently. `Chat.userUnreadCount` is what a chat contributes — every unread item when unmuted, only unread mentions when mentions-only, nothing when muted — and the places that change a chat's unread state now report that value before and after, so the count moves by the difference rather than by a locally guessed delta. `changeUserUnreadCounter` applies it.

Covered: adding items, the mark-read helpers, removing a chat, and the notification settings toggle, which previously stranded a count when a chat was muted while it still had unread items. `decreaseCounterInPrimaryContext` also decrements `unreadMentions`, which it did not before, so a mentions-only chat no longer leaves its mentions behind.

The second commit brings the unread *filter* into line with the same idea: a group where someone is waiting in a support chat has something to read and the chat list row already flags it, but the filter skipped it, because `chatStats.unreadCount` is filled by a query scoped to the main conversation. It now matches on `Chat.hasUnread`, gated so a fully muted group stays out — matching what the profile count does with that group.

Both platforms, plus the profile picker's staleness check, which compared everything about a user except the count.

## Note

#7340 is independent to compile but related in behaviour: the highlight there reads this per-profile count, so it only lights up correctly once this lands.