### PR TITLE
Limit memory usage when loading images on Android

### DIFF
--- a/apps/multiplatform/common/build.gradle.kts
+++ b/apps/multiplatform/common/build.gradle.kts
@@ -159,6 +159,7 @@ kotlin {
 android {
   namespace = "chat.simplex.common"
   compileSdk = 35
+  useLibrary("android.test.base")
   sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
   defaultConfig {
     minSdk = 26

--- a/apps/multiplatform/common/src/androidInstrumentedTest/AndroidManifest.xml
+++ b/apps/multiplatform/common/src/androidInstrumentedTest/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application>
+    <provider
+      android:name="chat.simplex.common.platform.TestImageProvider"
+      android:authorities="chat.simplex.common.test.imageprovider"
+      android:exported="true" />
+  </application>
+</manifest>

--- a/apps/multiplatform/common/src/androidInstrumentedTest/kotlin/chat/simplex/common/platform/ImageStreamDecoderTest.kt
+++ b/apps/multiplatform/common/src/androidInstrumentedTest/kotlin/chat/simplex/common/platform/ImageStreamDecoderTest.kt
@@ -1,0 +1,113 @@
+package chat.simplex.common.platform
+
+import android.content.*
+import android.database.*
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.*
+import android.provider.OpenableColumns
+import android.test.InstrumentationTestCase
+import chat.simplex.common.views.helpers.*
+import java.io.*
+import java.net.URI
+import kotlinx.coroutines.runBlocking
+import kotlin.random.Random
+
+class ImageStreamDecoderTest : InstrumentationTestCase() {
+  private val rejectedWidth = 16385
+
+  override fun setUp() {
+    super.setUp()
+    androidAppContext = instrumentation.targetContext
+    TestImageProvider.file = null
+  }
+
+  fun testBoundsInspectionIsLimitedAndFailureDoesNotCloseTheSource() {
+    val stream = TrackingStream()
+    try { loadImageBitmap(stream); fail("invalid input was decoded") } catch (_: IOException) {}
+    assertTrue(stream.bytesRead <= MAX_IMAGE_HEADER_BYTES)
+    assertFalse(stream.closed)
+  }
+
+  fun testSuccessfulDecodeContinuesPastTheHeaderWindowAndLeavesTheSourceOpen() {
+    val random = Random(7)
+    val pixels = IntArray(1024 * 1024) { random.nextInt() }
+    val encoded = encodePng(1024, 1024, pixels)
+    assertTrue(encoded.size > MAX_IMAGE_HEADER_BYTES)
+    val stream = TrackingStream(ByteArrayInputStream(encoded))
+    assertEquals(1024, loadImageBitmap(stream).width)
+    assertTrue(stream.bytesRead > MAX_IMAGE_HEADER_BYTES)
+    assertFalse(stream.closed)
+  }
+
+  fun testImmutableBytesAndPublicStreamUseTheirDistinctFixedTargets() {
+    val encoded = encodePng(2400, 2400)
+    assertEquals(1200, decodeImageBitmap(ByteArrayInputStream(encoded), MAX_THUMBNAIL_DIMENSION).width)
+    assertEquals(2400, loadImageBitmap(ByteArrayInputStream(encoded)).width)
+  }
+
+  fun testApi28UriBitmapAndDrawableRevalidateChangedProviderContent() {
+    if (Build.VERSION.SDK_INT < 28) return
+    TestImageProvider.file = File(androidAppContext.cacheDir, "uri-policy.png").apply { writeBytes(encodePng(5000, 100)) }
+    val uri = URI(TestImageProvider.URI.toString())
+    assertEquals(5000, getBitmapFromUri(uri, false)?.width)
+    assertNotNull(getDrawableFromUri(uri, false))
+    TestImageProvider.file!!.writeBytes(encodePng(rejectedWidth, 1))
+    assertNull(getBitmapFromUri(uri, false))
+    assertNull(getDrawableFromUri(uri, false))
+  }
+
+  fun testApi26And27UriUsesPrivateFile() {
+    if (Build.VERSION.SDK_INT !in 26..27) return
+    appFilesDir.mkdirs()
+    File(appFilesDir, TestImageProvider.DISPLAY_NAME).writeBytes(encodePng(5000, 100))
+    TestImageProvider.file = File(androidAppContext.cacheDir, "provider-invalid.bin").apply { writeText("not decoded") }
+    assertEquals(5000, getBitmapFromUri(URI(TestImageProvider.URI.toString()), false)?.width)
+
+  }
+
+  fun testWallpaperAndDirectImageLinkUseBoundedStreamDecoder() {
+    val suffix = System.nanoTime()
+    val normal = "wallpaper-normal-$suffix.png"
+    File(getWallpaperFilePath(normal)).writeBytes(encodePng(5000, 100))
+    assertEquals(5000, WallpaperType.Image(normal, null, WallpaperScaleType.FIT).image?.width)
+    val rejected = "wallpaper-rejected-$suffix.png"
+    File(getWallpaperFilePath(rejected)).writeBytes(encodePng(rejectedWidth, 1))
+    assertNull(WallpaperType.Image(rejected, null, WallpaperScaleType.FIT).image)
+    val link = File(androidAppContext.cacheDir, "link-rejected-$suffix.png").apply { writeBytes(encodePng(rejectedWidth, 1)) }
+    assertNull(runBlocking { getLinkPreview(link.toURI().toString()) })
+  }
+
+  private fun encodePng(width: Int, height: Int, pixels: IntArray? = null): ByteArray {
+    val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+    if (pixels != null) bitmap.setPixels(pixels, 0, width, 0, 0, width, height)
+    return ByteArrayOutputStream().use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it); bitmap.recycle(); it.toByteArray() }
+  }
+
+  private class TrackingStream(private val delegate: InputStream? = null) : InputStream() {
+    var bytesRead = 0
+    var closed = false
+    override fun read(): Int = (delegate?.read() ?: 0).also { if (it >= 0) bytesRead++ }
+    override fun read(buffer: ByteArray, offset: Int, length: Int): Int =
+      (delegate?.read(buffer, offset, length) ?: length.also { buffer.fill(0, offset, offset + it) }).also { if (it > 0) bytesRead += it }
+    override fun close() { closed = true }
+  }
+}
+
+class TestImageProvider : ContentProvider() {
+  override fun onCreate() = true
+  override fun query(uri: Uri, projection: Array<out String>?, selection: String?, selectionArgs: Array<out String>?, sortOrder: String?) =
+    MatrixCursor(arrayOf(OpenableColumns.DISPLAY_NAME)).apply { addRow(arrayOf(DISPLAY_NAME)) }
+  override fun getType(uri: Uri) = "image/png"
+  override fun openFile(uri: Uri, mode: String) = ParcelFileDescriptor.open(checkNotNull(file), ParcelFileDescriptor.MODE_READ_ONLY)
+  override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+  override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?) = 0
+  override fun update(uri: Uri, values: ContentValues?, selection: String?, selectionArgs: Array<out String>?) = 0
+
+  companion object {
+    const val AUTHORITY = "chat.simplex.common.test.imageprovider"
+    const val DISPLAY_NAME = "provider-image.png"
+    val URI: Uri = Uri.parse("content://$AUTHORITY/image")
+    var file: File? = null
+  }
+}

--- a/apps/multiplatform/common/src/androidInstrumentedTest/kotlin/chat/simplex/common/platform/LegacyImageLoaderTest.kt
+++ b/apps/multiplatform/common/src/androidInstrumentedTest/kotlin/chat/simplex/common/platform/LegacyImageLoaderTest.kt
@@ -1,0 +1,27 @@
+package chat.simplex.common.platform
+
+import android.os.Build
+import android.test.InstrumentationTestCase
+import coil.ImageLoader
+import coil.request.*
+import java.util.Base64
+import kotlinx.coroutines.runBlocking
+
+class LegacyImageLoaderTest : InstrumentationTestCase() {
+  override fun setUp() {
+    super.setUp()
+    androidAppContext = instrumentation.targetContext
+  }
+
+  fun testApi26And27LegacyLoadersDoNotUseMovie() {
+    if (Build.VERSION.SDK_INT !in 26..27) return
+    val gif = Base64.getDecoder().decode("R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==")
+    listOf("CIImageView_androidKt", "ImageFullScreenView_androidKt").forEach {
+      val field = Class.forName("chat.simplex.common.views.chat.item.$it").getDeclaredField("imageLoader")
+      val loader = field.apply { isAccessible = true }.get(null) as ImageLoader
+      val result = runBlocking { loader.execute(ImageRequest.Builder(androidAppContext).data(gif).size(1000, 1000).build()) }
+      assertTrue(result is SuccessResult)
+      assertFalse((result as SuccessResult).drawable.javaClass.name.contains("Movie"))
+    }
+  }
+}

--- a/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/platform/Images.android.kt
+++ b/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/platform/Images.android.kt
@@ -15,13 +15,19 @@ import boofcv.struct.image.GrayU8
 import chat.simplex.common.R
 import chat.simplex.common.views.helpers.errorBitmap
 import chat.simplex.common.views.helpers.getFileName
+import java.io.BufferedInputStream
 import java.io.ByteArrayOutputStream
+import java.io.IOException
 import java.io.InputStream
 import java.net.URI
 import kotlin.math.min
 import kotlin.math.sqrt
 
-private const val MAX_IMAGE_DIMENSION = 4320
+internal const val MAX_IMAGE_DIMENSION = 4320
+internal const val MAX_THUMBNAIL_DIMENSION = 1000
+private const val MAX_SOURCE_IMAGE_DIMENSION = 16384
+private const val MAX_DECODED_PIXELS = 18_662_400L
+internal const val MAX_IMAGE_HEADER_BYTES = 1024 * 1024
 
 actual fun base64ToBitmap(base64ImageString: String): ImageBitmap {
   val imageString = base64ImageString
@@ -131,5 +137,62 @@ actual fun isAnimImage(uri: URI, drawable: Any?): Boolean {
   return isAnimNewApi || isAnimOldApi
 }
 
+internal fun boundedImageSampleSize(width: Int, height: Int, target: Int): Int? {
+  if (width !in 1..MAX_SOURCE_IMAGE_DIMENSION || height !in 1..MAX_SOURCE_IMAGE_DIMENSION) return null
+  var sampleSize = 1
+  val halfHeight = height / 2
+  val halfWidth = width / 2
+  while (halfHeight / sampleSize >= target && halfWidth / sampleSize >= target) sampleSize *= 2
+  while (ceilDiv(width, sampleSize) * ceilDiv(height, sampleSize) > MAX_DECODED_PIXELS) sampleSize *= 2
+  return sampleSize
+}
+
+private fun ceilDiv(value: Int, divisor: Int): Long =
+  (value.toLong() + divisor - 1L) / divisor
+
+internal class LimitedInputStream(
+  private val source: InputStream,
+  limit: Int,
+) : InputStream() {
+  private var remaining = limit
+
+  override fun read(): Int {
+    if (remaining == 0) return -1
+    val value = source.read()
+    if (value >= 0) remaining--
+    return value
+  }
+
+  override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+    if (length == 0) return 0
+    if (remaining == 0) return -1
+    val count = source.read(buffer, offset, minOf(length, remaining))
+    if (count > 0) remaining -= count
+    return count
+  }
+
+  override fun skip(count: Long): Long {
+    val allowed = minOf(count.coerceAtLeast(0), remaining.toLong())
+    val skipped = source.skip(allowed).coerceIn(0, allowed)
+    remaining -= skipped.toInt()
+    return skipped
+  }
+
+  override fun available(): Int = source.available().coerceIn(0, remaining)
+}
+
+internal fun decodeImageBitmap(inputStream: InputStream, target: Int): ImageBitmap {
+  val source = BufferedInputStream(inputStream)
+  source.mark(MAX_IMAGE_HEADER_BYTES)
+  val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+  BitmapFactory.decodeStream(LimitedInputStream(source, MAX_IMAGE_HEADER_BYTES), null, options)
+  val sampleSize = boundedImageSampleSize(options.outWidth, options.outHeight, target)
+    ?: throw IOException("Image dimensions exceed limit")
+  source.reset()
+  options.inJustDecodeBounds = false
+  options.inSampleSize = sampleSize
+  return (BitmapFactory.decodeStream(source, null, options) ?: throw IOException("Unable to decode image")).asImageBitmap()
+}
+
 actual fun loadImageBitmap(inputStream: InputStream): ImageBitmap =
-  BitmapFactory.decodeStream(inputStream).asImageBitmap()
+  decodeImageBitmap(inputStream, MAX_IMAGE_DIMENSION)

--- a/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/views/chat/item/CIImageView.android.kt
+++ b/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/views/chat/item/CIImageView.android.kt
@@ -13,7 +13,6 @@ import chat.simplex.common.ui.theme.CurrentColors
 import chat.simplex.common.views.helpers.ModalManager
 import coil.ImageLoader
 import coil.compose.rememberAsyncImagePainter
-import coil.decode.GifDecoder
 import coil.decode.ImageDecoderDecoder
 import coil.request.ImageRequest
 import coil.size.Scale
@@ -49,8 +48,6 @@ private val imageLoader = ImageLoader.Builder(androidAppContext)
   .components {
     if (SDK_INT >= 28) {
       add(ImageDecoderDecoder.Factory())
-    } else {
-      add(GifDecoder.Factory())
     }
   }
   .build()

--- a/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/views/chat/item/CIImageView.android.kt
+++ b/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/views/chat/item/CIImageView.android.kt
@@ -16,6 +16,7 @@ import coil.compose.rememberAsyncImagePainter
 import coil.decode.GifDecoder
 import coil.decode.ImageDecoderDecoder
 import coil.request.ImageRequest
+import coil.size.Scale
 
 @Composable
 actual fun SimpleAndAnimatedImageView(
@@ -28,7 +29,7 @@ actual fun SimpleAndAnimatedImageView(
 ) {
   val context = LocalContext.current
   val imagePainter = rememberAsyncImagePainter(
-    ImageRequest.Builder(context).data(data = data).size(coil.size.Size.ORIGINAL).build(),
+    ImageRequest.Builder(context).data(data = data).size(MAX_THUMBNAIL_DIMENSION, MAX_THUMBNAIL_DIMENSION).scale(Scale.FIT).build(),
     placeholder = BitmapPainter(imageBitmap), // show original image while it's still loading by coil
     imageLoader = imageLoader
   )

--- a/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/views/chat/item/ImageFullScreenView.android.kt
+++ b/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/views/chat/item/ImageFullScreenView.android.kt
@@ -17,7 +17,6 @@ import chat.simplex.common.platform.androidAppContext
 import chat.simplex.res.MR
 import coil.ImageLoader
 import coil.compose.rememberAsyncImagePainter
-import coil.decode.GifDecoder
 import coil.decode.ImageDecoderDecoder
 import coil.request.ImageRequest
 import coil.size.Scale
@@ -70,8 +69,6 @@ private val imageLoader = ImageLoader.Builder(androidAppContext)
   .components {
     if (Build.VERSION.SDK_INT >= 28) {
       add(ImageDecoderDecoder.Factory())
-    } else {
-      add(GifDecoder.Factory())
     }
   }
   .build()

--- a/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/views/chat/item/ImageFullScreenView.android.kt
+++ b/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/views/chat/item/ImageFullScreenView.android.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.view.isVisible
+import chat.simplex.common.platform.MAX_IMAGE_DIMENSION
 import chat.simplex.common.platform.VideoPlayer
 import chat.simplex.common.platform.androidAppContext
 import chat.simplex.res.MR
@@ -19,7 +20,7 @@ import coil.compose.rememberAsyncImagePainter
 import coil.decode.GifDecoder
 import coil.decode.ImageDecoderDecoder
 import coil.request.ImageRequest
-import coil.size.Size
+import coil.size.Scale
 import com.google.android.exoplayer2.ui.AspectRatioFrameLayout
 import com.google.android.exoplayer2.ui.StyledPlayerView
 import dev.icerock.moko.resources.compose.stringResource
@@ -30,7 +31,7 @@ actual fun FullScreenImageView(modifier: Modifier, data: ByteArray, imageBitmap:
   // after end of composition here a GIF from the first instance will be paused automatically which isn't what I want
   Image(
     rememberAsyncImagePainter(
-      ImageRequest.Builder(LocalContext.current).data(data = data).size(Size.ORIGINAL).build(),
+      ImageRequest.Builder(LocalContext.current).data(data = data).size(MAX_IMAGE_DIMENSION, MAX_IMAGE_DIMENSION).scale(Scale.FIT).build(),
       placeholder = BitmapPainter(imageBitmap), // show original image while it's still loading by coil
       imageLoader = imageLoader
     ),

--- a/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/views/helpers/Utils.android.kt
+++ b/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/views/helpers/Utils.android.kt
@@ -183,7 +183,7 @@ actual suspend fun getLoadedImage(file: CIFile?): Pair<ImageBitmap, ByteArray>? 
       } else {
         File(getAppFilePath(file.fileName)).readBytes()
       }
-      decodeSampledBitmapFromByteArray(data, 1000, 1000).asImageBitmap() to data
+      decodeImageBitmap(ByteArrayInputStream(data), MAX_THUMBNAIL_DIMENSION) to data
     } catch (e: Exception) {
       Log.e(TAG, e.stackTraceToString())
       null
@@ -191,40 +191,6 @@ actual suspend fun getLoadedImage(file: CIFile?): Pair<ImageBitmap, ByteArray>? 
   } else {
     null
   }
-}
-
-// https://developer.android.com/topic/performance/graphics/load-bitmap#load-bitmap
-private fun decodeSampledBitmapFromByteArray(data: ByteArray, reqWidth: Int, reqHeight: Int): Bitmap {
-  // First decode with inJustDecodeBounds=true to check dimensions
-  return BitmapFactory.Options().run {
-    inJustDecodeBounds = true
-    BitmapFactory.decodeByteArray(data, 0, data.size, this)
-    // Calculate inSampleSize
-    inSampleSize = calculateInSampleSize(this, reqWidth, reqHeight)
-    // Decode bitmap with inSampleSize set
-    inJustDecodeBounds = false
-
-    BitmapFactory.decodeByteArray(data, 0, data.size, this)
-      ?: throw IOException("Unable to decode image")
-  }
-}
-
-private fun calculateInSampleSize(options: BitmapFactory.Options, reqWidth: Int, reqHeight: Int): Int {
-  // Raw height and width of image
-  val (height: Int, width: Int) = options.run { outHeight to outWidth }
-  var inSampleSize = 1
-
-  if (height > reqHeight || width > reqWidth) {
-    val halfHeight: Int = height / 2
-    val halfWidth: Int = width / 2
-    // Calculate the largest inSampleSize value that is a power of 2 and keeps both
-    // height and width larger than the requested height and width.
-    while (halfHeight / inSampleSize >= reqHeight && halfWidth / inSampleSize >= reqWidth) {
-      inSampleSize *= 2
-    }
-  }
-
-  return inSampleSize
 }
 
 actual fun getFileName(uri: URI): String? {
@@ -257,19 +223,23 @@ actual fun getFileSize(uri: URI): Long? {
 }
 
 actual fun getBitmapFromUri(uri: URI, withAlertOnException: Boolean): ImageBitmap? {
-  return if (Build.VERSION.SDK_INT >= 28) {
-    try {
+  return try {
+    if (Build.VERSION.SDK_INT >= 28) {
       val source = ImageDecoder.createSource(androidAppContext.contentResolver, uri.toUri())
-      ImageDecoder.decodeBitmap(source)
-    } catch (e: Exception) {
-      Log.e(TAG, "Unable to decode the image: ${e.stackTraceToString()}")
-      if (withAlertOnException) showImageDecodingException()
-
-      null
+      ImageDecoder.decodeBitmap(source) { decoder, info, _ ->
+        val sampleSize = boundedImageSampleSize(info.size.width, info.size.height, MAX_IMAGE_DIMENSION)
+          ?: throw IOException("Image dimensions exceed limit")
+        decoder.setTargetSampleSize(sampleSize)
+      }.asImageBitmap()
+    } else {
+      val path = getAppFilePath(uri) ?: throw IOException("Unable to resolve image path")
+      FileInputStream(path).use(::loadImageBitmap)
     }
-  } else {
-    BitmapFactory.decodeFile(getAppFilePath(uri))
-  }?.asImageBitmap()
+  } catch (e: Exception) {
+    Log.e(TAG, "Unable to decode the image: ${e.stackTraceToString()}")
+    if (withAlertOnException) showImageDecodingException()
+    null
+  }
 }
 
 actual fun getBitmapFromByteArray(data: ByteArray, withAlertOnException: Boolean): ImageBitmap? {
@@ -292,7 +262,11 @@ actual fun getDrawableFromUri(uri: URI, withAlertOnException: Boolean): Any? {
   return if (Build.VERSION.SDK_INT >= 28) {
     try {
       val source = ImageDecoder.createSource(androidAppContext.contentResolver, uri.toUri())
-      ImageDecoder.decodeDrawable(source)
+      ImageDecoder.decodeDrawable(source) { decoder, info, _ ->
+        val sampleSize = boundedImageSampleSize(info.size.width, info.size.height, MAX_IMAGE_DIMENSION)
+          ?: throw IOException("Image dimensions exceed limit")
+        decoder.setTargetSampleSize(sampleSize)
+      }
     } catch (e: Exception) {
       Log.e(TAG, "Error while decoding drawable: ${e.stackTraceToString()}")
       if (withAlertOnException) showImageDecodingException()

--- a/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/views/helpers/Utils.android.kt
+++ b/apps/multiplatform/common/src/androidMain/kotlin/chat/simplex/common/views/helpers/Utils.android.kt
@@ -3,7 +3,6 @@ package chat.simplex.common.views.helpers
 import android.content.res.Resources
 import android.graphics.*
 import android.graphics.Typeface
-import android.graphics.drawable.Drawable
 import android.media.MediaMetadataRetriever
 import android.os.*
 import android.provider.OpenableColumns
@@ -274,7 +273,7 @@ actual fun getDrawableFromUri(uri: URI, withAlertOnException: Boolean): Any? {
       null
     }
   } else {
-    Drawable.createFromPath(getAppFilePath(uri))
+    null
   }
 }
 

--- a/apps/multiplatform/common/src/androidUnitTest/kotlin/chat/simplex/common/platform/ImageDecodePolicyTest.kt
+++ b/apps/multiplatform/common/src/androidUnitTest/kotlin/chat/simplex/common/platform/ImageDecodePolicyTest.kt
@@ -1,0 +1,47 @@
+package chat.simplex.common.platform
+
+import java.io.ByteArrayInputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ImageDecodePolicyTest {
+  @Test
+  fun boundedSamplingCoversDimensionsOrientationAndPixelEdges() {
+    data class Case(val width: Int, val height: Int, val target: Int, val sample: Int?)
+
+    listOf(
+      Case(800, 600, MAX_THUMBNAIL_DIMENSION, 1),
+      Case(100_000, 1_000, MAX_THUMBNAIL_DIMENSION, null),
+      Case(1_000, 100_000, MAX_THUMBNAIL_DIMENSION, null),
+      Case(16_384, 1, MAX_IMAGE_DIMENSION, 1),
+      Case(16_385, 1, MAX_IMAGE_DIMENSION, null),
+      Case(4_320, 4_320, MAX_IMAGE_DIMENSION, 1),
+      Case(4_321, 4_320, MAX_IMAGE_DIMENSION, 2),
+      Case(5_000, 5_000, MAX_IMAGE_DIMENSION, 2),
+      Case(16_383, 2_279, MAX_THUMBNAIL_DIMENSION, 2),
+    ).forEach { (width, height, target, sample) ->
+      assertEquals(sample, boundedImageSampleSize(width, height, target), "$width x $height")
+    }
+
+    assertNull(boundedImageSampleSize(0, 100, MAX_IMAGE_DIMENSION))
+    assertNull(boundedImageSampleSize(100, -1, MAX_IMAGE_DIMENSION))
+    val sample = boundedImageSampleSize(16_383, 2_279, MAX_THUMBNAIL_DIMENSION)!!
+    val pixels = ((16_383L + sample - 1) / sample) * ((2_279L + sample - 1) / sample)
+    assertTrue(pixels <= 18_662_400L)
+  }
+
+  @Test
+  fun limitingStreamCapsEveryReadOperation() {
+    val backing = ByteArrayInputStream(ByteArray(32))
+    val limited = LimitedInputStream(backing, 8)
+    assertEquals(8, limited.available())
+    assertEquals(5L, limited.skip(5))
+    assertEquals(2, limited.read(ByteArray(2)))
+    assertEquals(0, limited.read(ByteArray(0)))
+    assertEquals(0, limited.read())
+    assertEquals(-1, limited.read())
+    assertEquals(24, backing.available())
+  }
+}


### PR DESCRIPTION
## Summary

PR #7082 made the Android client downsample large images to avoid displaying an oversized image during a preview; however, downsampling stops when it would take _either_ dimension below the target, no matter how big the other dimension is. As such, large images with an extreme aspect ratio (either wide or tall) can still be displayed at full size and exhaust the app's memory.

This PR checks the dimensions declared in the image header before loading any pixels. Images with either dimension greater than 16,384 pixels are rejected, and accepted images are reduced further if needed to keep the final result at or below a max of 18,662,400 pixels, regardless of aspect ratio. This value is based on the 4320x4320 total pixel limit for images on the desktop client.

For images read from a stream, the decoder reads at most 1 MB to determine the image dimensions.

This patch also limits Android chat and full-screen loading to fit within 1000x1000 and 4320x4320 pixels respectively, while preserving the image’s proportions (originally those views requested the original image size). I chose these values based on the existing thumbnail and full-size image size limits in the desktop client.

## Tradeoff regression for GIFs on Android 8.0/8.1

On Android 8.0 and 8.1, the animated image decoder ignores the requested size limit, such that even after creating a smaller preview, playing the animation can allocate subsequent frames at an arbitrarily large size. I couldn't find a way to limit GIF size reliably while preserving animation without introducing significant complexity (such as parsing the size of every frame of a GIF in advance), so I resolved this as simply as I could by having GIFs display as still images on Android 8.0/8.1. Since this is a behavioral regression, albeit one affecting what I would guess is a rarely used Android version these days, I split this off into a separate commit from the main fix, in case you would prefer to drop that part of the patch and just accept the risk of the Android 8.0/8.1 client being able to load animated images of unbounded size.

## Tests added

- Very wide and very tall images are rejected when they exceed 16,384px limit in either dimension
- Images close to the total pixel-count limit are reduced enough to satisfy it
- Dimension checks stop at the 1 MB read limit, while accepted images can continue loading beyond it
- Loading leaves the input open for the caller to close
- Images are checked again if a content provider changes them between opens
- Older Android versions load GIFs as still images in chat and full-screen views
- Wallpaper and direct-image link previews use the size-limited image loader