### PR TITLE
core: archive reports when removing member with messages

### DIFF
--- a/plans/2026-09-08-archive-reports-on-member-removal.md
+++ b/plans/2026-09-08-archive-reports-on-member-removal.md
@@ -73,7 +73,9 @@ Both call sites inline the two lines rather than sharing a new function. This ma
 
 ## Testing
 
-`testGroupMemberReportsRemoveMember` (`tests/ChatTests/Groups.hs`) covers both defects in one scenario: cath reports bob's message, bob reports cath's message, then alice removes bob with messages. It asserts that **two** reports are archived (`#jokes: 2 messages deleted by user`) — the one about bob and the one filed by him — and that the reporter's own copy is archived on her device too.
+`testGroupMemberReportsRemoveMember` (`tests/ChatTests/Groups.hs`) covers both defects in one scenario: cath reports bob's message, bob reports cath's message, then alice removes bob with messages. It asserts that **two** reports are archived (`#jokes: 2 messages deleted by user`) — the one about bob and the one filed by him — which is the assertion that fails without the `OR group_member_id = ?` branch, since only one id would be emitted and the badge would stick.
+
+Note that bob's own report row does not survive as marked-deleted: reports live in a member-support scope, and `chat_items.group_scope_group_member_id` is `ON DELETE CASCADE`, so removing bob's member record deletes the row in his scope. Cath's report, in her own scope, remains archived. Both outcomes leave zero active reports, which is what the badge must agree with.
 
 Regression coverage relied on: `remove member with messages (full deletion is enabled)`, `remove member with messages mark deleted`, `remove member - delete messages of left/removed members`, and `should send report to group owner, admins and moderators, but not other users`.
 

--- a/plans/2026-09-08-archive-reports-on-member-removal.md
+++ b/plans/2026-09-08-archive-reports-on-member-removal.md
@@ -1,0 +1,83 @@
+# Archive Reports When Removing a Member With Messages
+
+## Context
+
+"Remove member and delete messages" left reports untouched. Moderating a single message already archives the reports about it; removing the member who sent those messages did not, so reports stayed in the moderators' list pointing at messages that no longer existed.
+
+Two distinct defects, both user-visible:
+
+1. **Reports about the removed member survived.** They stayed active in the reports list and in the badge count.
+2. **The reports badge got stuck.** After removing a member, the badge could show a non-zero count while the reports list was empty.
+
+**Root cause (1).** The removal path (`Commands.hs:3174`, `Subscriber.hs:3657`) calls only `deleteGroupMembersCIs` / `markGroupMembersCIsDeleted`, which reach the removed member's *own* chat items via `group_member_id = ?` (`markMemberCIsDeleted`, `Store/Messages.hs:2963`; `deleteMemberCIs`, `Store/Messages.hs:2862`). A report about that member is authored by the *reporter*, so it carries a different `group_member_id` and is never matched. The moderation path does not have this gap — `delGroupChatItems` (`Commands.hs:4160`) and `archiveMessageReports` (`Subscriber.hs:2411`) call `markMessageReportsDeleted` and emit `CEvtGroupChatItemsDeleted`.
+
+**Root cause (2).** Reports *filed by* the removed member are his own items, so `markMemberCIsDeleted` / `deleteMemberCIs` did archive them — silently, with no event. `getGroupReportsCount_` (`Store/Messages.hs:1744`) counts received, non-deleted reports, so those rows were being counted before removal and vanished from the count afterwards, but nothing told the client. `removeMemberItems` (`ChatModel.kt:699`) cannot compensate: it walks the primary context's `chatItems`, and reports live in a member-support scope, so they are never in that list. Defect (2) predates this change; fixing (1) made it visible, because the list could now empty out while the badge stayed high.
+
+## Solution Summary
+
+Add `markMemberReportsDeleted` (`Store/Messages.hs:3028`), mirroring `markMessageReportsDeleted` but keyed on the member rather than on one message:
+
+```sql
+WHERE user_id = ? AND group_id = ? AND msg_content_tag = ? AND item_deleted = ?
+  AND (quoted_member_id = ? OR group_member_id = ?)
+RETURNING chat_item_id;
+```
+
+Call it from both `deleteMessages` helpers — the local command path and `xGrpMemDel` on receiving clients — and emit `CEvtGroupChatItemsDeleted` with the returned ids, so every side archives symmetrically and the badge updates without a reload.
+
+## Technical Design
+
+### Why key on `quoted_member_id`
+
+`quoted_member_id` is denormalised onto the report row at insert (`Store/Messages.hs:603`, populated from the incoming `MsgRef`), not resolved by joining the quoted message. Deleting the member's messages therefore cannot affect the predicate — verified against the real schema by deleting the message first and confirming the report still matches.
+
+The alternative — a subquery over the member's stored `shared_msg_id`s, mirroring `markMessageReportsDeleted`'s key exactly — was rejected: it requires running before the member's items are deleted under full-delete, and only covers messages still stored locally.
+
+### Why the `OR group_member_id = ?` branch
+
+This is the fix for defect (2). It adds the removed member's own reports to the returned ids so the emitted event decrements the badge for them.
+
+**It changes no database state.** Those rows are already marked (or physically deleted) moments later by `markMemberCIsDeleted` / `deleteMemberCIs`, which carry no `item_deleted` filter and overwrite the same columns. Verified by running both paths with and without the branch and diffing the final table: identical on both the mark-delete and full-delete paths. The branch exists solely to widen the event payload.
+
+The net effect is that the only DB-state change in this diff is: reports about the removed member get archived.
+
+### Why the event is required
+
+Without `CEvtGroupChatItemsDeleted`, the rows would be archived correctly but the badge would not move: `updateGroup` → `updateChat` → `updateChatInfo` (`ChatModel.kt:415`) replaces only `chatInfo` and never `chatStats`, so `reportsCount` is not refreshed by the removal response. The client would show a stale count until a full chat-list reload. This is also why the archiving cannot simply be pushed down into `deleteGroupMemberCIs_` / `markGroupMemberCIsDeleted_` — the shared choke point both paths funnel through — since those are `IO` inside `withStore'` and cannot emit.
+
+The existing handler `groupChatItemsDeleted` (`SimpleXAPI.kt:3550`) already decrements per returned id, so no client change is needed.
+
+### Ordering
+
+The archiving runs **before** the member's items are deleted. It has to: the member's own reports must still be active to be matched.
+
+The trade-off is that a store error in new code can now abort the removal after `x.grp.mem.del` has been sent. This was accepted deliberately. `deleteMessages` already sits in a fallible sequence (`sendGroupMessages` → `saveSndChatItems` → `deleteMessages`), so this adds one more store operation to an already-exposed path rather than creating a new class of risk. The alternative — a separate read-only `SELECT` of the member's report ids before deletion, with the `UPDATE` after — is more code for the same outcome.
+
+### Why no `item_sent` filter
+
+`markMessageReportsDeleted` has none, and the existing moderation test asserts that the reporter's own sent report is marked on their device. Filtering to `item_sent = 0` would leave the reporter's copy active — the original bug, relocated.
+
+This means ids for sent reports can reach the counter, which counts only received ones. It is not reachable harmfully: filing a report requires `memberRole == GroupMemberRole.Member` exactly (`ChatItemView.kt:493`), while removing a member requires `>= GRAdmin`, so no remover can hold a self-authored report; and on a plain member's device the count is already 0, where `coerceAtLeast(0)` absorbs it. The one residual case is a member promoted to moderator after filing a report — identical in the moderation path, and out of scope here.
+
+### Inlined rather than a shared helper
+
+Both call sites inline the two lines rather than sharing a new function. This matches how the codebase already handles exactly this pattern: `Commands.hs:4160` inlines it, and `Subscriber.hs:2411` uses a local `where` helper. Neither introduces a shared top-level function. The Subscriber side needs no `forM`/`concat`, having a single member.
+
+## Locality
+
+- Five files. `Library/Internal.hs` untouched.
+- `deleteMessages` has three call sites, all `when withMessages`-gated, so no other command or event reaches the new code.
+- No protocol or type surface change — the existing `CEvtGroupChatItemsDeleted` is reused, so `Controller.hs`, the generated bot API docs, and the TypeScript/Python types are untouched.
+- Groups with no reports return an empty id list, `unless (null ciIds)` suppresses the event, and behaviour is byte-identical. This is what keeps the pre-existing `messages=on` tests passing.
+- `chat_query_plans.txt` gains exactly one entry (verified by set comparison against master, not by reading the diff).
+
+## Testing
+
+`testGroupMemberReportsRemoveMember` (`tests/ChatTests/Groups.hs`) covers both defects in one scenario: cath reports bob's message, bob reports cath's message, then alice removes bob with messages. It asserts that **two** reports are archived (`#jokes: 2 messages deleted by user`) — the one about bob and the one filed by him — and that the reporter's own copy is archived on her device too.
+
+Regression coverage relied on: `remove member with messages (full deletion is enabled)`, `remove member with messages mark deleted`, `remove member - delete messages of left/removed members`, and `should send report to group owner, admins and moderators, but not other users`.
+
+## Known limitations
+
+- **Removing a member destroys the reports they filed.** If a member reports abuse and is later removed for unrelated reasons, their report disappears from the moderators' list. This is pre-existing behaviour of `markMemberCIsDeleted`; this change only makes the badge agree with it. Whether reports should outlive their author is a separate product decision.
+- **Counter over-decrement for sent reports** in the promoted-member case described above, shared with the moderation path. A proper fix belongs with `getGroupReportsCount_`, not here.

--- a/src/Simplex/Chat/Library/Commands.hs
+++ b/src/Simplex/Chat/Library/Commands.hs
@@ -3175,7 +3175,8 @@ processChatCommand cxt nm = \case
         if groupFeatureUserAllowed SGFFullDelete gInfo
           then deleteGroupMembersCIs user gInfo ms
           else markGroupMembersCIsDeleted user gInfo ms membership
-        archiveMembersReports user gInfo ms membership True
+        ciIds <- concat <$> withStore' (\db -> forM ms $ \m -> markMemberReportsDeleted db user gInfo m membership)
+        unless (null ciIds) $ toView $ CEvtGroupChatItemsDeleted user gInfo ciIds True (Just membership)
   APILeaveGroup groupId -> withUser $ \user@User {userId} -> do
     gInfo@GroupInfo {membership} <- withFastStore $ \db -> getGroupInfo db cxt user groupId
     filesInfo <- withFastStore' $ \db -> getGroupFileInfo db user gInfo

--- a/src/Simplex/Chat/Library/Commands.hs
+++ b/src/Simplex/Chat/Library/Commands.hs
@@ -3172,10 +3172,10 @@ processChatCommand cxt nm = \case
                 else void $ deleteOrUpdateMemberRecordIO db user gInfo m
               pure m {memberStatus = GSMemRemoved}
       deleteMessages user gInfo@GroupInfo {membership} ms = do
-        archiveMembersReports user gInfo ms membership True
         if groupFeatureUserAllowed SGFFullDelete gInfo
           then deleteGroupMembersCIs user gInfo ms
           else markGroupMembersCIsDeleted user gInfo ms membership
+        archiveMembersReports user gInfo ms membership True
   APILeaveGroup groupId -> withUser $ \user@User {userId} -> do
     gInfo@GroupInfo {membership} <- withFastStore $ \db -> getGroupInfo db cxt user groupId
     filesInfo <- withFastStore' $ \db -> getGroupFileInfo db user gInfo

--- a/src/Simplex/Chat/Library/Commands.hs
+++ b/src/Simplex/Chat/Library/Commands.hs
@@ -3172,11 +3172,11 @@ processChatCommand cxt nm = \case
                 else void $ deleteOrUpdateMemberRecordIO db user gInfo m
               pure m {memberStatus = GSMemRemoved}
       deleteMessages user gInfo@GroupInfo {membership} ms = do
+        ciIds <- concat <$> withStore' (\db -> forM ms $ \m -> markMemberReportsDeleted db user gInfo m membership)
+        unless (null ciIds) $ toView $ CEvtGroupChatItemsDeleted user gInfo ciIds True (Just membership)
         if groupFeatureUserAllowed SGFFullDelete gInfo
           then deleteGroupMembersCIs user gInfo ms
           else markGroupMembersCIsDeleted user gInfo ms membership
-        ciIds <- concat <$> withStore' (\db -> forM ms $ \m -> markMemberReportsDeleted db user gInfo m membership)
-        unless (null ciIds) $ toView $ CEvtGroupChatItemsDeleted user gInfo ciIds True (Just membership)
   APILeaveGroup groupId -> withUser $ \user@User {userId} -> do
     gInfo@GroupInfo {membership} <- withFastStore $ \db -> getGroupInfo db cxt user groupId
     filesInfo <- withFastStore' $ \db -> getGroupFileInfo db user gInfo

--- a/src/Simplex/Chat/Library/Commands.hs
+++ b/src/Simplex/Chat/Library/Commands.hs
@@ -3171,9 +3171,11 @@ processChatCommand cxt nm = \case
                 then void $ fullyDeleteMemberRecordIO db user gInfo m
                 else void $ deleteOrUpdateMemberRecordIO db user gInfo m
               pure m {memberStatus = GSMemRemoved}
-      deleteMessages user gInfo@GroupInfo {membership} ms
-        | groupFeatureUserAllowed SGFFullDelete gInfo = deleteGroupMembersCIs user gInfo ms
-        | otherwise = markGroupMembersCIsDeleted user gInfo ms membership
+      deleteMessages user gInfo@GroupInfo {membership} ms = do
+        archiveMembersReports user gInfo ms membership True
+        if groupFeatureUserAllowed SGFFullDelete gInfo
+          then deleteGroupMembersCIs user gInfo ms
+          else markGroupMembersCIsDeleted user gInfo ms membership
   APILeaveGroup groupId -> withUser $ \user@User {userId} -> do
     gInfo@GroupInfo {membership} <- withFastStore $ \db -> getGroupInfo db cxt user groupId
     filesInfo <- withFastStore' $ \db -> getGroupFileInfo db user gInfo

--- a/src/Simplex/Chat/Library/Internal.hs
+++ b/src/Simplex/Chat/Library/Internal.hs
@@ -647,14 +647,6 @@ markGroupMembersCIsDeleted user gInfo members byGroupMember = do
   filesInfo <- withStore' $ \db -> fmap concat $ forM members $ \m -> markGroupMemberCIsDeleted_ db user gInfo m byGroupMember deletedTs
   cancelFilesInProgress user filesInfo
 
--- Reports about a member's messages are authored by the reporter, so deleting the member's own
--- chat items never reaches them - they have to be archived separately, as moderation does.
-archiveMembersReports :: User -> GroupInfo -> [GroupMember] -> GroupMember -> Bool -> CM ()
-archiveMembersReports user gInfo members byGroupMember byUser = do
-  deletedTs <- liftIO getCurrentTime
-  ciIds <- concat <$> withStore' (\db -> forM members $ \m -> markMemberReportsDeleted db user gInfo m byGroupMember deletedTs)
-  unless (null ciIds) $ toView $ CEvtGroupChatItemsDeleted user gInfo ciIds byUser (Just byGroupMember)
-
 markGroupMemberCIsDeleted_ :: DB.Connection -> User -> GroupInfo -> GroupMember -> GroupMember -> UTCTime -> IO [CIFileInfo]
 markGroupMemberCIsDeleted_ db user gInfo member byGroupMember deletedTs = do
   fs <- getGroupMemberFileInfo db user gInfo member

--- a/src/Simplex/Chat/Library/Internal.hs
+++ b/src/Simplex/Chat/Library/Internal.hs
@@ -647,6 +647,14 @@ markGroupMembersCIsDeleted user gInfo members byGroupMember = do
   filesInfo <- withStore' $ \db -> fmap concat $ forM members $ \m -> markGroupMemberCIsDeleted_ db user gInfo m byGroupMember deletedTs
   cancelFilesInProgress user filesInfo
 
+-- Reports about a member's messages are authored by the reporter, so deleting the member's own
+-- chat items never reaches them - they have to be archived separately, as moderation does.
+archiveMembersReports :: User -> GroupInfo -> [GroupMember] -> GroupMember -> Bool -> CM ()
+archiveMembersReports user gInfo members byGroupMember byUser = do
+  deletedTs <- liftIO getCurrentTime
+  ciIds <- concat <$> withStore' (\db -> forM members $ \m -> markMemberReportsDeleted db user gInfo m byGroupMember deletedTs)
+  unless (null ciIds) $ toView $ CEvtGroupChatItemsDeleted user gInfo ciIds byUser (Just byGroupMember)
+
 markGroupMemberCIsDeleted_ :: DB.Connection -> User -> GroupInfo -> GroupMember -> GroupMember -> UTCTime -> IO [CIFileInfo]
 markGroupMemberCIsDeleted_ db user gInfo member byGroupMember deletedTs = do
   fs <- getGroupMemberFileInfo db user gInfo member

--- a/src/Simplex/Chat/Library/Subscriber.hs
+++ b/src/Simplex/Chat/Library/Subscriber.hs
@@ -3655,11 +3655,11 @@ processAgentMessageConn cxt user@User {userId} corrId agentConnId agentMessage =
           groupMsgToView cInfo ci
         deleteMessages :: GroupInfo -> GroupMember -> CM ()
         deleteMessages gInfo' delMem = do
+          ciIds <- withStore' $ \db -> markMemberReportsDeleted db user gInfo' delMem m
+          unless (null ciIds) $ toView $ CEvtGroupChatItemsDeleted user gInfo' ciIds False (Just m)
           if groupFeatureMemberAllowed SGFFullDelete m gInfo'
             then deleteGroupMemberCIs user gInfo' delMem
             else markGroupMemberCIsDeleted user gInfo' delMem m
-          ciIds <- withStore' $ \db -> markMemberReportsDeleted db user gInfo' delMem m
-          unless (null ciIds) $ toView $ CEvtGroupChatItemsDeleted user gInfo' ciIds False (Just m)
         forwardToMember :: GroupMember -> CM ()
         forwardToMember member =
           let fwd = GrpMsgForward {fwdSender = FwdMember (memberId' m) (memberShortenedName m), fwdBrokerTs = brokerTs}

--- a/src/Simplex/Chat/Library/Subscriber.hs
+++ b/src/Simplex/Chat/Library/Subscriber.hs
@@ -3654,9 +3654,11 @@ processAgentMessageConn cxt user@User {userId} corrId agentConnId agentMessage =
           (ci, cInfo) <- saveRcvChatItemNoParse user (CDGroupRcv gi' scopeInfo m') msg' brokerTs (CIRcvGroupEvent gEvent)
           groupMsgToView cInfo ci
         deleteMessages :: GroupInfo -> GroupMember -> CM ()
-        deleteMessages gInfo' delMem
-          | groupFeatureMemberAllowed SGFFullDelete m gInfo' = deleteGroupMemberCIs user gInfo' delMem
-          | otherwise = markGroupMemberCIsDeleted user gInfo' delMem m
+        deleteMessages gInfo' delMem = do
+          archiveMembersReports user gInfo' [delMem] m False
+          if groupFeatureMemberAllowed SGFFullDelete m gInfo'
+            then deleteGroupMemberCIs user gInfo' delMem
+            else markGroupMemberCIsDeleted user gInfo' delMem m
         forwardToMember :: GroupMember -> CM ()
         forwardToMember member =
           let fwd = GrpMsgForward {fwdSender = FwdMember (memberId' m) (memberShortenedName m), fwdBrokerTs = brokerTs}

--- a/src/Simplex/Chat/Library/Subscriber.hs
+++ b/src/Simplex/Chat/Library/Subscriber.hs
@@ -3655,10 +3655,10 @@ processAgentMessageConn cxt user@User {userId} corrId agentConnId agentMessage =
           groupMsgToView cInfo ci
         deleteMessages :: GroupInfo -> GroupMember -> CM ()
         deleteMessages gInfo' delMem = do
-          archiveMembersReports user gInfo' [delMem] m False
           if groupFeatureMemberAllowed SGFFullDelete m gInfo'
             then deleteGroupMemberCIs user gInfo' delMem
             else markGroupMemberCIsDeleted user gInfo' delMem m
+          archiveMembersReports user gInfo' [delMem] m False
         forwardToMember :: GroupMember -> CM ()
         forwardToMember member =
           let fwd = GrpMsgForward {fwdSender = FwdMember (memberId' m) (memberShortenedName m), fwdBrokerTs = brokerTs}

--- a/src/Simplex/Chat/Library/Subscriber.hs
+++ b/src/Simplex/Chat/Library/Subscriber.hs
@@ -3658,7 +3658,8 @@ processAgentMessageConn cxt user@User {userId} corrId agentConnId agentMessage =
           if groupFeatureMemberAllowed SGFFullDelete m gInfo'
             then deleteGroupMemberCIs user gInfo' delMem
             else markGroupMemberCIsDeleted user gInfo' delMem m
-          archiveMembersReports user gInfo' [delMem] m False
+          ciIds <- withStore' $ \db -> markMemberReportsDeleted db user gInfo' delMem m
+          unless (null ciIds) $ toView $ CEvtGroupChatItemsDeleted user gInfo' ciIds False (Just m)
         forwardToMember :: GroupMember -> CM ()
         forwardToMember member =
           let fwd = GrpMsgForward {fwdSender = FwdMember (memberId' m) (memberShortenedName m), fwdBrokerTs = brokerTs}

--- a/src/Simplex/Chat/Store/Messages.hs
+++ b/src/Simplex/Chat/Store/Messages.hs
@@ -73,6 +73,7 @@ module Simplex.Chat.Store.Messages
     markGroupChatItemBlocked,
     markGroupCIBlockedByAdmin,
     markMessageReportsDeleted,
+    markMemberReportsDeleted,
     markReceivedGroupReportsDeleted,
     deleteLocalChatItem,
     updateDirectChatItemsRead,
@@ -3023,6 +3024,20 @@ markMessageReportsDeleted db User {userId} GroupInfo {groupId} ChatItem {meta = 
         RETURNING chat_item_id;
       |]
       (DBCIDeleted, deletedTs, groupMemberId, currentTs, userId, groupId, MCReport_, itemSharedMsgId, DBCINotDeleted)
+
+markMemberReportsDeleted :: DB.Connection -> User -> GroupInfo -> GroupMember -> GroupMember -> UTCTime -> IO [ChatItemId]
+markMemberReportsDeleted db User {userId} GroupInfo {groupId} reportedMember byGroupMember deletedTs = do
+  currentTs <- liftIO getCurrentTime
+  map fromOnly
+    <$> DB.query
+      db
+      [sql|
+        UPDATE chat_items
+        SET item_deleted = ?, item_deleted_ts = ?, item_deleted_by_group_member_id = ?, updated_at = ?
+        WHERE user_id = ? AND group_id = ? AND msg_content_tag = ? AND quoted_member_id = ? AND item_deleted = ?
+        RETURNING chat_item_id;
+      |]
+      (DBCIDeleted, deletedTs, groupMemberId' byGroupMember, currentTs, userId, groupId, MCReport_, memberId' reportedMember, DBCINotDeleted)
 
 markReceivedGroupReportsDeleted :: DB.Connection -> User -> GroupInfo -> UTCTime -> IO [ChatItemId]
 markReceivedGroupReportsDeleted db User {userId} GroupInfo {groupId, membership} deletedTs = do

--- a/src/Simplex/Chat/Store/Messages.hs
+++ b/src/Simplex/Chat/Store/Messages.hs
@@ -3034,10 +3034,11 @@ markMemberReportsDeleted db User {userId} GroupInfo {groupId} reportedMember byG
       [sql|
         UPDATE chat_items
         SET item_deleted = ?, item_deleted_ts = ?, item_deleted_by_group_member_id = ?, updated_at = ?
-        WHERE user_id = ? AND group_id = ? AND msg_content_tag = ? AND quoted_member_id = ? AND item_deleted = ?
+        WHERE user_id = ? AND group_id = ? AND msg_content_tag = ? AND item_deleted = ?
+          AND (quoted_member_id = ? OR group_member_id = ?)
         RETURNING chat_item_id;
       |]
-      (DBCIDeleted, deletedTs, groupMemberId' byGroupMember, deletedTs, userId, groupId, MCReport_, memberId' reportedMember, DBCINotDeleted)
+      ((DBCIDeleted, deletedTs, groupMemberId' byGroupMember, deletedTs) :. (userId, groupId, MCReport_, DBCINotDeleted, memberId' reportedMember, groupMemberId' reportedMember))
 
 markReceivedGroupReportsDeleted :: DB.Connection -> User -> GroupInfo -> UTCTime -> IO [ChatItemId]
 markReceivedGroupReportsDeleted db User {userId} GroupInfo {groupId, membership} deletedTs = do

--- a/src/Simplex/Chat/Store/Messages.hs
+++ b/src/Simplex/Chat/Store/Messages.hs
@@ -3025,9 +3025,9 @@ markMessageReportsDeleted db User {userId} GroupInfo {groupId} ChatItem {meta = 
       |]
       (DBCIDeleted, deletedTs, groupMemberId, currentTs, userId, groupId, MCReport_, itemSharedMsgId, DBCINotDeleted)
 
-markMemberReportsDeleted :: DB.Connection -> User -> GroupInfo -> GroupMember -> GroupMember -> UTCTime -> IO [ChatItemId]
-markMemberReportsDeleted db User {userId} GroupInfo {groupId} reportedMember byGroupMember deletedTs = do
-  currentTs <- liftIO getCurrentTime
+markMemberReportsDeleted :: DB.Connection -> User -> GroupInfo -> GroupMember -> GroupMember -> IO [ChatItemId]
+markMemberReportsDeleted db User {userId} GroupInfo {groupId} reportedMember byGroupMember = do
+  deletedTs <- getCurrentTime
   map fromOnly
     <$> DB.query
       db
@@ -3037,7 +3037,7 @@ markMemberReportsDeleted db User {userId} GroupInfo {groupId} reportedMember byG
         WHERE user_id = ? AND group_id = ? AND msg_content_tag = ? AND quoted_member_id = ? AND item_deleted = ?
         RETURNING chat_item_id;
       |]
-      (DBCIDeleted, deletedTs, groupMemberId' byGroupMember, currentTs, userId, groupId, MCReport_, memberId' reportedMember, DBCINotDeleted)
+      (DBCIDeleted, deletedTs, groupMemberId' byGroupMember, deletedTs, userId, groupId, MCReport_, memberId' reportedMember, DBCINotDeleted)
 
 markReceivedGroupReportsDeleted :: DB.Connection -> User -> GroupInfo -> UTCTime -> IO [ChatItemId]
 markReceivedGroupReportsDeleted db User {userId} GroupInfo {groupId, membership} deletedTs = do

--- a/src/Simplex/Chat/Store/SQLite/Migrations/chat_query_plans.txt
+++ b/src/Simplex/Chat/Store/SQLite/Migrations/chat_query_plans.txt
@@ -4163,6 +4163,15 @@ SEARCH chat_items USING COVERING INDEX idx_chat_items_groups_msg_content_tag_del
 Query: 
         UPDATE chat_items
         SET item_deleted = ?, item_deleted_ts = ?, item_deleted_by_group_member_id = ?, updated_at = ?
+        WHERE user_id = ? AND group_id = ? AND msg_content_tag = ? AND quoted_member_id = ? AND item_deleted = ?
+        RETURNING chat_item_id;
+      
+Plan:
+SEARCH chat_items USING INDEX idx_chat_items_groups_msg_content_tag_deleted (user_id=? AND group_id=? AND msg_content_tag=? AND item_deleted=?)
+
+Query: 
+        UPDATE chat_items
+        SET item_deleted = ?, item_deleted_ts = ?, item_deleted_by_group_member_id = ?, updated_at = ?
         WHERE user_id = ? AND group_id = ? AND msg_content_tag = ? AND quoted_shared_msg_id = ? AND item_deleted = ?
         RETURNING chat_item_id;
       

--- a/src/Simplex/Chat/Store/SQLite/Migrations/chat_query_plans.txt
+++ b/src/Simplex/Chat/Store/SQLite/Migrations/chat_query_plans.txt
@@ -4154,20 +4154,21 @@ SEARCH chat_items USING INDEX idx_chat_items_group_shared_msg_id (user_id=? AND 
 Query: 
         UPDATE chat_items
         SET item_deleted = ?, item_deleted_ts = ?, item_deleted_by_group_member_id = ?, updated_at = ?
+        WHERE user_id = ? AND group_id = ? AND msg_content_tag = ? AND item_deleted = ?
+          AND (quoted_member_id = ? OR group_member_id = ?)
+        RETURNING chat_item_id;
+      
+Plan:
+SEARCH chat_items USING INDEX idx_chat_items_groups_msg_content_tag_deleted (user_id=? AND group_id=? AND msg_content_tag=? AND item_deleted=?)
+
+Query: 
+        UPDATE chat_items
+        SET item_deleted = ?, item_deleted_ts = ?, item_deleted_by_group_member_id = ?, updated_at = ?
         WHERE user_id = ? AND group_id = ? AND msg_content_tag = ? AND item_deleted = ? AND item_sent = 0
         RETURNING chat_item_id
       
 Plan:
 SEARCH chat_items USING COVERING INDEX idx_chat_items_groups_msg_content_tag_deleted (user_id=? AND group_id=? AND msg_content_tag=? AND item_deleted=? AND item_sent=?)
-
-Query: 
-        UPDATE chat_items
-        SET item_deleted = ?, item_deleted_ts = ?, item_deleted_by_group_member_id = ?, updated_at = ?
-        WHERE user_id = ? AND group_id = ? AND msg_content_tag = ? AND quoted_member_id = ? AND item_deleted = ?
-        RETURNING chat_item_id;
-      
-Plan:
-SEARCH chat_items USING INDEX idx_chat_items_groups_msg_content_tag_deleted (user_id=? AND group_id=? AND msg_content_tag=? AND item_deleted=?)
 
 Query: 
         UPDATE chat_items

--- a/tests/ChatTests/Groups.hs
+++ b/tests/ChatTests/Groups.hs
@@ -7401,16 +7401,25 @@ testGroupMemberReportsRemoveMember =
       concurrently_
         (alice <# "#jokes bob> inappropriate joke")
         (cath <# "#jokes bob> inappropriate joke")
+      cath #> "#jokes another joke"
+      concurrently_
+        (alice <# "#jokes cath> another joke")
+        (bob <# "#jokes cath> another joke")
       cath ##> "/report #jokes content inappropriate joke"
       cath <# "#jokes (support) > bob inappropriate joke"
       cath <## "      report content"
       alice <# "#jokes (support: cath) cath> > bob inappropriate joke"
       alice <## "      report content"
-      alice #$> ("/_get chat #1 content=report count=100", chat, [(0, "report content")])
+      bob ##> "/report #jokes content another joke"
+      bob <# "#jokes (support) > cath another joke"
+      bob <## "      report content"
+      alice <# "#jokes (support: bob) bob> > cath another joke"
+      alice <## "      report content"
+      alice #$> ("/_get chat #1 content=report count=100", chat, [(0, "report content"), (0, "report content")])
       cath #$> ("/_get chat #1 content=report count=100", chat, [(1, "report content")])
       threadDelay 1000000
       alice ##> "/rm #jokes bob messages=on"
-      alice <## "#jokes: 1 messages deleted by user"
+      alice <## "#jokes: 2 messages deleted by user"
       alice <## "#jokes: you removed bob from the group with all messages"
       bob <## "#jokes: alice removed you from the group with all messages"
       bob <## "use /d #jokes to delete the group"

--- a/tests/ChatTests/Groups.hs
+++ b/tests/ChatTests/Groups.hs
@@ -219,6 +219,7 @@ chatGroupTests = do
     it "mark member inactive on reaching quota" testGroupMemberInactive
   describe "group member reports" $ do
     it "should send report to group owner, admins and moderators, but not other users" testGroupMemberReports
+    it "should archive reports about the messages of the member removed with messages" testGroupMemberReportsRemoveMember
   describe "group member mentions" $ do
     it "should send and edit messages with member mentions" testMemberMention
     it "should forward and quote message updating mentioned member name" testForwardQuoteMention
@@ -7389,6 +7390,34 @@ testGroupMemberInactive ps = do
               { smpServers = ["smp://LcJUMfVhwD8yxjAiSaDzzGF3-kLG4Uh0Fl_ZIjrRwjI=:server_password@localhost:7003"]
               }
         }
+
+testGroupMemberReportsRemoveMember :: HasCallStack => TestParams -> IO ()
+testGroupMemberReportsRemoveMember =
+  testChat3 aliceProfile bobProfile cathProfile $
+    \alice bob cath -> do
+      createGroup3' "jokes" alice (bob, GRMember) (cath, GRMember)
+      threadDelay 1000000
+      bob #> "#jokes inappropriate joke"
+      concurrently_
+        (alice <# "#jokes bob> inappropriate joke")
+        (cath <# "#jokes bob> inappropriate joke")
+      cath ##> "/report #jokes content inappropriate joke"
+      cath <# "#jokes (support) > bob inappropriate joke"
+      cath <## "      report content"
+      alice <# "#jokes (support: cath) cath> > bob inappropriate joke"
+      alice <## "      report content"
+      alice #$> ("/_get chat #1 content=report count=100", chat, [(0, "report content")])
+      cath #$> ("/_get chat #1 content=report count=100", chat, [(1, "report content")])
+      threadDelay 1000000
+      alice ##> "/rm #jokes bob messages=on"
+      alice <## "#jokes: 1 messages deleted by user"
+      alice <## "#jokes: you removed bob from the group with all messages"
+      bob <## "#jokes: alice removed you from the group with all messages"
+      bob <## "use /d #jokes to delete the group"
+      cath <## "#jokes: 1 messages deleted by member alice"
+      cath <## "#jokes: alice removed bob from the group with all messages"
+      alice #$> ("/_get chat #1 content=report count=100", chat, [(0, "report content [marked deleted by you]")])
+      cath #$> ("/_get chat #1 content=report count=100", chat, [(1, "report content [marked deleted by alice]")])
 
 testGroupMemberReports :: HasCallStack => TestParams -> IO ()
 testGroupMemberReports =


### PR DESCRIPTION
"Remove member and delete messages" left reports untouched, unlike moderating a message. Two defects:

1. **Reports about the removed member stayed active.** They are authored by the reporter, so deleting the removed member's own chat items never reaches them.
2. **The reports counter got stuck.** Reports *filed by* the removed member were archived by `markMemberCIsDeleted` with no event, so the counter kept counting them — it could show a non-zero badge with an empty reports list.

Adds `markMemberReportsDeleted`, matching both sets in one query (`quoted_member_id = ? OR group_member_id = ?`), called from both `deleteMessages` paths — the removing moderator's and `xGrpMemDel` on receiving clients — and emits `CEvtGroupChatItemsDeleted` so the counter updates without a reload.

The `group_member_id` branch changes no database state; those rows are archived moments later by the existing member-item deletion either way. It only widens the event payload so the counter agrees with the list.

Rationale, rejected alternatives and known limitations: `plans/2026-09-08-archive-reports-on-member-removal.md`.
