### PR TITLE
android: show contact and group avatars in message notifications

### DIFF
--- a/apps/multiplatform/android/src/main/java/chat/simplex/app/model/NtfManager.android.kt
+++ b/apps/multiplatform/android/src/main/java/chat/simplex/app/model/NtfManager.android.kt
@@ -109,9 +109,10 @@ object NtfManager {
     val title = if (previewMode == NotificationPreviewMode.HIDDEN.name) generalGetString(MR.strings.notification_preview_somebody) else displayName
     val content = if (previewMode != NotificationPreviewMode.MESSAGE.name) generalGetString(MR.strings.notification_preview_new_message) else msgText
     val largeIcon = when {
-      actions.isEmpty() -> null
-      image == null || previewMode == NotificationPreviewMode.HIDDEN.name -> BitmapFactory.decodeResource(context.resources, R.drawable.icon)
-      else -> base64ToBitmap(image).asAndroidBitmap()
+      // no avatar to show - keep the app icon for notifications with actions, and no large icon otherwise
+      image == null || previewMode == NotificationPreviewMode.HIDDEN.name ->
+        if (actions.isEmpty()) null else BitmapFactory.decodeResource(context.resources, R.drawable.icon)
+      else -> base64ToBitmap(image).asAndroidBitmap().clipToCircle()
     }
     val builder = NotificationCompat.Builder(context, MessageChannel)
       .setContentTitle(title)

--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/platform/NtfManager.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/platform/NtfManager.kt
@@ -44,7 +44,7 @@ abstract class NtfManager {
               chatModel.chatId.value != cInfo.id ||
               chatModel.remoteHostId() != rhId)
     ) {
-      displayNotification(user = user, chatId = cInfo.id, displayName = cInfo.displayName, msgText = hideSecrets(cItem, cInfo.isChannel))
+      displayNotification(user = user, chatId = cInfo.id, displayName = cInfo.displayName, msgText = hideSecrets(cItem, cInfo.isChannel), image = cInfo.image)
     }
   }
 

--- a/apps/multiplatform/spec/services/notifications.md
+++ b/apps/multiplatform/spec/services/notifications.md
@@ -90,6 +90,7 @@ Channel creation happens in `createNtfChannelsMaybeShowAlert()` ([line 298](../.
 [Line 102](../../android/src/main/java/chat/simplex/app/model/NtfManager.android.kt#L102):
 
 - Uses `NotificationCompat.Builder` with `MessageChannel`.
+- Sets the chat avatar as the large icon, clipped to a circle -- the contact's profile image for direct chats, the group's image for groups. No large icon is set when the chat has no image or `NotificationPreviewMode.HIDDEN` is set, except for notifications with action buttons, which fall back to the app icon.
 - Groups notifications using `MessageGroup` with `GROUP_ALERT_CHILDREN` behavior.
 - Applies rate limiting: silent mode if notification for the same `(userId, chatId)` was shown within 30 seconds (`msgNtfTimeoutMs`).
 - Creates a group summary notification ([line 142](../../android/src/main/java/chat/simplex/app/model/NtfManager.android.kt#L142)) with `setGroupSummary(true)`.


### PR DESCRIPTION
opening this to accompany #7441. Per the contributing guide I'd like to
confirm the approach is acceptable before marking it ready, since it changes what is
shown in notifications.

Closes #7441

## Problem

Message notifications only ever show the SimpleX logo, so every notification looks
identical and you can't tell who messaged at a glance.

The avatar is suppressed in two places, both dating back to #1129 (which added large
icons only for contact requests):

1. `notifyMessageReceived` in `common/.../platform/NtfManager.kt` never passes
   `cInfo.image` through to `displayNotification`.
2. The Android builder in `android/.../model/NtfManager.android.kt` discards the large
   icon whenever the notification has no action buttons, which is always true for a
   plain message.

## Change (3 files, ~6 lines)

1. **`NtfManager.kt`** - forward the chat image: `displayNotification(..., image = cInfo.image)`.
   The `image: String?` parameter already exists on the abstract signature.
2. **`NtfManager.android.kt`** - the `actions` check now governs only the *fallback*,
   not whether an avatar is shown. When an image is present it is used as the large
   icon, clipped with the existing `Bitmap.clipToCircle()` helper (already used by
   `CallService`).
3. **`spec/services/notifications.md`** - one line documenting the new behaviour.

## Behaviour preserved

- `NotificationPreviewMode.HIDDEN` - no avatar, as before.
- Chats with no profile image - no large icon, as before.
- Contact-request notifications - still fall back to the app icon.
- Direct chats use the contact image; groups use the group image. Works for both
  direct and group message notifications.