### PR TITLE
ui: use backward compatible Java api in stripFormattedTextLink

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/TextItemView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/item/TextItemView.kt
@@ -622,7 +622,7 @@ fun stripFormattedTextLink(ft: List<FormattedText>?, link: String): List<Formatt
   val i = result.lastIndex
   if (i >= 0 && result[i].format == null && result[i].text.endsWith("\n")) {
     result[i] = FormattedText(result[i].text.dropLast(1), null)
-    if (result[i].text.isEmpty()) result.removeLast()
+    if (result[i].text.isEmpty()) result.removeAt(result.lastIndex)
   }
   return result.ifEmpty { null }
 }


### PR DESCRIPTION
Fixes a crash when showing a message with a chat link where the text before the link ends with markdown formatting (e.g. `*hi*`). Reported in 7.0.1 on Android 10:

```
java.lang.NoSuchMethodError: No interface method removeLast()Ljava/lang/Object; in class Ljava/util/List; or its super classes (declaration of 'java.util.List' appears in /apex/com.android.runtime/javalib/core-oj.jar)
    at chat.simplex.common.views.chat.item.TextItemViewKt.stripFormattedTextLink(TextItemView.kt:625)
    at chat.simplex.common.views.chat.item.TextItemViewKt.MarkdownText-PQrcpis(TextItemView.kt:151)
    at chat.simplex.common.views.chat.item.FramedItemViewKt.FramedItemView$ciQuotedMsgTextView(FramedItemView.kt:60)
```

`MutableList.removeLast()` resolves to `java.util.List.removeLast()` when compiled with JDK 21. That method only exists from API 35, so it throws on Android below 15.

#6839 changed the other `removeLast()` in this function but missed this one.
