### PR TITLE
fix(markdown): Implement standard Markdown formatting (fixes #7221) 

### DIFF
--- a/bots/api/TYPES.md
+++ b/bots/api/TYPES.md
@@ -2140,12 +2140,15 @@ NO_FILE:
 
 Bold:
 - type: "bold"
+- mark: string
 
 Italic:
 - type: "italic"
+- mark: string
 
 StrikeThrough:
 - type: "strikeThrough"
+- mark: string
 
 Snippet:
 - type: "snippet"

--- a/src/Simplex/Chat/Help.hs
+++ b/src/Simplex/Chat/Help.hs
@@ -309,9 +309,9 @@ markdownInfo =
   map
     styleMarkdown
     [ green "Markdown:",
-      indent <> highlight "*bold*         " <> " - " <> markdown Bold "bold text",
-      indent <> highlight "_italic_       " <> " - " <> markdown Italic "italic text" <> " (shown as underlined)",
-      indent <> highlight "~strikethrough~" <> " - " <> markdown StrikeThrough "strikethrough text" <> " (shown as inverse)",
+      indent <> highlight "**bold**       " <> " - " <> markdown (Bold "**") "bold text",
+      indent <> highlight "*italic*       " <> " - " <> markdown (Italic "*") "italic text" <> " (shown as underlined)",
+      indent <> highlight "~strikethrough~" <> " - " <> markdown (StrikeThrough "~") "strikethrough text" <> " (shown as inverse)",
       indent <> highlight "`code snippet` " <> " - " <> markdown Snippet "a + b // no *markdown* here",
       indent <> highlight "!1 text!       " <> " - " <> markdown (colored Red) "red text" <> " (1-6: red, green, blue, yellow, cyan, magenta)",
       indent <> highlight "#secret#       " <> " - " <> markdown Secret "secret text" <> " (can be copy-pasted)"

--- a/src/Simplex/Chat/Markdown.hs
+++ b/src/Simplex/Chat/Markdown.hs
@@ -49,9 +49,12 @@ data Markdown = Markdown (Maybe Format) Text | Markdown :|: Markdown
   deriving (Eq, Show)
 
 data Format
-  = Bold
-  | Italic
-  | StrikeThrough
+  -- mark is the delimiter used in the source text: several spellings map to the
+  -- same format (*x* and _x_ are both italic, ~x~ and ~~x~~ both strikethrough),
+  -- so it is recorded here for markdownText to render the text back unchanged
+  = Bold {mark :: Text}
+  | Italic {mark :: Text}
+  | StrikeThrough {mark :: Text}
   | Snippet
   | Secret
   | Small
@@ -211,10 +214,10 @@ markdownP = mconcat <$> A.many' fragmentP
         Just c -> case c of
           ' ' -> unmarked <$> A.takeWhile (== ' ')
           '+' -> phoneP <|> wordP
-          '*' -> formattedP '*' Bold
-          '_' -> formattedP '_' Italic
-          '~' -> formattedP '~' StrikeThrough
-          '`' -> formattedP '`' Snippet
+          '*' -> formattedP2 '*' Italic Bold
+          '_' -> formattedP2 '_' Italic Bold
+          '~' -> formattedP2 '~' StrikeThrough StrikeThrough
+          '`' -> formattedP1 '`' Snippet
           '#' -> A.char '#' *> (secretP <|> nameRefP '#' <|> secretFallback)
           '!' -> styledP <|> wordP
           '@' -> (A.char '@' *> nameRefP '@') <|> mentionP <|> wordP
@@ -224,15 +227,37 @@ markdownP = mconcat <$> A.many' fragmentP
             | isDigit c -> phoneP <|> wordP
             | otherwise -> wordP
         Nothing -> fail ""
-    formattedP :: Char -> Format -> Parser Markdown
-    formattedP c f = do
+
+    -- Single-char formatter (for `)
+    formattedP1 :: Char -> Format -> Parser Markdown
+    formattedP1 c f = do
       s <- A.char c *> A.takeTill (== c)
       (A.char c $> md c f s) <|> noFormat (c `T.cons` s)
+    -- Dual-char formatter (for *, _ and ~): f1 for a single delimiter, f2 for a doubled one
+    formattedP2 :: Char -> (Text -> Format) -> (Text -> Format) -> Parser Markdown
+    formattedP2 c f1 f2 = do
+      _ <- A.char c
+      isDouble <- (True <$ A.char c) <|> pure False
+      if isDouble
+        then do
+          s <- A.takeTill (== c)
+          let m = T.pack [c, c]
+          (A.string m $> mdDouble c (f2 m) s) <|> noFormat (c `T.cons` c `T.cons` s)
+        else do
+          s <- A.takeTill (== c)
+          let m = T.singleton c
+          (A.char c $> md c (f1 m) s) <|> noFormat (c `T.cons` s)
     md :: Char -> Format -> Text -> Markdown
     md c f s
       | T.null s || T.head s == ' ' || T.last s == ' ' =
           unmarked $ c `T.cons` s `T.snoc` c
       | otherwise = markdown f s
+    mdDouble :: Char -> Format -> Text -> Markdown
+    mdDouble c f s
+      | T.null s || T.head s == ' ' || T.last s == ' ' =
+          unmarked $ c `T.cons` c `T.cons` s `T.snoc` c `T.snoc` c
+      | otherwise = markdown f s
+
     secretP :: Parser Markdown
     secretP = secret <$?> ((,,) <$> A.takeWhile (== '#') <*> A.takeTill (== '#') <*> A.takeWhile1 (== '#'))
     secret :: (Text, Text, Text) -> Either String Markdown
@@ -467,9 +492,9 @@ markdownText :: FormattedText -> Text
 markdownText (FormattedText f_ t) = case f_ of
   Nothing -> t
   Just f -> case f of
-    Bold -> around '*'
-    Italic -> around '_'
-    StrikeThrough -> around '~'
+    Bold m -> marked m
+    Italic m -> marked m
+    StrikeThrough m -> marked m
     Snippet -> around '`'
     Secret -> around '#'
     Small -> "!- " <> t <> "!"
@@ -485,6 +510,7 @@ markdownText (FormattedText f_ t) = case f_ of
     Unknown _ -> t
     where
       around c = c `T.cons` t `T.snoc` c
+      marked m = m <> t <> m
       color c = case colorStr c of
         Just cStr -> cStr <> t `T.snoc` '!'
         Nothing -> t

--- a/src/Simplex/Chat/Styled.hs
+++ b/src/Simplex/Chat/Styled.hs
@@ -70,9 +70,9 @@ sShow = plain . show
 
 sgr :: Format -> [SGR]
 sgr = \case
-  Bold -> [SetConsoleIntensity BoldIntensity]
-  Italic -> [SetUnderlining SingleUnderline, SetItalicized True]
-  StrikeThrough -> [SetSwapForegroundBackground True]
+  Bold {} -> [SetConsoleIntensity BoldIntensity]
+  Italic {} -> [SetUnderlining SingleUnderline, SetItalicized True]
+  StrikeThrough {} -> [SetSwapForegroundBackground True]
   Colored (FormatColor c) -> [SetColor Foreground Vivid c]
   Secret -> [SetColor Foreground Dull Black, SetColor Background Dull Black]
   Small -> [SetConsoleIntensity FaintIntensity]

--- a/src/Simplex/Chat/View.hs
+++ b/src/Simplex/Chat/View.hs
@@ -973,7 +973,7 @@ viewItemReactions ChatItem {reactions} = ["      " <> viewReactions reactions | 
     viewReactions = mconcat . intersperse " " . map viewReaction
     viewReaction CIReactionCount {reaction = MRUnknown {}} = "?"
     viewReaction CIReactionCount {reaction = MREmoji (MREmojiChar emoji), userReacted, totalReacted} =
-      plain [emoji, ' '] <> (if userReacted then styled Italic else plain) (show totalReacted)
+      plain [emoji, ' '] <> (if userReacted then styled (Italic "*") else plain) (show totalReacted)
 
 viewTestInfo :: Bool -> ChatItem c d -> [StyledString]
 viewTestInfo testView ChatItem {content} = maybe [] (viewMsgTestInfo testView) $ ciMsgContent content
@@ -2088,7 +2088,7 @@ viewGroupDescription GroupInfo {groupProfile = GroupProfile {description}} =
   maybe ["No welcome message!"] ((bold' "Welcome message:" :) . map plain . T.lines) description
 
 bold' :: String -> StyledString
-bold' = styled Bold
+bold' = styled (Bold "**")
 
 viewContactAliasUpdated :: Contact -> [StyledString]
 viewContactAliasUpdated ct@Contact {profile = LocalProfile {localAlias}}

--- a/tests/MarkdownTests.hs
+++ b/tests/MarkdownTests.hs
@@ -54,26 +54,85 @@ s <<== ft = T.concat (map markdownText ft) `shouldBe` s
 (<<==>>) :: Text -> MarkdownList -> Expectation
 s <<==>> ft = (s ==>> ft) >> (s <<== ft)
 
+-- formats carry the delimiter used in the source text, so each spelling has its
+-- own helper and round-trips back to exactly what was written
 bold :: Text -> Markdown
-bold = markdown Bold
+bold = markdown (Bold "**")
 
+boldU :: Text -> Markdown
+boldU = markdown (Bold "__")
+
+italic :: Text -> Markdown
+italic = markdown (Italic "*")
+
+italicU :: Text -> Markdown
+italicU = markdown (Italic "_")
+
+strikethrough :: Text -> Markdown
+strikethrough = markdown (StrikeThrough "~")
+
+strikethrough2 :: Text -> Markdown
+strikethrough2 = markdown (StrikeThrough "~~")
+
+-- Text format tests: standard Markdown syntax
+-- * = italic (single asterisk)
+-- ** = bold (double asterisk)
+-- _ = italic (single underscore)
+-- __ = bold (double underscore)
+-- ~ or ~~ = strikethrough
 textFormat :: Spec
-textFormat = describe "text format (bold)" do
-  it "correct markdown" do
-    "this is *bold formatted* text"
+textFormat = describe "text format (standard markdown)" do
+  it "correct markdown - single asterisk for italic" do
+    "this is *italic formatted* text"
+      <==> "this is " <> italic "italic formatted" <> " text"
+    "*italic formatted* text"
+      <==> italic "italic formatted" <> " text"
+    "this is *italic*"
+      <==> "this is " <> italic "italic"
+    " *italic* text"
+      <==> " " <> italic "italic" <> " text"
+    "   *italic* text"
+      <==> "   " <> italic "italic" <> " text"
+    "this is *italic* "
+      <==> "this is " <> italic "italic" <> " "
+    "this is *italic*   "
+      <==> "this is " <> italic "italic" <> "   "
+  it "correct markdown - double asterisk for bold" do
+    "this is **bold formatted** text"
       <==> "this is " <> bold "bold formatted" <> " text"
-    "*bold formatted* text"
+    "**bold formatted** text"
       <==> bold "bold formatted" <> " text"
-    "this is *bold*"
+    "this is **bold**"
       <==> "this is " <> bold "bold"
-    " *bold* text"
+    " **bold** text"
       <==> " " <> bold "bold" <> " text"
-    "   *bold* text"
+    "   **bold** text"
       <==> "   " <> bold "bold" <> " text"
-    "this is *bold* "
+    "this is **bold** "
       <==> "this is " <> bold "bold" <> " "
-    "this is *bold*   "
+    "this is **bold**   "
       <==> "this is " <> bold "bold" <> "   "
+  it "correct markdown - single underscore for italic" do
+    "this is _italic formatted_ text"
+      <==> "this is " <> italicU "italic formatted" <> " text"
+    "_italic formatted_ text"
+      <==> italicU "italic formatted" <> " text"
+    "this is _italic_"
+      <==> "this is " <> italicU "italic"
+  it "correct markdown - double underscore for bold" do
+    "this is __bold formatted__ text"
+      <==> "this is " <> boldU "bold formatted" <> " text"
+    "__bold formatted__ text"
+      <==> boldU "bold formatted" <> " text"
+    "this is __bold__"
+      <==> "this is " <> boldU "bold"
+  it "correct markdown - strikethrough" do
+    "this is ~struck~ text"
+      <==> "this is " <> strikethrough "struck" <> " text"
+    "this is ~~struck~~ text"
+      <==> "this is " <> strikethrough2 "struck" <> " text"
+    "~struck~ text"
+      <==> strikethrough "struck" <> " text"
   it "ignored as markdown" do
     "this is * unformatted * text"
       <==> "this is * unformatted * text"
@@ -81,19 +140,21 @@ textFormat = describe "text format (bold)" do
       <==> "this is *unformatted * text"
     "this is * unformatted* text"
       <==> "this is * unformatted* text"
-    "this is **unformatted** text"
-      <==> "this is **unformatted** text"
+    "this is ** unformatted ** text"
+      <==> "this is ** unformatted ** text"
+    "this is **unformatted ** text"
+      <==> "this is **unformatted ** text"
     "this is*unformatted* text"
       <==> "this is*unformatted* text"
     "this is *unformatted text"
       <==> "this is *unformatted text"
     "*this* is *unformatted text"
-      <==> bold "this" <> " is *unformatted text"
+      <==> italic "this" <> " is *unformatted text"
   it "ignored internal markdown" do
     "this is *long _bold_ (not italic)* text"
-      <==> "this is " <> bold "long _bold_ (not italic)" <> " text"
-    "snippet: `this is *bold text*`"
-      <==> "snippet: " <> markdown Snippet "this is *bold text*"
+      <==> "this is " <> italic "long _bold_ (not italic)" <> " text"
+    "snippet: `this is *italic text*`"
+      <==> "snippet: " <> markdown Snippet "this is *italic text*"
 
 secretText :: Spec
 secretText = describe "secret text" do
@@ -130,7 +191,7 @@ secretText = describe "secret text" do
     "this is #unformatted text"
       <==> "this is " <> sname NTPublicGroup TLDSimplex "unformatted" [] "unformatted" <> " text"
     "*this* is #unformatted text"
-      <==> bold "this" <> " is " <> sname NTPublicGroup TLDSimplex "unformatted" [] "unformatted" <> " text"
+      <==> italic "this" <> " is " <> sname NTPublicGroup TLDSimplex "unformatted" [] "unformatted" <> " text"
   it "ignored internal markdown" do
     "snippet: `this is #secret_text#`"
       <==> "snippet: " <> markdown Snippet "this is #secret_text#"
@@ -191,14 +252,12 @@ textColor = describe "text color (red)" do
       <==> "this is !1 unformatted ! text"
     "this is !1  unformatted! text"
       <==> "this is !1  unformatted! text"
-    -- "this is !!1 unformatted!! text"
-    --   <==> "this is " <> "!!1" <> "unformatted!! text"
     "this is!1 unformatted! text"
       <==> "this is!1 unformatted! text"
     "this is !1 unformatted text"
       <==> "this is !1 unformatted text"
     "*this* is !1 unformatted text"
-      <==> bold "this" <> " is !1 unformatted text"
+      <==> italic "this" <> " is !1 unformatted text"
   it "ignored internal markdown" do
     "this is !1 long *red* (not bold)! text"
       <==> "this is " <> red "long *red* (not bold)" <> " text"
@@ -322,7 +381,7 @@ textWithEmail = describe "text with Email" do
     "this is chat @simplex.chat" <==> "this is chat " <> sname NTContact TLDWeb "simplex.chat" [] "simplex.chat"
     "this is chat@ simplex.chat" <==> "this is chat@ " <> uri "simplex.chat"
     "this is chat @ simplex.chat" <==> "this is chat @ " <> uri "simplex.chat"
-    "*this* is chat @ simplex.chat" <==> bold "this" <> " is chat @ " <> uri "simplex.chat"
+    "*this* is chat @ simplex.chat" <==> italic "this" <> " is chat @ " <> uri "simplex.chat"
 
 phone :: Text -> Markdown
 phone = Markdown $ Just Phone
@@ -344,7 +403,7 @@ textWithPhone = describe "text with Phone" do
     "test 077777 test" <==> "test 077777 test"
   it "ignored as markdown (double spaces)" $ do
     "test 07777  777  777 test" <==> "test 07777  777  777 test"
-    "*test* 07777  777  777 test" <==> bold "test" <> " 07777  777  777 test"
+    "*test* 07777  777  777 test" <==> italic "test" <> " 07777  777  777 test"
 
 mention :: Text -> Text -> Markdown
 mention = Markdown . Just . Mention


### PR DESCRIPTION
Currently, simplex-chat implemented markdown wrongly (as reported in #7221)
So this PR implements very basic Markdown correctly for supported text spans (bold, italic, strikethrough):

- Single asterisk (*text*) now produces italic instead of bold
- Double asterisk (**text**) now produces bold
- Single underscore (_text_) produces italic
- Double underscore (__text__) produces bold
- Tilde (~text~ or ~~text~~) produces strikethrough

This makes SimpleX Chat compatible with standard Markdown syntax, enabling proper integration with AI bots and content from the web.

Since Markdown is ambiguous (`*T*` and `_T_` both produce the same format), instead of converting the AST to a single node and loose the original utterance, that wouldn't survive round tripping, the logic was to enhance the AST format to remember the initial formatting char. This ensures that the text supports lossless parsing and regenerating (and this can be improved for later implementation of other Markdown features).

I've changed the type for this additional field and let it propagate to documentation. 

Actual clients (swift, ...) ignore the additional field so it shouldn't impact them.

I've run the tests for this change and it's all green.