### PR TITLE
android, desktop: offer key verification when member profile is opened from chat

### DIFF
--- a/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
+++ b/apps/multiplatform/common/src/commonMain/kotlin/chat/simplex/common/views/chat/ChatView.kt
@@ -502,7 +502,7 @@ fun ChatView(
               groupMembersJob = scope.launch(Dispatchers.Default) {
                 val r = chatModel.controller.apiGroupMemberInfo(chatRh, groupInfo.groupId, member.groupMemberId)
                 val stats = r?.second
-                val (updatedMember, code) = if (member.memberActive) {
+                val (updatedMember, code) = if ((member.memberActive || (groupInfo.useRelays && member.memberCurrent)) && member.memberRole != GroupMemberRole.Relay) {
                   val memCode = chatModel.controller.apiGetGroupMemberCode(chatRh, groupInfo.apiId, member.groupMemberId)
                   (memCode?.first ?: r?.first ?: member) to memCode?.second
                 } else {


### PR DESCRIPTION
Opening a channel member's profile by tapping their avatar in the chat does not offer "Verify security code", while opening the same member from the members list does. #7255 widened the condition for requesting the member security code to cover channel members, which are `memberCurrent` but not `memberActive`, and updated `GroupChatInfoView`, `MemberSupportChatView` and iOS — but not the copy of the same code in `ChatView`. This aligns that condition with the other two call sites; it applies to `stable` as well, where the gap is live in 7.0.0-7.0.2.